### PR TITLE
MEN::Scolarites: add new scopes for bourse data

### DIFF
--- a/siade/app/interactors/men/scolarites/make_request.rb
+++ b/siade/app/interactors/men/scolarites/make_request.rb
@@ -97,7 +97,7 @@ class MEN::Scolarites::MakeRequest < MakeRequest
       sexe:,
       'date-naissance': date_naissance,
       'annee-scolaire': params[:annee_scolaire],
-      scope: 'men_statut_scolarite',
+      scope: 'men_statut_scolarite,men_statut_boursier,men_echelon_bourse',
       'degre-etablissement': params[:degre_etablissement],
       'type-perimetre': context.perimetre_type,
       'valeurs-perimetre': context.perimetre_valeurs
@@ -133,7 +133,7 @@ class MEN::Scolarites::MakeRequest < MakeRequest
   end
 
   def scope_param
-    return { scope: 'men_statut_scolarite' } if provider_api_version == 'v2'
+    return { scope: 'men_statut_scolarite,men_statut_boursier,men_echelon_bourse' } if provider_api_version == 'v2'
 
     {}
   end

--- a/siade/spec/fixtures/cassettes/men/scolarites/not_found_v2.yml
+++ b/siade/spec/fixtures/cassettes/men/scolarites/not_found_v2.yml
@@ -59,7 +59,7 @@ http_interactions:
   recorded_at: Thu, 27 Apr 2023 10:20:06 GMT
 - request:
     method: get
-    uri: "<MEN_SCOLARITES_URL_V2>?annee-scolaire=2021&code-uai=0511474A&date-naissance=2000-06-10&nom=NOMFAMILLE&prenom=prenom&scope=men_statut_scolarite&sexe=2"
+    uri: "<MEN_SCOLARITES_URL_V2>?annee-scolaire=2021&code-uai=0511474A&date-naissance=2000-06-10&nom=NOMFAMILLE&prenom=prenom&scope=men_statut_scolarite,men_statut_boursier,men_echelon_bourse&sexe=2"
     body:
       encoding: US-ASCII
       string: ''

--- a/siade/spec/fixtures/cassettes/men/scolarites/valid_v2.yml
+++ b/siade/spec/fixtures/cassettes/men/scolarites/valid_v2.yml
@@ -59,7 +59,7 @@ http_interactions:
   recorded_at: Fri, 13 Jan 2023 10:43:19 GMT
 - request:
     method: get
-    uri: <MEN_SCOLARITES_URL_V2>?annee-scolaire=2021&code-uai=0511474A&date-naissance=2000-06-10&nom=NOMFAMILLE&prenom=prenom&scope=men_statut_scolarite&sexe=2
+    uri: <MEN_SCOLARITES_URL_V2>?annee-scolaire=2021&code-uai=0511474A&date-naissance=2000-06-10&nom=NOMFAMILLE&prenom=prenom&scope=men_statut_scolarite,men_statut_boursier,men_echelon_bourse&sexe=2
     body:
       encoding: US-ASCII
       string: ''

--- a/siade/spec/interactors/men/scolarites/make_request_spec.rb
+++ b/siade/spec/interactors/men/scolarites/make_request_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe MEN::Scolarites::MakeRequest, type: :make_request do
           sexe: 2,
           'date-naissance': '2000-06-10',
           'annee-scolaire': '2021',
-          scope: 'men_statut_scolarite',
+          scope: 'men_statut_scolarite,men_statut_boursier,men_echelon_bourse',
           'degre-etablissement': '2D',
           'type-perimetre': 'region',
           'valeurs-perimetre': %w[11]


### PR DESCRIPTION
Thanks to an arrete, we can now request bourse data to this data provider: it was not the case the last year. Before that, we used to call the API v1 of this data provider, this code is brand new.