### PR TITLE
INSEE: rotation automatique du mot de passe par dérivation HMAC

### DIFF
--- a/siade/app/interactors/insee/authenticate.rb
+++ b/siade/app/interactors/insee/authenticate.rb
@@ -44,6 +44,6 @@ class INSEE::Authenticate < AbstractGetToken
   end
 
   def password
-    Siade.credentials[:insee_apim_password]
+    INSEE::PasswordDerivation.current_password
   end
 end

--- a/siade/app/interactors/insee/make_request.rb
+++ b/siade/app/interactors/insee/make_request.rb
@@ -1,6 +1,6 @@
 class INSEE::MakeRequest < MakeRequest::Get
   ROTATION_LOCK_KEY = 'insee/password_rotation_lock'.freeze
-  ROTATION_LOCK_TTL = 10
+  ROTATION_LOCK_TTL = 30
 
   def call
     super
@@ -80,17 +80,16 @@ class INSEE::MakeRequest < MakeRequest::Get
   def rotate_password_if_needed!
     return unless password_rotation_needed?
 
-    lock_acquired = acquire_rotation_lock!
-    return unless lock_acquired
+    return unless acquire_rotation_lock!
 
-    INSEE::RenewPassword.call(
+    renew_context = INSEE::RenewPassword.call(
       token: context.token,
       old_password: INSEE::PasswordDerivation.previous_password,
       new_password: INSEE::PasswordDerivation.current_password,
       provider_name: context.provider_name
     )
-  ensure
-    release_rotation_lock! if lock_acquired
+
+    INSEE::Authenticate.invalidate_token_cache! if renew_context.success?
   end
 
   def password_rotation_needed?
@@ -116,10 +115,6 @@ class INSEE::MakeRequest < MakeRequest::Get
 
   def acquire_rotation_lock!
     rotation_redis.set(ROTATION_LOCK_KEY, Process.pid, nx: true, ex: ROTATION_LOCK_TTL)
-  end
-
-  def release_rotation_lock!
-    rotation_redis.del(ROTATION_LOCK_KEY)
   end
 
   def rotation_redis

--- a/siade/app/interactors/insee/make_request.rb
+++ b/siade/app/interactors/insee/make_request.rb
@@ -1,7 +1,11 @@
 class INSEE::MakeRequest < MakeRequest::Get
+  ROTATION_LOCK_KEY = 'insee/password_rotation_lock'.freeze
+  ROTATION_LOCK_TTL = 10
+
   def call
     super
 
+    rotate_password_if_needed!
     retry_with_new_token! if should_retry_with_new_token?
   end
 
@@ -71,6 +75,55 @@ class INSEE::MakeRequest < MakeRequest::Get
       fail_with_temporary_auth_error! if attempt == max_auth_attempts - 1
       sleep(0.2)
     end
+  end
+
+  def rotate_password_if_needed!
+    return unless password_rotation_needed?
+
+    lock_acquired = acquire_rotation_lock!
+    return unless lock_acquired
+
+    INSEE::RenewPassword.call(
+      token: context.token,
+      old_password: INSEE::PasswordDerivation.previous_password,
+      new_password: INSEE::PasswordDerivation.current_password,
+      provider_name: context.provider_name
+    )
+  ensure
+    release_rotation_lock! if lock_acquired
+  end
+
+  def password_rotation_needed?
+    return false if context.token.blank?
+    return false if INSEE::PasswordDerivation.current_period < INSEE::PasswordDerivation::DERIVATION_START
+
+    pwd_changed_period = pwd_changed_period_from_token
+    return false if pwd_changed_period.nil?
+
+    pwd_changed_period < INSEE::PasswordDerivation.current_period
+  end
+
+  def pwd_changed_period_from_token
+    payload = JWT.decode(context.token, nil, false).first
+    pwd_changed_time = payload['pwdChangedTime']
+    return if pwd_changed_time.nil?
+
+    date = Time.zone.parse(pwd_changed_time).to_date
+    INSEE::PasswordDerivation.send(:period_for, date)
+  rescue JWT::DecodeError
+    nil
+  end
+
+  def acquire_rotation_lock!
+    rotation_redis.set(ROTATION_LOCK_KEY, Process.pid, nx: true, ex: ROTATION_LOCK_TTL)
+  end
+
+  def release_rotation_lock!
+    rotation_redis.del(ROTATION_LOCK_KEY)
+  end
+
+  def rotation_redis
+    @rotation_redis ||= RedisService.new
   end
 
   def fail_with_temporary_auth_error!

--- a/siade/app/interactors/insee/renew_password.rb
+++ b/siade/app/interactors/insee/renew_password.rb
@@ -1,0 +1,27 @@
+class INSEE::RenewPassword < MakeRequest::Post
+  protected
+
+  def request_uri
+    URI("#{base_uri}/#{sirene_base_path}/renouvellement")
+  end
+
+  def request_params
+    {
+      oldPassword: context.old_password,
+      newPassword: context.new_password
+    }
+  end
+
+  def extra_headers(request)
+    request['Authorization'] = "Bearer #{context.token}"
+    super
+  end
+
+  def base_uri
+    Siade.credentials[:insee_sirene_url]
+  end
+
+  def sirene_base_path
+    'api-sirene/prive/3.11'
+  end
+end

--- a/siade/app/services/insee/password_derivation.rb
+++ b/siade/app/services/insee/password_derivation.rb
@@ -1,0 +1,69 @@
+require 'openssl'
+
+class INSEE::PasswordDerivation
+  DERIVATION_START = '2026-09'.freeze
+  BIMESTER_MONTHS = [1, 3, 5, 7, 9, 11].freeze
+  PASSWORD_LENGTH = 16
+  CHAR_GUARANTEES = {
+    /[A-Z]/ => 'A',
+    /[a-z]/ => 'a',
+    /[0-9]/ => '0',
+    /[^a-zA-Z0-9]/ => '#'
+  }.freeze
+
+  def self.current_password
+    password_for(current_period)
+  end
+
+  def self.previous_password
+    password_for(previous_period)
+  end
+
+  def self.current_period
+    period_for(Time.zone.today)
+  end
+
+  def self.previous_period
+    date = Time.zone.today
+    month = BIMESTER_MONTHS.rfind { |m| m <= date.month }
+
+    if month == BIMESTER_MONTHS.first
+      format('%<year>d-%<month>02d', year: date.year - 1, month: BIMESTER_MONTHS.last)
+    else
+      idx = BIMESTER_MONTHS.index(month)
+      format('%<year>d-%<month>02d', year: date.year, month: BIMESTER_MONTHS[idx - 1])
+    end
+  end
+
+  def self.password_for(period)
+    return Siade.credentials[:insee_apim_password] if period < DERIVATION_START
+
+    derive(period)
+  end
+
+  def self.derive(period)
+    hmac = OpenSSL::HMAC.digest('SHA256', secret, period)
+    format_password(hmac)
+  end
+
+  def self.period_for(date)
+    month = BIMESTER_MONTHS.rfind { |m| m <= date.month }
+    format('%<year>d-%<month>02d', year: date.year, month:)
+  end
+
+  def self.format_password(hmac_bytes)
+    chars = Base64.urlsafe_encode64(hmac_bytes, padding: false)[0, PASSWORD_LENGTH].chars
+
+    CHAR_GUARANTEES.each_with_index do |(pattern, fallback), idx|
+      chars[idx] = fallback unless chars.any? { |c| c.match?(pattern) }
+    end
+
+    chars.join
+  end
+
+  def self.secret
+    Siade.credentials[:insee_apim_password_derivation_key]
+  end
+
+  private_class_method :password_for, :derive, :period_for, :format_password, :secret
+end

--- a/siade/app/services/redis_service.rb
+++ b/siade/app/services/redis_service.rb
@@ -23,8 +23,8 @@ class RedisService
   end
 
   # rubocop:disable Naming/MethodParameterName
-  def set(key, value, ex: nil)
-    redis.set(key, value, ex:)
+  def set(key, value, ex: nil, nx: false)
+    redis.set(key, value, ex:, nx:)
   rescue *redis_errors
     nil
   end

--- a/siade/spec/interactors/insee/make_request_spec.rb
+++ b/siade/spec/interactors/insee/make_request_spec.rb
@@ -7,6 +7,11 @@ RSpec.describe INSEE::MakeRequest, type: :interactor do
   let(:insee_sirene_url) { Siade.credentials[:insee_sirene_url] }
   let(:insee_oauth_url) { Siade.credentials[:insee_oauth_url] }
 
+  def jwt_token_with_pwd_changed_time(time_string)
+    payload = { 'pwdChangedTime' => time_string }
+    JWT.encode(payload, nil, 'none')
+  end
+
   describe 'retry on 401 token expired' do
     before do
       EncryptedCache.write('insee/authenticate', token)
@@ -220,6 +225,110 @@ RSpec.describe INSEE::MakeRequest, type: :interactor do
 
         expect(WebMock).to have_requested(:get, /#{insee_sirene_url}/)
           .with(headers: { 'Authorization' => "Bearer #{token_from_other_thread}" })
+      end
+    end
+  end
+
+  describe 'password rotation' do
+    let(:renew_url) { %r{#{insee_sirene_url}/api-sirene/prive/3.11/renouvellement} }
+
+    before do
+      EncryptedCache.write('insee/authenticate', token)
+    end
+
+    after do
+      Timecop.return
+      RedisService.new.del(INSEE::MakeRequest::ROTATION_LOCK_KEY)
+    end
+
+    context 'when pwdChangedTime is in a previous bimester' do
+      let(:token) { jwt_token_with_pwd_changed_time('2026-08-15T10:00:00Z') }
+
+      before do
+        Timecop.freeze(Date.new(2026, 9, 15))
+
+        stub_request(:get, /#{insee_sirene_url}/)
+          .to_return(status: 200, body: '{"uniteLegale":{}}')
+
+        stub_request(:post, renew_url)
+          .to_return(status: 200, body: '{}')
+      end
+
+      it 'calls the renewal API' do
+        make_request
+
+        expect(WebMock).to have_requested(:post, renew_url)
+      end
+
+      it 'sends old and new passwords' do
+        make_request
+
+        expect(WebMock).to have_requested(:post, renew_url)
+          .with(body: {
+            oldPassword: INSEE::PasswordDerivation.previous_password,
+            newPassword: INSEE::PasswordDerivation.current_password
+          }.to_json)
+      end
+
+    end
+
+    context 'when pwdChangedTime is in the current bimester' do
+      let(:token) { jwt_token_with_pwd_changed_time('2026-09-10T10:00:00Z') }
+
+      before do
+        Timecop.freeze(Date.new(2026, 9, 15))
+
+        stub_request(:get, /#{insee_sirene_url}/)
+          .to_return(status: 200, body: '{"uniteLegale":{}}')
+      end
+
+      it 'does not call the renewal API' do
+        make_request
+
+        expect(WebMock).not_to have_requested(:post, renew_url)
+      end
+    end
+
+    context 'when the token is not a valid JWT' do
+      let(:token) { 'not-a-jwt' }
+
+      before do
+        stub_request(:get, /#{insee_sirene_url}/)
+          .to_return(status: 200, body: '{"uniteLegale":{}}')
+      end
+
+      it 'does not attempt rotation' do
+        make_request
+
+        expect(WebMock).not_to have_requested(:post, renew_url)
+      end
+    end
+
+    context 'when the rotation lock is already held' do
+      let(:token) { jwt_token_with_pwd_changed_time('2026-08-15T10:00:00Z') }
+
+      before do
+        Timecop.freeze(Date.new(2026, 9, 15))
+
+        RedisService.new.set(
+          INSEE::MakeRequest::ROTATION_LOCK_KEY,
+          true,
+          nx: true,
+          ex: INSEE::MakeRequest::ROTATION_LOCK_TTL
+        )
+
+        stub_request(:get, /#{insee_sirene_url}/)
+          .to_return(status: 200, body: '{"uniteLegale":{}}')
+      end
+
+      after do
+        RedisService.new.del(INSEE::MakeRequest::ROTATION_LOCK_KEY)
+      end
+
+      it 'does not call the renewal API' do
+        make_request
+
+        expect(WebMock).not_to have_requested(:post, renew_url)
       end
     end
   end

--- a/siade/spec/interactors/insee/make_request_spec.rb
+++ b/siade/spec/interactors/insee/make_request_spec.rb
@@ -270,6 +270,11 @@ RSpec.describe INSEE::MakeRequest, type: :interactor do
           }.to_json)
       end
 
+      it 'invalidates the token cache so next auth gets a fresh JWT' do
+        make_request
+
+        expect(EncryptedCache.read('insee/authenticate')).to be_nil
+      end
     end
 
     context 'when pwdChangedTime is in the current bimester' do

--- a/siade/spec/interactors/insee/renew_password_spec.rb
+++ b/siade/spec/interactors/insee/renew_password_spec.rb
@@ -1,0 +1,69 @@
+RSpec.describe INSEE::RenewPassword, type: :interactor do
+  subject(:renew) do
+    described_class.call(
+      token:,
+      old_password:,
+      new_password:,
+      provider_name: 'insee'
+    )
+  end
+
+  let(:token) { 'valid-bearer-token' }
+  let(:old_password) { 'OldP4ssword!xyz' }
+  let(:new_password) { 'NewP4ssword!abc' }
+  let(:insee_sirene_url) { Siade.credentials[:insee_sirene_url] }
+  let(:renew_url) { %r{#{insee_sirene_url}/api-sirene/prive/3.11/renouvellement} }
+
+  context 'when the renewal succeeds' do
+    before do
+      stub_request(:post, renew_url)
+        .with(
+          headers: { 'Authorization' => "Bearer #{token}", 'Content-Type' => 'application/json' },
+          body: { oldPassword: old_password, newPassword: new_password }.to_json
+        )
+        .to_return(status: 200, body: '{}')
+    end
+
+    it { is_expected.to be_a_success }
+
+    it 'sends a POST with correct body' do
+      renew
+
+      expect(WebMock).to have_requested(:post, renew_url)
+        .with(body: { oldPassword: old_password, newPassword: new_password }.to_json)
+    end
+
+    it 'sends the Authorization header' do
+      renew
+
+      expect(WebMock).to have_requested(:post, renew_url)
+        .with(headers: { 'Authorization' => "Bearer #{token}" })
+    end
+  end
+
+  context 'when the old password is incorrect (400)' do
+    before do
+      stub_request(:post, renew_url)
+        .to_return(status: 400, body: '{"message":"Ancien mot de passe incorrect"}')
+    end
+
+    it { is_expected.to be_a_success }
+
+    it 'returns the 400 response' do
+      expect(renew.response.code).to eq('400')
+    end
+  end
+
+  context 'when the new password is invalid (400)' do
+    before do
+      stub_request(:post, renew_url)
+        .to_return(status: 400, body: '{"message":"Le mot de passe ne respecte pas les règles"}')
+    end
+
+    it { is_expected.to be_a_success }
+
+    it 'returns the 400 response' do
+      expect(renew.response.code).to eq('400')
+    end
+  end
+end

--- a/siade/spec/services/insee/password_derivation_spec.rb
+++ b/siade/spec/services/insee/password_derivation_spec.rb
@@ -1,0 +1,144 @@
+RSpec.describe INSEE::PasswordDerivation do
+  describe '.current_period' do
+    after { Timecop.return }
+
+    it 'returns the bimester seed for January' do
+      Timecop.freeze(Date.new(2026, 1, 15))
+      expect(described_class.current_period).to eq('2026-01')
+    end
+
+    it 'returns the bimester seed for February (still jan-feb bimester)' do
+      Timecop.freeze(Date.new(2026, 2, 28))
+      expect(described_class.current_period).to eq('2026-01')
+    end
+
+    it 'returns the bimester seed for March' do
+      Timecop.freeze(Date.new(2026, 3, 1))
+      expect(described_class.current_period).to eq('2026-03')
+    end
+
+    it 'returns the bimester seed for September' do
+      Timecop.freeze(Date.new(2026, 9, 10))
+      expect(described_class.current_period).to eq('2026-09')
+    end
+
+    it 'returns the bimester seed for December' do
+      Timecop.freeze(Date.new(2026, 12, 31))
+      expect(described_class.current_period).to eq('2026-11')
+    end
+  end
+
+  describe '.previous_period' do
+    after { Timecop.return }
+
+    it 'returns the previous bimester for March (-> jan)' do
+      Timecop.freeze(Date.new(2026, 3, 15))
+      expect(described_class.previous_period).to eq('2026-01')
+    end
+
+    it 'returns the previous bimester for September (-> jul)' do
+      Timecop.freeze(Date.new(2026, 9, 10))
+      expect(described_class.previous_period).to eq('2026-07')
+    end
+
+    it 'wraps to previous year for January (-> nov of previous year)' do
+      Timecop.freeze(Date.new(2027, 1, 5))
+      expect(described_class.previous_period).to eq('2026-11')
+    end
+
+    it 'wraps to previous year for February (still jan bimester -> nov of previous year)' do
+      Timecop.freeze(Date.new(2027, 2, 10))
+      expect(described_class.previous_period).to eq('2026-11')
+    end
+  end
+
+  describe '.current_password' do
+    after { Timecop.return }
+
+    context 'when before DERIVATION_START (2026-09)' do
+      it 'returns the static credential' do
+        Timecop.freeze(Date.new(2026, 7, 1))
+        expect(described_class.current_password).to eq(Siade.credentials[:insee_apim_password])
+      end
+    end
+
+    context 'when at DERIVATION_START' do
+      it 'returns a derived password' do
+        Timecop.freeze(Date.new(2026, 9, 1))
+        expect(described_class.current_password).not_to eq(Siade.credentials[:insee_apim_password])
+      end
+    end
+
+    context 'when after DERIVATION_START' do
+      it 'returns a derived password' do
+        Timecop.freeze(Date.new(2027, 1, 15))
+        expect(described_class.current_password).not_to eq(Siade.credentials[:insee_apim_password])
+      end
+    end
+  end
+
+  describe '.previous_password' do
+    after { Timecop.return }
+
+    context 'when previous period is before DERIVATION_START' do
+      it 'returns the static credential' do
+        Timecop.freeze(Date.new(2026, 9, 1))
+        expect(described_class.previous_password).to eq(Siade.credentials[:insee_apim_password])
+      end
+    end
+
+    context 'when previous period is at or after DERIVATION_START' do
+      it 'returns a derived password' do
+        Timecop.freeze(Date.new(2026, 11, 1))
+        expect(described_class.previous_password).not_to eq(Siade.credentials[:insee_apim_password])
+      end
+    end
+  end
+
+  describe 'determinism' do
+    after { Timecop.return }
+
+    it 'produces the same password for the same period' do
+      Timecop.freeze(Date.new(2026, 10, 1))
+      first_call = described_class.current_password
+      second_call = described_class.current_password
+      expect(first_call).to eq(second_call)
+    end
+
+    it 'produces different passwords for different periods' do
+      Timecop.freeze(Date.new(2026, 9, 1))
+      pwd_sep = described_class.current_password
+
+      Timecop.freeze(Date.new(2026, 11, 1))
+      pwd_nov = described_class.current_password
+
+      expect(pwd_sep).not_to eq(pwd_nov)
+    end
+  end
+
+  describe 'password format' do
+    after { Timecop.return }
+
+    before { Timecop.freeze(Date.new(2026, 9, 1)) }
+
+    it 'is 16 characters long' do
+      expect(described_class.current_password.length).to eq(16)
+    end
+
+    it 'contains at least one uppercase letter' do
+      expect(described_class.current_password).to match(/[A-Z]/)
+    end
+
+    it 'contains at least one lowercase letter' do
+      expect(described_class.current_password).to match(/[a-z]/)
+    end
+
+    it 'contains at least one digit' do
+      expect(described_class.current_password).to match(/[0-9]/)
+    end
+
+    it 'contains at least one special character' do
+      expect(described_class.current_password).to match(/[^a-zA-Z0-9]/)
+    end
+  end
+end


### PR DESCRIPTION
L'INSEE impose à partir de septembre 2026 de rotate le mdp du compte de l'APIM tous les 3 mois.
Plus d'infos ici: https://portail-api.insee.fr/catalog/api/26d13266-689d-3fee-845d-c08e12b8f0dd/doc?page=a7e0ed84-020c-48bc-a0ed-84020c08bce2#lapi-de-renouvellement-de-mot-de-passe

- Dérivation déterministe du mot de passe INSEE par bimestre via HMAC(secret, period), sans coordination entre instances
- Rotation lazy : après chaque requête réussie, détecte via `pwdChangedTime` du JWT si le mot de passe doit être renouvelé
- Lock distribué Redis (NX + TTL 30s) pour éviter les rotations concurrentes
- Invalidation du cache JWT après rotation réussie
- Avant septembre 2026, le credential statique est toujours utilisé

Nouveau credential requis : `insee_apim_password_derivation_key` (clé HMAC, `openssl rand -hex 32`)