### PR TITLE
Replace Rails credentials with plain YAML file

### DIFF
--- a/siade/.gitignore
+++ b/siade/.gitignore
@@ -61,6 +61,7 @@ vendor/bundle
 builds/
 
 config/credentials/
+config/credentials.yml
 config/credentials.yml.enc
 config/master.key
 

--- a/siade/config/initializers/credentials.rb
+++ b/siade/config/initializers/credentials.rb
@@ -1,7 +1,16 @@
 module Siade
   def self.credentials
     @credentials ||= begin
-      credentials = Rails.application.credentials.config[Rails.env.to_sym] || {}
+      env_file = Rails.root.join('config', 'credentials', "#{Rails.env}.yml")
+      base_file = Rails.root.join('config', 'credentials.yml')
+
+      credentials = if env_file.exist?
+        YAML.safe_load_file(env_file, symbolize_names: true, aliases: true) || {}
+      elsif base_file.exist?
+        YAML.safe_load_file(base_file, symbolize_names: true, aliases: true)[Rails.env.to_sym] || {}
+      else
+        {}
+      end
 
       unless ENV['ZEITWERK_CHECK']
         if Rails.env.local?


### PR DESCRIPTION
Switch from Rails.application.credentials (encrypted) to a plain config/credentials.yml file provisioned by Ansible on servers. In local dev, the file absence triggers the existing default_proc fallback, keeping behavior identical.