### PR TITLE
Fix: Memoize authorizations config to prevent EBADF on Puma workers

### DIFF
--- a/siade/app/interactors/france_connect/data_fetcher_through_access_token/build_user.rb
+++ b/siade/app/interactors/france_connect/data_fetcher_through_access_token/build_user.rb
@@ -35,7 +35,7 @@ class FranceConnect::DataFetcherThroughAccessToken::BuildUser < FranceConnect::D
   end
 
   def scopes_for(controller_name)
-    Rails.application.config_for(:authorizations)[controller_name]
+    Scope.config[controller_name]
   end
 
   def remove_api_identity_scopes(scopes)

--- a/siade/app/models/scope.rb
+++ b/siade/app/models/scope.rb
@@ -8,6 +8,6 @@ class Scope
   end
 
   def self.config
-    Rails.application.config_for(:authorizations)
+    @config ||= Rails.application.config_for(:authorizations)
   end
 end

--- a/siade/app/services/scopes_authorization_service.rb
+++ b/siade/app/services/scopes_authorization_service.rb
@@ -34,6 +34,6 @@ class ScopesAuthorizationService
   end
 
   def config
-    Rails.application.config_for(:authorizations)
+    Scope.config
   end
 end

--- a/siade/app/tools/application_tool.rb
+++ b/siade/app/tools/application_tool.rb
@@ -29,7 +29,7 @@ class ApplicationTool < MCP::Tool
   end
 
   def self.scopes
-    Rails.application.config_for(:authorizations)["mcp/#{tool_name}"] || []
+    Scope.config["mcp/#{tool_name}"] || []
   end
 
   def self.text_response(text)


### PR DESCRIPTION
Errno::EBADF (Bad file descriptor) was raised in production when Puma workers tried to read config/authorizations.yml after fork.

Rails.application.config_for(:authorizations) was called on every request, re-reading the YAML file each time. After Puma forks workers, inherited file descriptors can become invalid, causing EBADF.

Memoize the config in Scope.config (class-level @config) and have all other call sites (ScopesAuthorizationService, ApplicationTool, BuildUser) reference Scope.config instead of calling config_for directly.

Fixes Sentry#281986