### PR TITLE
Fix seeds flushdb FK violation by deleting magic_links before tokens

### DIFF
--- a/site/app/lib/seeds.rb
+++ b/site/app/lib/seeds.rb
@@ -25,6 +25,7 @@ class Seeds
     ProlongTokenWizard.destroy_all
 
     ActiveRecord::Base.connection.transaction do
+      MagicLink.delete_all
       ApplicationRecord.descendants.each(&:delete_all)
       AccessLog.delete_all
     end


### PR DESCRIPTION
MagicLink rows reference tokens via fk_rails_75d8d0c9bf, so delete_all on Token raised a FK violation during sandbox seeding. delete_all skips the dependent: :destroy callback, so clear MagicLink explicitly first.

