### PR TITLE
Fix CNAV quotient familial year validation error message

### DIFF
--- a/siade/app/errors/unprocessable_entity_error.rb
+++ b/siade/app/errors/unprocessable_entity_error.rb
@@ -38,6 +38,7 @@ class UnprocessableEntityError < ApplicationError
       cnaf_beneficiary_number: '00352',
       # CNAV
       annee: '00353',
+      annee_cnav: '00356',
       mois: '00354',
       sngi: '00355',
       # MESRI / MEN / CNOUS

--- a/siade/app/interactors/cnav/quotient_familial_v2/validate_year.rb
+++ b/siade/app/interactors/cnav/quotient_familial_v2/validate_year.rb
@@ -11,6 +11,10 @@ class CNAV::QuotientFamilialV2::ValidateYear < ValidateYear
     :annee
   end
 
+  def error_field
+    :annee_cnav
+  end
+
   def start_year
     current_year - 2
   end

--- a/siade/app/interactors/validate_year.rb
+++ b/siade/app/interactors/validate_year.rb
@@ -2,13 +2,17 @@ class ValidateYear < ValidateParamInteractor
   def call
     return if valid?
 
-    invalid_param!(year_param_name)
+    invalid_param!(error_field)
   end
 
   protected
 
   def year_param_name
     :year
+  end
+
+  def error_field
+    year_param_name
   end
 
   def start_year

--- a/siade/config/errors.yml
+++ b/siade/config/errors.yml
@@ -455,6 +455,10 @@
   title: 'Entité non traitable'
   detail: "L'année demandée n'est pas correctement formatée ou est dans le futur."
 
+- code: '00356'
+  title: 'Entité non traitable'
+  detail: "L'année demandée doit être l'année en cours (N), N-1 ou N-2."
+
 - code: '00354'
   title: 'Entité non traitable'
   detail: "Le mois demandé est incorrect ou est dans le futur."

--- a/siade/spec/interactors/cnav/quotient_familial_v2/validate_year_spec.rb
+++ b/siade/spec/interactors/cnav/quotient_familial_v2/validate_year_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe CNAV::QuotientFamilialV2::ValidateYear, type: :validate_param_int
       its(:errors) { is_expected.to include(instance_of(UnprocessableEntityError)) }
 
       it 'error has correct error code (non-regression)' do
-        expect(subject.errors.first.code).to eq('00353')
+        expect(subject.errors.first.code).to eq('00356')
       end
     end
 

--- a/siade/swagger/openapi-particulierv2.yaml
+++ b/siade/swagger/openapi-particulierv2.yaml
@@ -1737,10 +1737,10 @@ paths:
                 Mois invalide:
                   value:
                     error: bad_request
-                    reason: L'année demandée n'est pas correctement formatée ou est
-                      dans le futur.
-                    message: L'année demandée n'est pas correctement formatée ou est
-                      dans le futur.
+                    reason: L'année demandée doit être l'année en cours (N), N-1 ou
+                      N-2.
+                    message: L'année demandée doit être l'année en cours (N), N-1
+                      ou N-2.
                 Allocataire non identifié:
                   value:
                     error: not_found


### PR DESCRIPTION
The CNAV quotient familial endpoint accepts years N, N-1 and N-2 only, but the error returned used the generic code 00353 whose message says "L'année n'est pas correctement formatée ou est dans le futur", which is misleading for this specific constraint.

Add a dedicated error code 00356 with the message "L'année demandée doit être l'année en cours (N), N-1 ou N-2" and introduce an `error_field` hook in ValidateYear so the CNAV validator can use it without affecting other year validators.