### PR TITLE
Expose boarding school regime in student enrollment API (V5)

### DIFF
--- a/.github/workflows/mocks-tests.yml
+++ b/.github/workflows/mocks-tests.yml
@@ -23,3 +23,5 @@ jobs:
 
       - name: Run tests
         run: bundle exec rspec
+        env:
+          LOCAL: true

--- a/mocks/lib/open_api_helpers.rb
+++ b/mocks/lib/open_api_helpers.rb
@@ -66,6 +66,11 @@ module OpenApiHelpers
           hash[key] = convert_open_api_3_to_json_schema(value)
         end
       end
+
+      if open_api_schema['nullable']
+        open_api_schema['type'] = [open_api_schema['type'], 'null']
+        open_api_schema.delete('nullable')
+      end
     else
       if open_api_schema['nullable']
         open_api_schema['type'] = [open_api_schema['type'], 'null']

--- a/mocks/openapi_files/api_particulier.yaml
+++ b/mocks/openapi_files/api_particulier.yaml
@@ -13812,6 +13812,602 @@ paths:
                     traitement avant d'effectuer une nouvelle requête.
               schema:
                 "$ref": "#/components/schemas/Error"
+  "/v5/men/scolarites/identite":
+    get:
+      summary: Statut élève scolarisé et boursier
+      tags:
+      - Statut élève scolarisé
+      parameters:
+      - name: recipient
+        in: query
+        description: |-
+          "**Bénéficiaire de l’appel**
+
+          SIRET de l’administration destinatrice des données."
+        example: '13002526500013'
+        required: true
+        schema:
+          type: string
+      - name: nomNaissance
+        in: query
+        description: "**Nom de naissance, également appelé nom de famille**. \n\nLe
+          nom de naissance est indiqué sur l'acte de naissance, de mariage, sur le
+          livret de famille, etc. Le nom de famille/naissance figure toujours sur
+          la pièce d'identité en premier, avant le nom d'usage si le particulier en
+          a un. \n\nEn cas de changement de nom de naissance, une mention avec le
+          nouveau nom de famille est inscrite sur l'acte de naissance. Pour appeler
+          l'API, le nom de naissance/famille nécessaire est bien le nom de famille
+          modifié."
+        example: DURANT
+        required: true
+        schema:
+          type: string
+      - name: prenoms[]
+        in: query
+        schema:
+          type: array
+          minItems: 1
+          maxItems: 3
+          items:
+            type: string
+          example:
+          - PIERRE
+          - RICHARD
+        description: "**Liste des prénoms**. \n\nFournir plusieurs prénoms maximise
+          les chances que l'API retrouve le particulier car cela permet de limiter
+          le risque d’homonymie."
+        required: true
+      - name: sexeEtatCivil
+        in: query
+        schema:
+          type: string
+          enum:
+          - M
+          - F
+        description: "**Sexe de la personne tel qu'indiqué sur les actes d'état civil**,
+          comme par exemple l'acte de naissance ou de mariage. \n\nDans la majorité
+          des cas, il s'agit également de la mention indiquée sur la pièce d'identité
+          et le passeport. Cette mention peut être masculin ('M') ou féminin ('F').
+          \nDans le cas d'un particulier ayant demandé une modification de sa mention
+          de sexe à l'état civil, le changement est indiqué en marge de l'acte de
+          naissance une fois la décision rendue. Le changement intervient sur les
+          titres d'identité seulement si le particulier en demande le renouvellement."
+        example: M
+        required: true
+      - name: anneeDateNaissance
+        in: query
+        description: "**Année de naissance**. \n\nPour un particulier né en France,
+          dans le cadre d'un appel à l'API avec l'utilisation du paramètre 'nomCommuneNaissance',
+          ce paramètre est obligatoire (ainsi que le paramètre 'codeCogInseeDepartementNaissance')
+          afin de retrouver le code COG de la commune de naissance."
+        example: 1990
+        required: true
+        schema:
+          type: integer
+      - name: moisDateNaissance
+        in: query
+        description: "**Mois de naissance**."
+        example: 1
+        required: true
+        schema:
+          type: integer
+      - name: jourDateNaissance
+        in: query
+        description: "**Jour de naissance**."
+        example: 1
+        required: true
+        schema:
+          type: integer
+      - name: codeEtablissement
+        in: query
+        description: |
+          Code d'unité administrative immatriculée (code UAI) de l'établissement où est scolarisé l'élève. Ce code unique inscrit au répertoire national des établissements est composé de 7 chiffres et d'une lettre ; les trois premiers chiffres correspondent au numéro de département de l'établissement.
+
+          Pour retrouver facilement le code UAI d'un établissement à partir d'informations plus facilement connues des usagers (commune, code postal, etc.), vous pouvez utiliser l'[API "Annuaire de l'éducation nationale"](https://api.gouv.fr/les-api/api-annuaire-education).
+
+          ⚠️ L'établissement 0861288H (CNED Direction générale) n'existe pas dans l'API annuaire de l'éducation nationale, il faudra donc compléter la liste des établissements avec une ligne CNED à laquelle sera associée le code UAI qui sera en passé en entrée.
+        example: 0210015C
+        required: false
+        schema:
+          type: string
+      - name: anneeScolaire
+        in: query
+        description: 'Année scolaire recherchée au format AAAA-AAAA ou AAAA. Les informations
+          connues par l''API concerne surtout l''année en cours et parfois l''année
+          scolaire à venir. Pour en savoir plus consulter la fiche métier : https://particulier.api.gouv.fr/catalogue/education_nationale/statut_eleve_scolarise#faq_entry_answer_0_api_particulier_endpoint_education_nationale_statut_eleve_scolarise.'
+        example: 2022-2023
+        required: true
+        schema:
+          type: string
+      - name: degreEtablissement
+        in: query
+        description: 'Degré de l''établissement scolaire : 1D pour le premier degré
+          (écoles maternelles et élémentaires) ou 2D pour le second degré (collèges
+          et lycées).'
+        example: 2D
+        required: false
+        schema:
+          type: string
+      - name: codesBcnDepartements[]
+        in: query
+        schema:
+          type: array
+          items:
+            type: string
+        description: |
+          Liste des codes BCN des départements du périmètre de recherche. Exactement un type de périmètre doit être fourni.
+
+          Référentiel : [N_DEPARTEMENT](https://bcn.depp.education.fr/bcn/workspace/viewTable/n/N_DEPARTEMENT)
+        required: false
+      - name: codesBcnRegions[]
+        in: query
+        schema:
+          type: array
+          items:
+            type: string
+        description: |
+          Liste des codes BCN des régions académiques du périmètre de recherche. Exactement un type de périmètre doit être fourni.
+
+          Référentiel : [N_REGION_ACADEMIQUE](https://bcn.depp.education.fr/bcn/workspace/viewTable/n/N_REGION_ACADEMIQUE)
+        required: false
+      security:
+      - jwt_bearer_token: []
+      description: Statut scolarisé d'un élève du primaire, collège ou lycée et statut
+        boursier.
+      responses:
+        '401':
+          description: Non autorisé
+          content:
+            application/json:
+              examples:
+                invalid_token_error:
+                  value:
+                    errors:
+                    - code: '00101'
+                      title: Interdit
+                      detail: Votre token n'est pas valide ou n'est pas renseigné
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Interdit
+                  description: Votre token n'est pas valide ou n'est pas renseigné
+                expired_token_error:
+                  value:
+                    errors:
+                    - code: '00103'
+                      title: Jeton expiré
+                      detail: Votre token est expiré. Vous devez refaire une demande
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Jeton expiré
+                  description: Votre token est expiré. Vous devez refaire une demande
+                blacklisted_token_error:
+                  value:
+                    errors:
+                    - code: '00105'
+                      title: Jeton sur liste noire
+                      detail: 'Votre jeton est sur liste noire, celui-ci a certainement
+                        été divulgué sur un canal non-sécurisé. Vous pouvez trouver
+                        un jeton valide sur votre espace personnel: https://entreprise.api.gouv.fr/compte'
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Jeton sur liste noire
+                  description: 'Votre jeton est sur liste noire, celui-ci a certainement
+                    été divulgué sur un canal non-sécurisé. Vous pouvez trouver un
+                    jeton valide sur votre espace personnel: https://entreprise.api.gouv.fr/compte'
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '403':
+          description: Accès interdit
+          content:
+            application/json:
+              examples:
+                insufficient_privileges_error:
+                  value:
+                    errors:
+                    - code: '00100'
+                      title: Privilèges insuffisants
+                      detail: Votre token est valide mais vos privilèges sont insuffisants.
+                        Listez vos privilèges sur /api/introspect
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Privilèges insuffisants
+                  description: Votre token est valide mais vos privilèges sont insuffisants.
+                    Listez vos privilèges sur /api/introspect
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '429':
+          description: Trop de requêtes
+          content:
+            application/json:
+              examples:
+                too_many_requests_error:
+                  value:
+                    errors:
+                    - code: '00429'
+                      title: Trop de requêtes
+                      detail: Vous avez effectué trop de requêtes
+                      source:
+                      meta: {}
+                  summary: Trop de requêtes
+                  description: Vous avez effectué trop de requêtes
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '200':
+          description: Scolarite trouvee par perimetre
+          x-operationId: api_particulier_v5_men_scolarites_with_civility
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      regime_pensionnat:
+                        title: Régime de pensionnat
+                        description: |
+                          Indique le régime de pensionnat de l'élève dans l'établissement. Ce champ est à "null" lorsque l'information n'est pas disponible. Les valeurs possibles sont :
+
+                          - 0 : Externe libre
+                          - 1 : Externe surveillé
+                          - 2 : Demi-pensionnaire dans l'établissement
+                          - 3 : Interne dans l'établissement
+                          - 4 : Interne externé
+                          - 5 : Interne hébergé
+                          - 6 : Demi-pensionnaire hors l'établissement
+                        type: object
+                        nullable: true
+                        properties:
+                          code:
+                            title: Code
+                            description: Code du régime de pensionnat de l'élève sur
+                              1 caractère, selon la nomenclature BCN.
+                            type: string
+                            example: '0'
+                            enum:
+                            - '0'
+                            - '1'
+                            - '2'
+                            - '3'
+                            - '4'
+                            - '5'
+                            - '6'
+                          libelle:
+                            title: Libellé
+                            description: Libellé du régime de pensionnat de l'élève.
+                            type: string
+                            example: Externe libre
+                            nullable: true
+                        required:
+                        - code
+                        - libelle
+                      identite:
+                        title: Données d'identité de l'élève
+                        description: Les informations d'identité retournées ici sont
+                          issues de la base de données des établissemets scolaires
+                          (API SIGNE) où les élèves sont inscrits et proviennent des
+                          pièces d'identité que les parents doivent fournir à l'établissement
+                          pour inscrire leur enfant.
+                        type: object
+                        properties:
+                          nom:
+                            title: Nom
+                            description: Nom de l'élève.
+                            type: string
+                            example: Martin
+                          prenom:
+                            title: Prénom
+                            description: Prénom de l'élève.
+                            type: string
+                            example: Justine
+                          sexe:
+                            title: Sexe
+                            description: Sexe de l'élève, masculin ou féminin.
+                            type: string
+                            example: F
+                            enum:
+                            - M
+                            - F
+                          date_naissance:
+                            title: Date de naissance
+                            description: Date de naissance de l'élève au format AAAA-MM-JJ
+                            type: string
+                            example: '2000-01-20'
+                        required:
+                        - nom
+                        - prenom
+                        - sexe
+                        - date_naissance
+                      module_elementaire_formation:
+                        title: Module élémentaire de formation (MEF)
+                        description: Libellé et code du module élémentaire de formation
+                          (MEF)
+                        type: object
+                        properties:
+                          code_mef_stat:
+                            title: Code MEF
+                            description: Code Mef Stat 11, selon la BCN
+                            type: string
+                            example: '211324099991'
+                            nullable: true
+                          libelle:
+                            title: Libéllé long, selon la BCN
+                            description: Libellé long, selon la BCN
+                            type: string
+                            example: 1CAP1 STAFFEUR ORNEMANISTE
+                            nullable: true
+                        required:
+                        - code_mef_stat
+                        - libelle
+                      etablissement:
+                        title: Établissement d'études
+                        description: Les informations relatives à l'établissement
+                        type: object
+                        properties:
+                          code_uai:
+                            title: Code UAI de l'établissement
+                            description: |
+                              Code d'unité administrative immatriculée (code UAI) de l'établissement où est scolarisé l'élève. Ce code unique inscrit au répertoire national des établissements est composé de 7 chiffres et d'une lettre ; les trois premiers chiffres correspondent au numéro de département de l'établissement.
+
+                              Pour retrouver le nom de l'établissement, vous pouvez utiliser l'[API "Annuaire de l'éducation nationale"](https://api.gouv.fr/les-api/api-annuaire-education) ou le site https://annuaire-education.fr.
+                            type: string
+                            pattern: "^\\d{7}\\w$"
+                            example: 0210015C
+                          code_ministere_tutelle:
+                            title: Code de l'établissement auprès du ministère de
+                              tutelle
+                            description: Code ministère de tutelle principale composé
+                              de 2 chiffres, selon la BCN
+                            type: string
+                            example: '06'
+                            nullable: true
+                        required:
+                        - code_uai
+                        - code_ministere_tutelle
+                      annee_scolaire:
+                        title: Année scolaire
+                        description: Année scolaire de l'élève au format AAAA-AAAA.
+                        type: string
+                        pattern: "^\\d{4}$|^\\d{4}-\\d{4}$"
+                        example: 2022-2023
+                      est_scolarise:
+                        title: Est scolarisé
+                        description: Indique si l'élève est scolarisé dans un établissement.
+                        type: boolean
+                        example: true
+                      statut_eleve:
+                        title: Statut de l'élève
+                        description: |
+                          Indique le statut sous lequel l'élève est scolarisé dans l'établissement. Les valeurs sont susceptibles d'évoluer :
+
+                          - ST : Scolaire, il s'agit du statut de base renvoyé pour près de 95% des élèves.
+                          - AP : Apprenti
+                          - CQ : Contrat de qualification
+                          - FC : Formation continue
+                          - ED : Enseignement à distance
+                          - IN : Candidat individuel
+                          - FQ : Stagiaire de la formation Professionnelle
+                          - SC : Scolaire ou formation initiale
+                          - CP : Contrat de professionnalisation.
+                          - NC : Non connu ou non communiqué.
+                        type: object
+                        properties:
+                          code:
+                            title: Code
+                            description: Code du statut sous lequel l'élève est scolarisé
+                              dans l'établissement.
+                            type: string
+                            example: ST
+                          libelle:
+                            title: Libellé
+                            description: Libellé du statut sous lequel l'élève est
+                              scolarisé dans l'établissement.
+                            type: string
+                            example: SCOLAIRE
+                        required:
+                        - code
+                        - libelle
+                      est_boursier:
+                        description: |
+                          Indique si l'élève est boursier dans l'établissement. Les bourses concernent uniquement les élèves des collèges et lycées.
+
+                          ⚠️ Si le statut boursier est à "false" avant mi-octobre, cela ne signifie pas forcément que l'élève n'est pas boursier. Il peut s'agir d'un faux négatif lié à une absence de l'information en base. Pour en savoir plus consulter la fiche métier : https://particulier.api.gouv.fr/catalogue/education_nationale/statut_eleve_scolarise#faq_entry_answer_1_api_particulier_endpoint_education_nationale_statut_eleve_scolarise.
+
+                          Ce champs prend la valeur null lorsque l'on ne sait pas si l'élève est boursier ou non
+                        type: boolean
+                        example: true
+                        nullable: false
+                      echelon_bourse:
+                        description: |
+                          Indique l'échelon de la bourse de l'élève. Est à "null" quand "est_boursier" est "false". Les bourses concernent uniquement les élèves des collèges et lycées.
+
+                          Il existe trois échelons de bourses pour les collégiens (1 à 3) et six échelons pour les lycéens (1 à 6), correspondant aux montants reçus par l'élève pour l'année scolaire. Pour en savoir plus, consulter la FAQ : https://particulier.api.gouv.fr/catalogue/education_nationale/statut_eleve_scolarise#faq_entry_answer_2_api_particulier_endpoint_education_nationale_statut_eleve_scolarise"
+                        type: integer
+                        example: 1
+                        nullable: true
+                        enum:
+                        -
+                        - 1
+                        - 2
+                        - 3
+                        - 4
+                        - 5
+                        - 6
+                    required:
+                    - regime_pensionnat
+                    - identite
+                    - module_elementaire_formation
+                    - etablissement
+                    - annee_scolaire
+                    - est_scolarise
+                    - statut_eleve
+                    - est_boursier
+                    - echelon_bourse
+                    additionalProperties: false
+                  links:
+                    type: object
+                  meta:
+                    type: object
+                required:
+                - data
+                - links
+                - meta
+        '404':
+          description: Non trouvee par perimetre
+          content:
+            application/json:
+              examples:
+                entite_non_trouvee_30003:
+                  value:
+                    errors:
+                    - code: '30003'
+                      title: Entité non trouvée
+                      detail: Aucun eleve n'a pu etre trouve avec les criteres de
+                        recherche fournis
+                      source:
+                      meta:
+                        provider: MEN
+                  summary: Entité non trouvée
+                  description: Aucun eleve n'a pu etre trouve avec les criteres de
+                    recherche fournis
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '422':
+          description: Paramètre(s) invalide(s)
+          content:
+            application/json:
+              examples:
+                unprocessable_content_error_code_etablissement_et_perimetre_error:
+                  value:
+                    errors:
+                    - code: '00419'
+                      title: Entité non traitable
+                      detail: Les paramètres codeEtablissement et périmètre (codesBcnRegions/codesBcnDepartements)
+                        sont mutuellement exclusifs
+                      source:
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Les paramètres codeEtablissement et périmètre (codesBcnRegions/codesBcnDepartements)
+                    sont mutuellement exclusifs
+                missing_mandatory_params_recipient_error:
+                  value:
+                    errors:
+                    - code: '00203'
+                      title: Entité non traitable
+                      detail: Le paramètre recipient est obligatoire
+                      source:
+                        parameter: recipient
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Le paramètre recipient est obligatoire
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '502':
+          description: Erreur du fournisseur
+          content:
+            application/json:
+              examples:
+                provider_unknown_error:
+                  value:
+                    errors:
+                    - code: '30999'
+                      title: Erreur inconnue du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et inconnue de notre service. L'équipe technique
+                        a été notifiée de cette erreur pour investigation.
+                      source:
+                      meta:
+                        provider: MEN
+                  summary: Erreur inconnue du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et inconnue de notre service. L'équipe technique
+                    a été notifiée de cette erreur pour investigation.
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '504':
+          description: Erreur d'intermédiaire
+          content:
+            application/json:
+              examples:
+                timeout_error:
+                  value:
+                    errors:
+                    - code: '30002'
+                      title: Intermédiaire hors-délai
+                      detail: Temps d’attente d’une réponse du fournisseur de données
+                        écoulé.
+                      source:
+                      meta:
+                        provider: MEN
+                  summary: Intermédiaire hors-délai
+                  description: Temps d’attente d’une réponse du fournisseur de données
+                    écoulé.
+                provider_unavailable_error:
+                  value:
+                    errors:
+                    - code: '30001'
+                      title: Service non disponible
+                      detail: Service du fournisseur de données temporairement indisponible
+                        ou en maintenance.
+                      source:
+                      meta:
+                        provider: MEN
+                  summary: Service non disponible
+                  description: Service du fournisseur de données temporairement indisponible
+                    ou en maintenance.
+                network_error:
+                  value:
+                    errors:
+                    - code: '00501'
+                      title: Erreur réseau
+                      detail: Problème de connexion au serveur distant. L'erreur peut
+                        venir soit du fournisseur, soit de API Entreprise. Il s'agit
+                        souvent d'une erreur temporaire.
+                      source:
+                      meta:
+                        retry_in: 10
+                  summary: Erreur réseau
+                  description: Problème de connexion au serveur distant. L'erreur
+                    peut venir soit du fournisseur, soit de API Entreprise. Il s'agit
+                    souvent d'une erreur temporaire.
+                dns_resolution_error:
+                  value:
+                    errors:
+                    - code: '30004'
+                      title: Erreur de résolution DNS
+                      detail: Problème de résolution DNS de l'adresse du serveur
+                      source:
+                      meta:
+                        provider: MEN
+                  summary: Erreur de résolution DNS
+                  description: Problème de résolution DNS de l'adresse du serveur
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '409':
+          description: Conflit
+          content:
+            application/json:
+              examples:
+                conflict_error:
+                  value:
+                    errors:
+                    - code: '00015'
+                      title: Conflit
+                      detail: Une requête associé à votre jeton est déjà en cours
+                        de traitement pour ces paramètres. Veuillez attendre la fin
+                        du traitement avant d'effectuer une nouvelle requête.
+                      source:
+                      meta: {}
+                  summary: Conflit
+                  description: Une requête associé à votre jeton est déjà en cours
+                    de traitement pour ces paramètres. Veuillez attendre la fin du
+                    traitement avant d'effectuer une nouvelle requête.
+              schema:
+                "$ref": "#/components/schemas/Error"
   "/v3/mesri/statut_etudiant/identite":
     get:
       summary: "[Identité] Statut étudiant"

--- a/mocks/payloads/README.md
+++ b/mocks/payloads/README.md
@@ -51,6 +51,7 @@ génère une payload par défaut basée sur la spécification OpenAPI associée.
 * [[FranceConnect] Statut service civique](api_particulier_v3_gip_mds_service_civique_with_france_connect) (`/v3/gip_mds/service_civique/france_connect`)
 * [Statut élève scolarisé et boursier](api_particulier_v3_men_scolarites_with_civility) (`/v3/men/scolarites/identite`)
 * [Statut élève scolarisé et boursier](api_particulier_v4_men_scolarites_with_civility) (`/v4/men/scolarites/identite`)
+* [Statut élève scolarisé et boursier](api_particulier_v5_men_scolarites_with_civility) (`/v5/men/scolarites/identite`)
 * [[Identité] Statut étudiant](api_particulier_v3_mesri_statut_etudiant_with_civility) (`/v3/mesri/statut_etudiant/identite`)
 * [[FranceConnect] Statut étudiant](api_particulier_v3_mesri_statut_etudiant_with_france_connect) (`/v3/mesri/statut_etudiant/france_connect`)
 * [[INE] Statut étudiant](api_particulier_v3_mesri_statut_etudiant_with_ine) (`/v3/mesri/statut_etudiant/ine`)

--- a/mocks/payloads/api_particulier_v5_men_scolarites_with_civility/200_eleve_boursier.yaml
+++ b/mocks/payloads/api_particulier_v5_men_scolarites_with_civility/200_eleve_boursier.yaml
@@ -1,0 +1,47 @@
+---
+description: 'Élève boursier'
+params:
+  nomNaissance: "MARTIN"
+  prenoms:
+    - 'EMMA'
+  sexeEtatCivil: "F"
+  anneeDateNaissance: 2012
+  moisDateNaissance: 8
+  jourDateNaissance: 15
+  codeEtablissement: "0132733A"
+  anneeScolaire: "2025"
+status: 200
+payload: |-
+  {
+    "data": {
+      "identite": {
+        "nom": "MARTIN",
+        "prenom": "EMMA",
+        "sexe": "F",
+        "date_naissance": "2012-08-15"
+      },
+      "module_elementaire_formation": {
+        "code_mef_stat": "211324099991",
+        "libelle": "1CAP1 STAFFEUR ORNEMANISTE"
+      },
+      "annee_scolaire": "2025-2026",
+      "est_scolarise": true,
+      "statut_eleve": {
+        "code": "ST",
+        "libelle": "Scolaire"
+      },
+      "etablissement": {
+        "code_uai": "0132733A",
+        "nom": "Lycée Polyvalent Antonin Artaud",
+        "code_ministere_tutelle": "06"
+      },
+      "est_boursier": true,
+      "echelon_bourse": 1,
+      "regime_pensionnat": {
+        "code": "2",
+        "libelle": "Demi-pensionnaire dans l'établissement"
+      }
+    },
+    "links": {},
+    "meta": {}
+  }

--- a/mocks/payloads/api_particulier_v5_men_scolarites_with_civility/200_eleve_non_boursier.yaml
+++ b/mocks/payloads/api_particulier_v5_men_scolarites_with_civility/200_eleve_non_boursier.yaml
@@ -1,0 +1,44 @@
+---
+description: 'Élève non boursier'
+params:
+  nomNaissance: "ROBERT"
+  prenoms:
+    - 'CLARA'
+  sexeEtatCivil: "F"
+  anneeDateNaissance: 2005
+  moisDateNaissance: 9
+  jourDateNaissance: 21
+  codeEtablissement: "0130039X"
+  anneeScolaire: "2025"
+status: 200
+payload: |-
+  {
+    "data": {
+      "identite": {
+        "nom": "ROBERT",
+        "prenom": "CLARA",
+        "sexe": "F",
+        "date_naissance": "2005-09-21"
+      },
+      "module_elementaire_formation": {
+        "code_mef_stat": "211324099991",
+        "libelle": "1CAP1 STAFFEUR ORNEMANISTE"
+      },
+      "annee_scolaire": "2025-2026",
+      "est_scolarise": true,
+      "statut_eleve": {
+        "code": "ST",
+        "libelle": "Scolaire"
+      },
+      "etablissement": {
+        "code_uai": "0130039X",
+        "nom": "Lycée Saint-Charles",
+        "code_ministere_tutelle": "06"
+      },
+      "est_boursier": false,
+      "echelon_bourse": null,
+      "regime_pensionnat": null
+    },
+    "links": {},
+    "meta": {}
+  }

--- a/mocks/payloads/api_particulier_v5_men_scolarites_with_civility/404.yaml
+++ b/mocks/payloads/api_particulier_v5_men_scolarites_with_civility/404.yaml
@@ -1,0 +1,27 @@
+---
+description: 'Élève non trouvé'
+params:
+  nomNaissance: "Martin"
+  prenoms:
+    - "Jerome"
+  sexeEtatCivil: "M"
+  anneeDateNaissance: 2000
+  moisDateNaissance: 1
+  jourDateNaissance: 20
+  codeEtablissement: "0890003V"
+  anneeScolaire: "2022"
+status: 404
+payload: |-
+  {
+    "errors": [
+      {
+        "code": "30003",
+        "title": "Entité non trouvée",
+        "detail": "Aucun élève n'a pu être trouvé avec les critères de recherche fournis.",
+        "source": null,
+        "meta": {
+          "provider": "MEN"
+        }
+      }
+    ]
+  }

--- a/mocks/payloads/api_particulier_v5_men_scolarites_with_civility/README.md
+++ b/mocks/payloads/api_particulier_v5_men_scolarites_with_civility/README.md
@@ -1,0 +1,218 @@
+# Statut élève scolarisé et boursier
+* [200_eleve_boursier.yaml](200_eleve_boursier.yaml)
+
+  Status `200`
+
+  Élève boursier
+
+  <details><summary>Paramètres</summary>
+  <p>
+
+  ```json
+  {
+    "nomNaissance": "MARTIN",
+    "prenoms": [
+      "EMMA"
+    ],
+    "sexeEtatCivil": "F",
+    "anneeDateNaissance": 2012,
+    "moisDateNaissance": 8,
+    "jourDateNaissance": 15,
+    "codeEtablissement": "0132733A",
+    "anneeScolaire": "2025"
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Réponse API</summary>
+  <p>
+
+  ```json
+  {
+    "data": {
+      "identite": {
+        "nom": "MARTIN",
+        "prenom": "EMMA",
+        "sexe": "F",
+        "date_naissance": "2012-08-15"
+      },
+      "module_elementaire_formation": {
+        "code_mef_stat": "211324099991",
+        "libelle": "1CAP1 STAFFEUR ORNEMANISTE"
+      },
+      "annee_scolaire": "2025-2026",
+      "est_scolarise": true,
+      "statut_eleve": {
+        "code": "ST",
+        "libelle": "Scolaire"
+      },
+      "etablissement": {
+        "code_uai": "0132733A",
+        "nom": "Lycée Polyvalent Antonin Artaud",
+        "code_ministere_tutelle": "06"
+      },
+      "est_boursier": true,
+      "echelon_bourse": 1,
+      "regime_pensionnat": {
+        "code": "2",
+        "libelle": "Demi-pensionnaire dans l'établissement"
+      }
+    },
+    "links": {},
+    "meta": {}
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Commande cURL</summary>
+  <p>
+
+  ```bash
+  curl -H "Authorization: Bearer $token" \
+    -G -d 'recipient=13002526500013' -d 'nomNaissance=MARTIN' -d 'prenoms[]=EMMA' -d 'sexeEtatCivil=F' -d 'anneeDateNaissance=2012' -d 'moisDateNaissance=8' -d 'jourDateNaissance=15' -d 'codeEtablissement=0132733A' -d 'anneeScolaire=2025' \
+    --url "https://staging.particulier.api.gouv.fr/v5/men/scolarites/identite"
+  ```
+
+  </p>
+  </details>
+* [200_eleve_non_boursier.yaml](200_eleve_non_boursier.yaml)
+
+  Status `200`
+
+  Élève non boursier
+
+  <details><summary>Paramètres</summary>
+  <p>
+
+  ```json
+  {
+    "nomNaissance": "ROBERT",
+    "prenoms": [
+      "CLARA"
+    ],
+    "sexeEtatCivil": "F",
+    "anneeDateNaissance": 2005,
+    "moisDateNaissance": 9,
+    "jourDateNaissance": 21,
+    "codeEtablissement": "0130039X",
+    "anneeScolaire": "2025"
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Réponse API</summary>
+  <p>
+
+  ```json
+  {
+    "data": {
+      "identite": {
+        "nom": "ROBERT",
+        "prenom": "CLARA",
+        "sexe": "F",
+        "date_naissance": "2005-09-21"
+      },
+      "module_elementaire_formation": {
+        "code_mef_stat": "211324099991",
+        "libelle": "1CAP1 STAFFEUR ORNEMANISTE"
+      },
+      "annee_scolaire": "2025-2026",
+      "est_scolarise": true,
+      "statut_eleve": {
+        "code": "ST",
+        "libelle": "Scolaire"
+      },
+      "etablissement": {
+        "code_uai": "0130039X",
+        "nom": "Lycée Saint-Charles",
+        "code_ministere_tutelle": "06"
+      },
+      "est_boursier": false,
+      "echelon_bourse": null,
+      "regime_pensionnat": null
+    },
+    "links": {},
+    "meta": {}
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Commande cURL</summary>
+  <p>
+
+  ```bash
+  curl -H "Authorization: Bearer $token" \
+    -G -d 'recipient=13002526500013' -d 'nomNaissance=ROBERT' -d 'prenoms[]=CLARA' -d 'sexeEtatCivil=F' -d 'anneeDateNaissance=2005' -d 'moisDateNaissance=9' -d 'jourDateNaissance=21' -d 'codeEtablissement=0130039X' -d 'anneeScolaire=2025' \
+    --url "https://staging.particulier.api.gouv.fr/v5/men/scolarites/identite"
+  ```
+
+  </p>
+  </details>
+* [404.yaml](404.yaml)
+
+  Status `404`
+
+  Élève non trouvé
+
+  <details><summary>Paramètres</summary>
+  <p>
+
+  ```json
+  {
+    "nomNaissance": "Martin",
+    "prenoms": [
+      "Jerome"
+    ],
+    "sexeEtatCivil": "M",
+    "anneeDateNaissance": 2000,
+    "moisDateNaissance": 1,
+    "jourDateNaissance": 20,
+    "codeEtablissement": "0890003V",
+    "anneeScolaire": "2022"
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Réponse API</summary>
+  <p>
+
+  ```json
+  {
+    "errors": [
+      {
+        "code": "30003",
+        "title": "Entité non trouvée",
+        "detail": "Aucun élève n'a pu être trouvé avec les critères de recherche fournis.",
+        "source": null,
+        "meta": {
+          "provider": "MEN"
+        }
+      }
+    ]
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Commande cURL</summary>
+  <p>
+
+  ```bash
+  curl -H "Authorization: Bearer $token" \
+    -G -d 'recipient=13002526500013' -d 'nomNaissance=Martin' -d 'prenoms[]=Jerome' -d 'sexeEtatCivil=M' -d 'anneeDateNaissance=2000' -d 'moisDateNaissance=1' -d 'jourDateNaissance=20' -d 'codeEtablissement=0890003V' -d 'anneeScolaire=2022' \
+    --url "https://staging.particulier.api.gouv.fr/v5/men/scolarites/identite"
+  ```
+
+  </p>
+  </details>

--- a/mocks/payloads/api_particulier_v5_men_scolarites_with_civility/summary.csv
+++ b/mocks/payloads/api_particulier_v5_men_scolarites_with_civility/summary.csv
@@ -1,0 +1,77 @@
+Titre,Description,Paramètres,Status,Réponse
+,Élève boursier,"{""nomNaissance"":""MARTIN"",""prenoms"":[""EMMA""],""sexeEtatCivil"":""F"",""anneeDateNaissance"":2012,""moisDateNaissance"":8,""jourDateNaissance"":15,""codeEtablissement"":""0132733A"",""anneeScolaire"":""2025""}",200,"{
+  ""data"": {
+    ""identite"": {
+      ""nom"": ""MARTIN"",
+      ""prenom"": ""EMMA"",
+      ""sexe"": ""F"",
+      ""date_naissance"": ""2012-08-15""
+    },
+    ""module_elementaire_formation"": {
+      ""code_mef_stat"": ""211324099991"",
+      ""libelle"": ""1CAP1 STAFFEUR ORNEMANISTE""
+    },
+    ""annee_scolaire"": ""2025-2026"",
+    ""est_scolarise"": true,
+    ""statut_eleve"": {
+      ""code"": ""ST"",
+      ""libelle"": ""Scolaire""
+    },
+    ""etablissement"": {
+      ""code_uai"": ""0132733A"",
+      ""nom"": ""Lycée Polyvalent Antonin Artaud"",
+      ""code_ministere_tutelle"": ""06""
+    },
+    ""est_boursier"": true,
+    ""echelon_bourse"": 1,
+    ""regime_pensionnat"": {
+      ""code"": ""2"",
+      ""libelle"": ""Demi-pensionnaire dans l'établissement""
+    }
+  },
+  ""links"": {},
+  ""meta"": {}
+}"
+,Élève non boursier,"{""nomNaissance"":""ROBERT"",""prenoms"":[""CLARA""],""sexeEtatCivil"":""F"",""anneeDateNaissance"":2005,""moisDateNaissance"":9,""jourDateNaissance"":21,""codeEtablissement"":""0130039X"",""anneeScolaire"":""2025""}",200,"{
+  ""data"": {
+    ""identite"": {
+      ""nom"": ""ROBERT"",
+      ""prenom"": ""CLARA"",
+      ""sexe"": ""F"",
+      ""date_naissance"": ""2005-09-21""
+    },
+    ""module_elementaire_formation"": {
+      ""code_mef_stat"": ""211324099991"",
+      ""libelle"": ""1CAP1 STAFFEUR ORNEMANISTE""
+    },
+    ""annee_scolaire"": ""2025-2026"",
+    ""est_scolarise"": true,
+    ""statut_eleve"": {
+      ""code"": ""ST"",
+      ""libelle"": ""Scolaire""
+    },
+    ""etablissement"": {
+      ""code_uai"": ""0130039X"",
+      ""nom"": ""Lycée Saint-Charles"",
+      ""code_ministere_tutelle"": ""06""
+    },
+    ""est_boursier"": false,
+    ""echelon_bourse"": null,
+    ""regime_pensionnat"": null
+  },
+  ""links"": {},
+  ""meta"": {}
+}"
+,Élève non trouvé,"{""nomNaissance"":""Martin"",""prenoms"":[""Jerome""],""sexeEtatCivil"":""M"",""anneeDateNaissance"":2000,""moisDateNaissance"":1,""jourDateNaissance"":20,""codeEtablissement"":""0890003V"",""anneeScolaire"":""2022""}",404,"{
+  ""errors"": [
+    {
+      ""code"": ""30003"",
+      ""title"": ""Entité non trouvée"",
+      ""detail"": ""Aucun élève n'a pu être trouvé avec les critères de recherche fournis."",
+      ""source"": null,
+      ""meta"": {
+        ""provider"": ""MEN""
+      }
+    }
+  ]
+}"

--- a/siade/app/interactors/men/scolarites/build_resource.rb
+++ b/siade/app/interactors/men/scolarites/build_resource.rb
@@ -1,4 +1,14 @@
 class MEN::Scolarites::BuildResource < BuildResource
+  REGIME_PENSIONNAT_LIBELLES = {
+    '0' => 'Externe libre',
+    '1' => 'Externe surveillé',
+    '2' => "Demi-pensionnaire dans l'établissement",
+    '3' => "Interne dans l'établissement",
+    '4' => 'Interne externé',
+    '5' => 'Interne hébergé',
+    '6' => "Demi-pensionnaire hors l'établissement"
+  }.freeze
+
   protected
 
   def resource_attributes
@@ -24,7 +34,8 @@ class MEN::Scolarites::BuildResource < BuildResource
       etablissement: {
         code_uai: json_body['identification']['etablissement']['code-uai'],
         code_ministere_tutelle: json_body['identification']['etablissement']['ministere-tutelle']
-      }
+      },
+      regime_pensionnat:
     }
   end
 
@@ -32,5 +43,15 @@ class MEN::Scolarites::BuildResource < BuildResource
 
   def sexe
     json_body['identification']['sexe'] == 1 ? 'M' : 'F'
+  end
+
+  def regime_pensionnat
+    code = json_body['info-scolarite']['code-regime']
+    return nil if code.nil?
+
+    {
+      code:,
+      libelle: REGIME_PENSIONNAT_LIBELLES[code]
+    }
   end
 end

--- a/siade/app/serializers/api_particulier/men/scolarites_serializer/v5.rb
+++ b/siade/app/serializers/api_particulier/men/scolarites_serializer/v5.rb
@@ -1,0 +1,3 @@
+class APIParticulier::MEN::ScolaritesSerializer::V5 < APIParticulier::MEN::ScolaritesSerializer::V4
+  attribute :regime_pensionnat, if: -> { scope?(:men_regime_pensionnat) }
+end

--- a/siade/config/authorizations.yml
+++ b/siade/config/authorizations.yml
@@ -264,6 +264,7 @@ shared:
     - men_statut_module_elementaire_formation
     - men_statut_boursier
     - men_echelon_bourse
+    - men_regime_pensionnat
   api_particulier/v3_and_more/mesri/statut_etudiant_with_ine:
     - mesri_identite
     - mesri_admissions

--- a/siade/config/swagger_data/men.yml
+++ b/siade/config/swagger_data/men.yml
@@ -57,7 +57,7 @@ men:
             value: "2022-2023"
         required: true
 
-    attributes:
+    attributes: &men_scolarite_attributes
       identite:
         title: "Données d'identité de l'élève"
         description: "Les informations d'identité retournées ici sont issues de la base de données des établissemets scolaires (API SIGNE) où les élèves sont inscrits et proviennent des pièces d'identité que les parents doivent fournir à l'établissement pour inscrire leur enfant."
@@ -187,6 +187,44 @@ men:
           - 4
           - 5
           - 6
+    regime_pensionnat_attribute: &regime_pensionnat_attribute
+      regime_pensionnat:
+        title: "Régime de pensionnat"
+        description: |+
+          Indique le régime de pensionnat de l'élève dans l'établissement. Ce champ est à "null" lorsque l'information n'est pas disponible. Les valeurs possibles sont :
+
+          - 0 : Externe libre
+          - 1 : Externe surveillé
+          - 2 : Demi-pensionnaire dans l'établissement
+          - 3 : Interne dans l'établissement
+          - 4 : Interne externé
+          - 5 : Interne hébergé
+          - 6 : Demi-pensionnaire hors l'établissement
+        type: object
+        nullable: true
+        properties:
+          code:
+            title: "Code"
+            description: "Code du régime de pensionnat de l'élève sur 1 caractère, selon la nomenclature BCN."
+            type: string
+            example: '0'
+            enum:
+              - '0'
+              - '1'
+              - '2'
+              - '3'
+              - '4'
+              - '5'
+              - '6'
+          libelle:
+            title: "Libellé"
+            description: "Libellé du régime de pensionnat de l'élève."
+            type: string
+            example: 'Externe libre'
+            nullable: true
+
+    v5_attributes:
+      <<: [*men_scolarite_attributes, *regime_pensionnat_attribute]
 
     v2:
       title: "Statut élève scolarisé"

--- a/siade/spec/interactors/men/scolarites/build_resource_spec.rb
+++ b/siade/spec/interactors/men/scolarites/build_resource_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe MEN::Scolarites::BuildResource, type: :build_resource do
             statut_eleve: {
               code: 'ST',
               libelle: 'SCOLAIRE'
-            }
+            },
+            regime_pensionnat: nil
           }
         end
 
@@ -69,7 +70,8 @@ RSpec.describe MEN::Scolarites::BuildResource, type: :build_resource do
             statut_eleve: {
               code: 'ST',
               libelle: 'SCOLAIRE'
-            }
+            },
+            regime_pensionnat: nil
           }
         end
 
@@ -101,7 +103,8 @@ RSpec.describe MEN::Scolarites::BuildResource, type: :build_resource do
             statut_eleve: {
               code: 'ST',
               libelle: 'SCOLAIRE'
-            }
+            },
+            regime_pensionnat: nil
           }
         end
 
@@ -141,6 +144,10 @@ RSpec.describe MEN::Scolarites::BuildResource, type: :build_resource do
           statut_eleve: {
             code: 'ST',
             libelle: 'SCOLAIRE'
+          },
+          regime_pensionnat: {
+            code: '0',
+            libelle: 'Externe libre'
           }
         }
       end

--- a/siade/spec/requests/api_particulier/v3_and_more/men/scolarites_with_civility/v5_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/men/scolarites_with_civility/v5_spec.rb
@@ -1,0 +1,147 @@
+require 'swagger_helper'
+
+RSpec.describe 'MEN: Scolarites with civility', api: :particulier, type: %i[request swagger] do
+  path '/v5/men/scolarites/identite' do
+    get SwaggerData.get('men.scolarite.title') do
+      tags(*SwaggerData.get('men.scolarite.tags'))
+
+      common_action_attributes
+
+      parameters_identite_pivot(
+        params: %w[
+          nomNaissance
+          prenoms
+          sexeEtatCivil
+          anneeDateNaissance
+          moisDateNaissance
+          jourDateNaissance
+        ],
+        required: %w[
+          nomNaissance
+          prenoms
+          sexeEtatCivil
+          anneeDateNaissance
+          moisDateNaissance
+          jourDateNaissance
+        ]
+      )
+
+      parameter name: :codeEtablissement,
+        in: :query,
+        type: SwaggerData.get('men.scolarite.parameters.code_etablissement.type'),
+        description: SwaggerData.get('men.scolarite.parameters.code_etablissement.description'),
+        example: SwaggerData.get('men.scolarite.parameters.code_etablissement.example'),
+        required: false
+
+      parameter name: :anneeScolaire,
+        in: :query,
+        type: SwaggerData.get('men.scolarite.parameters.annee_scolaire.type'),
+        description: SwaggerData.get('men.scolarite.parameters.annee_scolaire.description'),
+        example: SwaggerData.get('men.scolarite.parameters.annee_scolaire.examples.long.value'),
+        required: true
+
+      parameter name: :degreEtablissement,
+        in: :query,
+        type: SwaggerData.get('men.scolarite_perimetre.parameters.degre_etablissement.type'),
+        description: SwaggerData.get('men.scolarite_perimetre.parameters.degre_etablissement.description'),
+        example: SwaggerData.get('men.scolarite_perimetre.parameters.degre_etablissement.example'),
+        required: false
+
+      parameter name: :'codesBcnDepartements[]',
+        in: :query,
+        schema: { type: :array, items: { type: :string } },
+        description: SwaggerData.get('men.scolarite_perimetre.parameters.codes_bcn_departements.description'),
+        required: false
+
+      parameter name: :'codesBcnRegions[]',
+        in: :query,
+        schema: { type: :array, items: { type: :string } },
+        description: SwaggerData.get('men.scolarite_perimetre.parameters.codes_bcn_regions.description'),
+        required: false
+
+      let(:nomNaissance) { 'NOMFAMILLE' }
+      let(:'prenoms[]') { %w[prenom] }
+      let(:anneeDateNaissance) { '2000' }
+      let(:moisDateNaissance) { '06' }
+      let(:jourDateNaissance) { '10' }
+      let(:sexeEtatCivil) { 'f' }
+      let(:codeEtablissement) { '0511474A' }
+      let(:anneeScolaire) { '2021' }
+
+      unauthorized_request
+
+      forbidden_request('api_particulier')
+
+      too_many_requests(MEN::Scolarites)
+
+      let(:scopes) { %i[men_statut_scolarite men_statut_boursier men_echelon_bourse men_regime_pensionnat] }
+      describe 'with valid token and mandatory params', :valid do
+        describe 'with code_etablissement mode' do
+          response '200', 'Scolarite trouvee', vcr: { cassette_name: 'men/scolarites/valid_v2' } do
+            description SwaggerData.get('men.scolarite.description')
+
+            schema build_rswag_response(
+              attributes: SwaggerData.get('men.scolarite.v5_attributes')
+            )
+
+            run_test!
+          end
+
+          response '404', 'Non trouvee', vcr: { cassette_name: 'men/scolarites/not_found_v2' } do
+            let(:sexe) { 'f' }
+
+            build_rswag_example(NotFoundError.new('MEN', 'Aucun élève n\'a pu être trouvé avec les critères de recherche fournis.', with_identifiant_message: false))
+
+            schema '$ref' => '#/components/schemas/Error'
+
+            run_test!
+          end
+        end
+
+        describe 'with perimetre mode' do
+          let(:codeEtablissement) { nil }
+          let(:degreEtablissement) { '2D' }
+          let(:'codesBcnRegions[]') { %w[11] }
+
+          before do
+            stub_men_scolarites_auth
+          end
+
+          describe 'when found' do
+            before { stub_men_scolarites_perimetre_valid }
+
+            response '200', 'Scolarite trouvee par perimetre' do
+              schema build_rswag_response(
+                attributes: SwaggerData.get('men.scolarite.v5_attributes')
+              )
+
+              run_test!
+            end
+          end
+
+          describe 'when not found' do
+            before { stub_men_scolarites_perimetre_not_found }
+
+            response '404', 'Non trouvee par perimetre' do
+              build_rswag_example(NotFoundError.new('MEN', "Aucun eleve n'a pu etre trouve avec les criteres de recherche fournis", with_identifiant_message: false))
+
+              schema '$ref' => '#/components/schemas/Error'
+
+              run_test!
+            end
+          end
+        end
+
+        describe 'with mutual exclusivity error' do
+          let(:codeEtablissement) { '0511474A' }
+          let(:'codesBcnRegions[]') { %w[11] }
+
+          unprocessable_content_error_request(:code_etablissement_et_perimetre)
+        end
+
+        common_provider_errors_request('MEN', MEN::Scolarites)
+        common_network_error_request('MEN', MEN::Scolarites)
+      end
+    end
+  end
+end

--- a/siade/spec/serializers/api_particulier/men/scolarites_serializer/v5_spec.rb
+++ b/siade/spec/serializers/api_particulier/men/scolarites_serializer/v5_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe APIParticulier::MEN::ScolaritesSerializer::V5, type: :serializer do
+  subject { described_class.new(bundled_data, current_user).serializable_hash }
+
+  let(:bundled_data) { MEN::Scolarites::BuildResource.call(response:).bundled_data }
+
+  let(:response) { OpenStruct.new(body:) }
+  let(:body) { read_payload_file('men/scolarites/valid_v2_with_bourse.json') }
+
+  let(:current_user) { JwtUser.new(uid: SecureRandom.uuid, scopes:, jti: SecureRandom.uuid, iat: 1.year.ago.to_i, exp: 1.year.from_now.to_i) }
+
+  context 'with men_regime_pensionnat scope' do
+    let(:scopes) { %w[men_regime_pensionnat] }
+
+    it 'has only regime_pensionnat key' do
+      expect(subject[:data]).to have_key(:regime_pensionnat)
+      expect(subject[:data].keys).to eq([:regime_pensionnat])
+    end
+  end
+
+  context 'without men_regime_pensionnat scope' do
+    let(:scopes) { %w[men_statut_scolarite] }
+
+    it 'does not have regime_pensionnat key' do
+      expect(subject[:data]).not_to have_key(:regime_pensionnat)
+    end
+  end
+end

--- a/siade/swagger/openapi-particulier.yaml
+++ b/siade/swagger/openapi-particulier.yaml
@@ -13812,6 +13812,602 @@ paths:
                     traitement avant d'effectuer une nouvelle requête.
               schema:
                 "$ref": "#/components/schemas/Error"
+  "/v5/men/scolarites/identite":
+    get:
+      summary: Statut élève scolarisé et boursier
+      tags:
+      - Statut élève scolarisé
+      parameters:
+      - name: recipient
+        in: query
+        description: |-
+          "**Bénéficiaire de l’appel**
+
+          SIRET de l’administration destinatrice des données."
+        example: '13002526500013'
+        required: true
+        schema:
+          type: string
+      - name: nomNaissance
+        in: query
+        description: "**Nom de naissance, également appelé nom de famille**. \n\nLe
+          nom de naissance est indiqué sur l'acte de naissance, de mariage, sur le
+          livret de famille, etc. Le nom de famille/naissance figure toujours sur
+          la pièce d'identité en premier, avant le nom d'usage si le particulier en
+          a un. \n\nEn cas de changement de nom de naissance, une mention avec le
+          nouveau nom de famille est inscrite sur l'acte de naissance. Pour appeler
+          l'API, le nom de naissance/famille nécessaire est bien le nom de famille
+          modifié."
+        example: DURANT
+        required: true
+        schema:
+          type: string
+      - name: prenoms[]
+        in: query
+        schema:
+          type: array
+          minItems: 1
+          maxItems: 3
+          items:
+            type: string
+          example:
+          - PIERRE
+          - RICHARD
+        description: "**Liste des prénoms**. \n\nFournir plusieurs prénoms maximise
+          les chances que l'API retrouve le particulier car cela permet de limiter
+          le risque d’homonymie."
+        required: true
+      - name: sexeEtatCivil
+        in: query
+        schema:
+          type: string
+          enum:
+          - M
+          - F
+        description: "**Sexe de la personne tel qu'indiqué sur les actes d'état civil**,
+          comme par exemple l'acte de naissance ou de mariage. \n\nDans la majorité
+          des cas, il s'agit également de la mention indiquée sur la pièce d'identité
+          et le passeport. Cette mention peut être masculin ('M') ou féminin ('F').
+          \nDans le cas d'un particulier ayant demandé une modification de sa mention
+          de sexe à l'état civil, le changement est indiqué en marge de l'acte de
+          naissance une fois la décision rendue. Le changement intervient sur les
+          titres d'identité seulement si le particulier en demande le renouvellement."
+        example: M
+        required: true
+      - name: anneeDateNaissance
+        in: query
+        description: "**Année de naissance**. \n\nPour un particulier né en France,
+          dans le cadre d'un appel à l'API avec l'utilisation du paramètre 'nomCommuneNaissance',
+          ce paramètre est obligatoire (ainsi que le paramètre 'codeCogInseeDepartementNaissance')
+          afin de retrouver le code COG de la commune de naissance."
+        example: 1990
+        required: true
+        schema:
+          type: integer
+      - name: moisDateNaissance
+        in: query
+        description: "**Mois de naissance**."
+        example: 1
+        required: true
+        schema:
+          type: integer
+      - name: jourDateNaissance
+        in: query
+        description: "**Jour de naissance**."
+        example: 1
+        required: true
+        schema:
+          type: integer
+      - name: codeEtablissement
+        in: query
+        description: |
+          Code d'unité administrative immatriculée (code UAI) de l'établissement où est scolarisé l'élève. Ce code unique inscrit au répertoire national des établissements est composé de 7 chiffres et d'une lettre ; les trois premiers chiffres correspondent au numéro de département de l'établissement.
+
+          Pour retrouver facilement le code UAI d'un établissement à partir d'informations plus facilement connues des usagers (commune, code postal, etc.), vous pouvez utiliser l'[API "Annuaire de l'éducation nationale"](https://api.gouv.fr/les-api/api-annuaire-education).
+
+          ⚠️ L'établissement 0861288H (CNED Direction générale) n'existe pas dans l'API annuaire de l'éducation nationale, il faudra donc compléter la liste des établissements avec une ligne CNED à laquelle sera associée le code UAI qui sera en passé en entrée.
+        example: 0210015C
+        required: false
+        schema:
+          type: string
+      - name: anneeScolaire
+        in: query
+        description: 'Année scolaire recherchée au format AAAA-AAAA ou AAAA. Les informations
+          connues par l''API concerne surtout l''année en cours et parfois l''année
+          scolaire à venir. Pour en savoir plus consulter la fiche métier : https://particulier.api.gouv.fr/catalogue/education_nationale/statut_eleve_scolarise#faq_entry_answer_0_api_particulier_endpoint_education_nationale_statut_eleve_scolarise.'
+        example: 2022-2023
+        required: true
+        schema:
+          type: string
+      - name: degreEtablissement
+        in: query
+        description: 'Degré de l''établissement scolaire : 1D pour le premier degré
+          (écoles maternelles et élémentaires) ou 2D pour le second degré (collèges
+          et lycées).'
+        example: 2D
+        required: false
+        schema:
+          type: string
+      - name: codesBcnDepartements[]
+        in: query
+        schema:
+          type: array
+          items:
+            type: string
+        description: |
+          Liste des codes BCN des départements du périmètre de recherche. Exactement un type de périmètre doit être fourni.
+
+          Référentiel : [N_DEPARTEMENT](https://bcn.depp.education.fr/bcn/workspace/viewTable/n/N_DEPARTEMENT)
+        required: false
+      - name: codesBcnRegions[]
+        in: query
+        schema:
+          type: array
+          items:
+            type: string
+        description: |
+          Liste des codes BCN des régions académiques du périmètre de recherche. Exactement un type de périmètre doit être fourni.
+
+          Référentiel : [N_REGION_ACADEMIQUE](https://bcn.depp.education.fr/bcn/workspace/viewTable/n/N_REGION_ACADEMIQUE)
+        required: false
+      security:
+      - jwt_bearer_token: []
+      description: Statut scolarisé d'un élève du primaire, collège ou lycée et statut
+        boursier.
+      responses:
+        '401':
+          description: Non autorisé
+          content:
+            application/json:
+              examples:
+                invalid_token_error:
+                  value:
+                    errors:
+                    - code: '00101'
+                      title: Interdit
+                      detail: Votre token n'est pas valide ou n'est pas renseigné
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Interdit
+                  description: Votre token n'est pas valide ou n'est pas renseigné
+                expired_token_error:
+                  value:
+                    errors:
+                    - code: '00103'
+                      title: Jeton expiré
+                      detail: Votre token est expiré. Vous devez refaire une demande
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Jeton expiré
+                  description: Votre token est expiré. Vous devez refaire une demande
+                blacklisted_token_error:
+                  value:
+                    errors:
+                    - code: '00105'
+                      title: Jeton sur liste noire
+                      detail: 'Votre jeton est sur liste noire, celui-ci a certainement
+                        été divulgué sur un canal non-sécurisé. Vous pouvez trouver
+                        un jeton valide sur votre espace personnel: https://entreprise.api.gouv.fr/compte'
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Jeton sur liste noire
+                  description: 'Votre jeton est sur liste noire, celui-ci a certainement
+                    été divulgué sur un canal non-sécurisé. Vous pouvez trouver un
+                    jeton valide sur votre espace personnel: https://entreprise.api.gouv.fr/compte'
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '403':
+          description: Accès interdit
+          content:
+            application/json:
+              examples:
+                insufficient_privileges_error:
+                  value:
+                    errors:
+                    - code: '00100'
+                      title: Privilèges insuffisants
+                      detail: Votre token est valide mais vos privilèges sont insuffisants.
+                        Listez vos privilèges sur /api/introspect
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Privilèges insuffisants
+                  description: Votre token est valide mais vos privilèges sont insuffisants.
+                    Listez vos privilèges sur /api/introspect
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '429':
+          description: Trop de requêtes
+          content:
+            application/json:
+              examples:
+                too_many_requests_error:
+                  value:
+                    errors:
+                    - code: '00429'
+                      title: Trop de requêtes
+                      detail: Vous avez effectué trop de requêtes
+                      source:
+                      meta: {}
+                  summary: Trop de requêtes
+                  description: Vous avez effectué trop de requêtes
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '200':
+          description: Scolarite trouvee par perimetre
+          x-operationId: api_particulier_v5_men_scolarites_with_civility
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      regime_pensionnat:
+                        title: Régime de pensionnat
+                        description: |
+                          Indique le régime de pensionnat de l'élève dans l'établissement. Ce champ est à "null" lorsque l'information n'est pas disponible. Les valeurs possibles sont :
+
+                          - 0 : Externe libre
+                          - 1 : Externe surveillé
+                          - 2 : Demi-pensionnaire dans l'établissement
+                          - 3 : Interne dans l'établissement
+                          - 4 : Interne externé
+                          - 5 : Interne hébergé
+                          - 6 : Demi-pensionnaire hors l'établissement
+                        type: object
+                        nullable: true
+                        properties:
+                          code:
+                            title: Code
+                            description: Code du régime de pensionnat de l'élève sur
+                              1 caractère, selon la nomenclature BCN.
+                            type: string
+                            example: '0'
+                            enum:
+                            - '0'
+                            - '1'
+                            - '2'
+                            - '3'
+                            - '4'
+                            - '5'
+                            - '6'
+                          libelle:
+                            title: Libellé
+                            description: Libellé du régime de pensionnat de l'élève.
+                            type: string
+                            example: Externe libre
+                            nullable: true
+                        required:
+                        - code
+                        - libelle
+                      identite:
+                        title: Données d'identité de l'élève
+                        description: Les informations d'identité retournées ici sont
+                          issues de la base de données des établissemets scolaires
+                          (API SIGNE) où les élèves sont inscrits et proviennent des
+                          pièces d'identité que les parents doivent fournir à l'établissement
+                          pour inscrire leur enfant.
+                        type: object
+                        properties:
+                          nom:
+                            title: Nom
+                            description: Nom de l'élève.
+                            type: string
+                            example: Martin
+                          prenom:
+                            title: Prénom
+                            description: Prénom de l'élève.
+                            type: string
+                            example: Justine
+                          sexe:
+                            title: Sexe
+                            description: Sexe de l'élève, masculin ou féminin.
+                            type: string
+                            example: F
+                            enum:
+                            - M
+                            - F
+                          date_naissance:
+                            title: Date de naissance
+                            description: Date de naissance de l'élève au format AAAA-MM-JJ
+                            type: string
+                            example: '2000-01-20'
+                        required:
+                        - nom
+                        - prenom
+                        - sexe
+                        - date_naissance
+                      module_elementaire_formation:
+                        title: Module élémentaire de formation (MEF)
+                        description: Libellé et code du module élémentaire de formation
+                          (MEF)
+                        type: object
+                        properties:
+                          code_mef_stat:
+                            title: Code MEF
+                            description: Code Mef Stat 11, selon la BCN
+                            type: string
+                            example: '211324099991'
+                            nullable: true
+                          libelle:
+                            title: Libéllé long, selon la BCN
+                            description: Libellé long, selon la BCN
+                            type: string
+                            example: 1CAP1 STAFFEUR ORNEMANISTE
+                            nullable: true
+                        required:
+                        - code_mef_stat
+                        - libelle
+                      etablissement:
+                        title: Établissement d'études
+                        description: Les informations relatives à l'établissement
+                        type: object
+                        properties:
+                          code_uai:
+                            title: Code UAI de l'établissement
+                            description: |
+                              Code d'unité administrative immatriculée (code UAI) de l'établissement où est scolarisé l'élève. Ce code unique inscrit au répertoire national des établissements est composé de 7 chiffres et d'une lettre ; les trois premiers chiffres correspondent au numéro de département de l'établissement.
+
+                              Pour retrouver le nom de l'établissement, vous pouvez utiliser l'[API "Annuaire de l'éducation nationale"](https://api.gouv.fr/les-api/api-annuaire-education) ou le site https://annuaire-education.fr.
+                            type: string
+                            pattern: "^\\d{7}\\w$"
+                            example: 0210015C
+                          code_ministere_tutelle:
+                            title: Code de l'établissement auprès du ministère de
+                              tutelle
+                            description: Code ministère de tutelle principale composé
+                              de 2 chiffres, selon la BCN
+                            type: string
+                            example: '06'
+                            nullable: true
+                        required:
+                        - code_uai
+                        - code_ministere_tutelle
+                      annee_scolaire:
+                        title: Année scolaire
+                        description: Année scolaire de l'élève au format AAAA-AAAA.
+                        type: string
+                        pattern: "^\\d{4}$|^\\d{4}-\\d{4}$"
+                        example: 2022-2023
+                      est_scolarise:
+                        title: Est scolarisé
+                        description: Indique si l'élève est scolarisé dans un établissement.
+                        type: boolean
+                        example: true
+                      statut_eleve:
+                        title: Statut de l'élève
+                        description: |
+                          Indique le statut sous lequel l'élève est scolarisé dans l'établissement. Les valeurs sont susceptibles d'évoluer :
+
+                          - ST : Scolaire, il s'agit du statut de base renvoyé pour près de 95% des élèves.
+                          - AP : Apprenti
+                          - CQ : Contrat de qualification
+                          - FC : Formation continue
+                          - ED : Enseignement à distance
+                          - IN : Candidat individuel
+                          - FQ : Stagiaire de la formation Professionnelle
+                          - SC : Scolaire ou formation initiale
+                          - CP : Contrat de professionnalisation.
+                          - NC : Non connu ou non communiqué.
+                        type: object
+                        properties:
+                          code:
+                            title: Code
+                            description: Code du statut sous lequel l'élève est scolarisé
+                              dans l'établissement.
+                            type: string
+                            example: ST
+                          libelle:
+                            title: Libellé
+                            description: Libellé du statut sous lequel l'élève est
+                              scolarisé dans l'établissement.
+                            type: string
+                            example: SCOLAIRE
+                        required:
+                        - code
+                        - libelle
+                      est_boursier:
+                        description: |
+                          Indique si l'élève est boursier dans l'établissement. Les bourses concernent uniquement les élèves des collèges et lycées.
+
+                          ⚠️ Si le statut boursier est à "false" avant mi-octobre, cela ne signifie pas forcément que l'élève n'est pas boursier. Il peut s'agir d'un faux négatif lié à une absence de l'information en base. Pour en savoir plus consulter la fiche métier : https://particulier.api.gouv.fr/catalogue/education_nationale/statut_eleve_scolarise#faq_entry_answer_1_api_particulier_endpoint_education_nationale_statut_eleve_scolarise.
+
+                          Ce champs prend la valeur null lorsque l'on ne sait pas si l'élève est boursier ou non
+                        type: boolean
+                        example: true
+                        nullable: false
+                      echelon_bourse:
+                        description: |
+                          Indique l'échelon de la bourse de l'élève. Est à "null" quand "est_boursier" est "false". Les bourses concernent uniquement les élèves des collèges et lycées.
+
+                          Il existe trois échelons de bourses pour les collégiens (1 à 3) et six échelons pour les lycéens (1 à 6), correspondant aux montants reçus par l'élève pour l'année scolaire. Pour en savoir plus, consulter la FAQ : https://particulier.api.gouv.fr/catalogue/education_nationale/statut_eleve_scolarise#faq_entry_answer_2_api_particulier_endpoint_education_nationale_statut_eleve_scolarise"
+                        type: integer
+                        example: 1
+                        nullable: true
+                        enum:
+                        -
+                        - 1
+                        - 2
+                        - 3
+                        - 4
+                        - 5
+                        - 6
+                    required:
+                    - regime_pensionnat
+                    - identite
+                    - module_elementaire_formation
+                    - etablissement
+                    - annee_scolaire
+                    - est_scolarise
+                    - statut_eleve
+                    - est_boursier
+                    - echelon_bourse
+                    additionalProperties: false
+                  links:
+                    type: object
+                  meta:
+                    type: object
+                required:
+                - data
+                - links
+                - meta
+        '404':
+          description: Non trouvee par perimetre
+          content:
+            application/json:
+              examples:
+                entite_non_trouvee_30003:
+                  value:
+                    errors:
+                    - code: '30003'
+                      title: Entité non trouvée
+                      detail: Aucun eleve n'a pu etre trouve avec les criteres de
+                        recherche fournis
+                      source:
+                      meta:
+                        provider: MEN
+                  summary: Entité non trouvée
+                  description: Aucun eleve n'a pu etre trouve avec les criteres de
+                    recherche fournis
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '422':
+          description: Paramètre(s) invalide(s)
+          content:
+            application/json:
+              examples:
+                unprocessable_content_error_code_etablissement_et_perimetre_error:
+                  value:
+                    errors:
+                    - code: '00419'
+                      title: Entité non traitable
+                      detail: Les paramètres codeEtablissement et périmètre (codesBcnRegions/codesBcnDepartements)
+                        sont mutuellement exclusifs
+                      source:
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Les paramètres codeEtablissement et périmètre (codesBcnRegions/codesBcnDepartements)
+                    sont mutuellement exclusifs
+                missing_mandatory_params_recipient_error:
+                  value:
+                    errors:
+                    - code: '00203'
+                      title: Entité non traitable
+                      detail: Le paramètre recipient est obligatoire
+                      source:
+                        parameter: recipient
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Le paramètre recipient est obligatoire
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '502':
+          description: Erreur du fournisseur
+          content:
+            application/json:
+              examples:
+                provider_unknown_error:
+                  value:
+                    errors:
+                    - code: '30999'
+                      title: Erreur inconnue du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et inconnue de notre service. L'équipe technique
+                        a été notifiée de cette erreur pour investigation.
+                      source:
+                      meta:
+                        provider: MEN
+                  summary: Erreur inconnue du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et inconnue de notre service. L'équipe technique
+                    a été notifiée de cette erreur pour investigation.
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '504':
+          description: Erreur d'intermédiaire
+          content:
+            application/json:
+              examples:
+                timeout_error:
+                  value:
+                    errors:
+                    - code: '30002'
+                      title: Intermédiaire hors-délai
+                      detail: Temps d’attente d’une réponse du fournisseur de données
+                        écoulé.
+                      source:
+                      meta:
+                        provider: MEN
+                  summary: Intermédiaire hors-délai
+                  description: Temps d’attente d’une réponse du fournisseur de données
+                    écoulé.
+                provider_unavailable_error:
+                  value:
+                    errors:
+                    - code: '30001'
+                      title: Service non disponible
+                      detail: Service du fournisseur de données temporairement indisponible
+                        ou en maintenance.
+                      source:
+                      meta:
+                        provider: MEN
+                  summary: Service non disponible
+                  description: Service du fournisseur de données temporairement indisponible
+                    ou en maintenance.
+                network_error:
+                  value:
+                    errors:
+                    - code: '00501'
+                      title: Erreur réseau
+                      detail: Problème de connexion au serveur distant. L'erreur peut
+                        venir soit du fournisseur, soit de API Entreprise. Il s'agit
+                        souvent d'une erreur temporaire.
+                      source:
+                      meta:
+                        retry_in: 10
+                  summary: Erreur réseau
+                  description: Problème de connexion au serveur distant. L'erreur
+                    peut venir soit du fournisseur, soit de API Entreprise. Il s'agit
+                    souvent d'une erreur temporaire.
+                dns_resolution_error:
+                  value:
+                    errors:
+                    - code: '30004'
+                      title: Erreur de résolution DNS
+                      detail: Problème de résolution DNS de l'adresse du serveur
+                      source:
+                      meta:
+                        provider: MEN
+                  summary: Erreur de résolution DNS
+                  description: Problème de résolution DNS de l'adresse du serveur
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '409':
+          description: Conflit
+          content:
+            application/json:
+              examples:
+                conflict_error:
+                  value:
+                    errors:
+                    - code: '00015'
+                      title: Conflit
+                      detail: Une requête associé à votre jeton est déjà en cours
+                        de traitement pour ces paramètres. Veuillez attendre la fin
+                        du traitement avant d'effectuer une nouvelle requête.
+                      source:
+                      meta: {}
+                  summary: Conflit
+                  description: Une requête associé à votre jeton est déjà en cours
+                    de traitement pour ces paramètres. Veuillez attendre la fin du
+                    traitement avant d'effectuer une nouvelle requête.
+              schema:
+                "$ref": "#/components/schemas/Error"
   "/v3/mesri/statut_etudiant/identite":
     get:
       summary: "[Identité] Statut étudiant"

--- a/site/config/api-particulier-openapi-v3.yml
+++ b/site/config/api-particulier-openapi-v3.yml
@@ -13812,6 +13812,602 @@ paths:
                     traitement avant d'effectuer une nouvelle requête.
               schema:
                 "$ref": "#/components/schemas/Error"
+  "/v5/men/scolarites/identite":
+    get:
+      summary: Statut élève scolarisé et boursier
+      tags:
+      - Statut élève scolarisé
+      parameters:
+      - name: recipient
+        in: query
+        description: |-
+          "**Bénéficiaire de l’appel**
+
+          SIRET de l’administration destinatrice des données."
+        example: '13002526500013'
+        required: true
+        schema:
+          type: string
+      - name: nomNaissance
+        in: query
+        description: "**Nom de naissance, également appelé nom de famille**. \n\nLe
+          nom de naissance est indiqué sur l'acte de naissance, de mariage, sur le
+          livret de famille, etc. Le nom de famille/naissance figure toujours sur
+          la pièce d'identité en premier, avant le nom d'usage si le particulier en
+          a un. \n\nEn cas de changement de nom de naissance, une mention avec le
+          nouveau nom de famille est inscrite sur l'acte de naissance. Pour appeler
+          l'API, le nom de naissance/famille nécessaire est bien le nom de famille
+          modifié."
+        example: DURANT
+        required: true
+        schema:
+          type: string
+      - name: prenoms[]
+        in: query
+        schema:
+          type: array
+          minItems: 1
+          maxItems: 3
+          items:
+            type: string
+          example:
+          - PIERRE
+          - RICHARD
+        description: "**Liste des prénoms**. \n\nFournir plusieurs prénoms maximise
+          les chances que l'API retrouve le particulier car cela permet de limiter
+          le risque d’homonymie."
+        required: true
+      - name: sexeEtatCivil
+        in: query
+        schema:
+          type: string
+          enum:
+          - M
+          - F
+        description: "**Sexe de la personne tel qu'indiqué sur les actes d'état civil**,
+          comme par exemple l'acte de naissance ou de mariage. \n\nDans la majorité
+          des cas, il s'agit également de la mention indiquée sur la pièce d'identité
+          et le passeport. Cette mention peut être masculin ('M') ou féminin ('F').
+          \nDans le cas d'un particulier ayant demandé une modification de sa mention
+          de sexe à l'état civil, le changement est indiqué en marge de l'acte de
+          naissance une fois la décision rendue. Le changement intervient sur les
+          titres d'identité seulement si le particulier en demande le renouvellement."
+        example: M
+        required: true
+      - name: anneeDateNaissance
+        in: query
+        description: "**Année de naissance**. \n\nPour un particulier né en France,
+          dans le cadre d'un appel à l'API avec l'utilisation du paramètre 'nomCommuneNaissance',
+          ce paramètre est obligatoire (ainsi que le paramètre 'codeCogInseeDepartementNaissance')
+          afin de retrouver le code COG de la commune de naissance."
+        example: 1990
+        required: true
+        schema:
+          type: integer
+      - name: moisDateNaissance
+        in: query
+        description: "**Mois de naissance**."
+        example: 1
+        required: true
+        schema:
+          type: integer
+      - name: jourDateNaissance
+        in: query
+        description: "**Jour de naissance**."
+        example: 1
+        required: true
+        schema:
+          type: integer
+      - name: codeEtablissement
+        in: query
+        description: |
+          Code d'unité administrative immatriculée (code UAI) de l'établissement où est scolarisé l'élève. Ce code unique inscrit au répertoire national des établissements est composé de 7 chiffres et d'une lettre ; les trois premiers chiffres correspondent au numéro de département de l'établissement.
+
+          Pour retrouver facilement le code UAI d'un établissement à partir d'informations plus facilement connues des usagers (commune, code postal, etc.), vous pouvez utiliser l'[API "Annuaire de l'éducation nationale"](https://api.gouv.fr/les-api/api-annuaire-education).
+
+          ⚠️ L'établissement 0861288H (CNED Direction générale) n'existe pas dans l'API annuaire de l'éducation nationale, il faudra donc compléter la liste des établissements avec une ligne CNED à laquelle sera associée le code UAI qui sera en passé en entrée.
+        example: 0210015C
+        required: false
+        schema:
+          type: string
+      - name: anneeScolaire
+        in: query
+        description: 'Année scolaire recherchée au format AAAA-AAAA ou AAAA. Les informations
+          connues par l''API concerne surtout l''année en cours et parfois l''année
+          scolaire à venir. Pour en savoir plus consulter la fiche métier : https://particulier.api.gouv.fr/catalogue/education_nationale/statut_eleve_scolarise#faq_entry_answer_0_api_particulier_endpoint_education_nationale_statut_eleve_scolarise.'
+        example: 2022-2023
+        required: true
+        schema:
+          type: string
+      - name: degreEtablissement
+        in: query
+        description: 'Degré de l''établissement scolaire : 1D pour le premier degré
+          (écoles maternelles et élémentaires) ou 2D pour le second degré (collèges
+          et lycées).'
+        example: 2D
+        required: false
+        schema:
+          type: string
+      - name: codesBcnDepartements[]
+        in: query
+        schema:
+          type: array
+          items:
+            type: string
+        description: |
+          Liste des codes BCN des départements du périmètre de recherche. Exactement un type de périmètre doit être fourni.
+
+          Référentiel : [N_DEPARTEMENT](https://bcn.depp.education.fr/bcn/workspace/viewTable/n/N_DEPARTEMENT)
+        required: false
+      - name: codesBcnRegions[]
+        in: query
+        schema:
+          type: array
+          items:
+            type: string
+        description: |
+          Liste des codes BCN des régions académiques du périmètre de recherche. Exactement un type de périmètre doit être fourni.
+
+          Référentiel : [N_REGION_ACADEMIQUE](https://bcn.depp.education.fr/bcn/workspace/viewTable/n/N_REGION_ACADEMIQUE)
+        required: false
+      security:
+      - jwt_bearer_token: []
+      description: Statut scolarisé d'un élève du primaire, collège ou lycée et statut
+        boursier.
+      responses:
+        '401':
+          description: Non autorisé
+          content:
+            application/json:
+              examples:
+                invalid_token_error:
+                  value:
+                    errors:
+                    - code: '00101'
+                      title: Interdit
+                      detail: Votre token n'est pas valide ou n'est pas renseigné
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Interdit
+                  description: Votre token n'est pas valide ou n'est pas renseigné
+                expired_token_error:
+                  value:
+                    errors:
+                    - code: '00103'
+                      title: Jeton expiré
+                      detail: Votre token est expiré. Vous devez refaire une demande
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Jeton expiré
+                  description: Votre token est expiré. Vous devez refaire une demande
+                blacklisted_token_error:
+                  value:
+                    errors:
+                    - code: '00105'
+                      title: Jeton sur liste noire
+                      detail: 'Votre jeton est sur liste noire, celui-ci a certainement
+                        été divulgué sur un canal non-sécurisé. Vous pouvez trouver
+                        un jeton valide sur votre espace personnel: https://entreprise.api.gouv.fr/compte'
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Jeton sur liste noire
+                  description: 'Votre jeton est sur liste noire, celui-ci a certainement
+                    été divulgué sur un canal non-sécurisé. Vous pouvez trouver un
+                    jeton valide sur votre espace personnel: https://entreprise.api.gouv.fr/compte'
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '403':
+          description: Accès interdit
+          content:
+            application/json:
+              examples:
+                insufficient_privileges_error:
+                  value:
+                    errors:
+                    - code: '00100'
+                      title: Privilèges insuffisants
+                      detail: Votre token est valide mais vos privilèges sont insuffisants.
+                        Listez vos privilèges sur /api/introspect
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Privilèges insuffisants
+                  description: Votre token est valide mais vos privilèges sont insuffisants.
+                    Listez vos privilèges sur /api/introspect
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '429':
+          description: Trop de requêtes
+          content:
+            application/json:
+              examples:
+                too_many_requests_error:
+                  value:
+                    errors:
+                    - code: '00429'
+                      title: Trop de requêtes
+                      detail: Vous avez effectué trop de requêtes
+                      source:
+                      meta: {}
+                  summary: Trop de requêtes
+                  description: Vous avez effectué trop de requêtes
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '200':
+          description: Scolarite trouvee par perimetre
+          x-operationId: api_particulier_v5_men_scolarites_with_civility
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      regime_pensionnat:
+                        title: Régime de pensionnat
+                        description: |
+                          Indique le régime de pensionnat de l'élève dans l'établissement. Ce champ est à "null" lorsque l'information n'est pas disponible. Les valeurs possibles sont :
+
+                          - 0 : Externe libre
+                          - 1 : Externe surveillé
+                          - 2 : Demi-pensionnaire dans l'établissement
+                          - 3 : Interne dans l'établissement
+                          - 4 : Interne externé
+                          - 5 : Interne hébergé
+                          - 6 : Demi-pensionnaire hors l'établissement
+                        type: object
+                        nullable: true
+                        properties:
+                          code:
+                            title: Code
+                            description: Code du régime de pensionnat de l'élève sur
+                              1 caractère, selon la nomenclature BCN.
+                            type: string
+                            example: '0'
+                            enum:
+                            - '0'
+                            - '1'
+                            - '2'
+                            - '3'
+                            - '4'
+                            - '5'
+                            - '6'
+                          libelle:
+                            title: Libellé
+                            description: Libellé du régime de pensionnat de l'élève.
+                            type: string
+                            example: Externe libre
+                            nullable: true
+                        required:
+                        - code
+                        - libelle
+                      identite:
+                        title: Données d'identité de l'élève
+                        description: Les informations d'identité retournées ici sont
+                          issues de la base de données des établissemets scolaires
+                          (API SIGNE) où les élèves sont inscrits et proviennent des
+                          pièces d'identité que les parents doivent fournir à l'établissement
+                          pour inscrire leur enfant.
+                        type: object
+                        properties:
+                          nom:
+                            title: Nom
+                            description: Nom de l'élève.
+                            type: string
+                            example: Martin
+                          prenom:
+                            title: Prénom
+                            description: Prénom de l'élève.
+                            type: string
+                            example: Justine
+                          sexe:
+                            title: Sexe
+                            description: Sexe de l'élève, masculin ou féminin.
+                            type: string
+                            example: F
+                            enum:
+                            - M
+                            - F
+                          date_naissance:
+                            title: Date de naissance
+                            description: Date de naissance de l'élève au format AAAA-MM-JJ
+                            type: string
+                            example: '2000-01-20'
+                        required:
+                        - nom
+                        - prenom
+                        - sexe
+                        - date_naissance
+                      module_elementaire_formation:
+                        title: Module élémentaire de formation (MEF)
+                        description: Libellé et code du module élémentaire de formation
+                          (MEF)
+                        type: object
+                        properties:
+                          code_mef_stat:
+                            title: Code MEF
+                            description: Code Mef Stat 11, selon la BCN
+                            type: string
+                            example: '211324099991'
+                            nullable: true
+                          libelle:
+                            title: Libéllé long, selon la BCN
+                            description: Libellé long, selon la BCN
+                            type: string
+                            example: 1CAP1 STAFFEUR ORNEMANISTE
+                            nullable: true
+                        required:
+                        - code_mef_stat
+                        - libelle
+                      etablissement:
+                        title: Établissement d'études
+                        description: Les informations relatives à l'établissement
+                        type: object
+                        properties:
+                          code_uai:
+                            title: Code UAI de l'établissement
+                            description: |
+                              Code d'unité administrative immatriculée (code UAI) de l'établissement où est scolarisé l'élève. Ce code unique inscrit au répertoire national des établissements est composé de 7 chiffres et d'une lettre ; les trois premiers chiffres correspondent au numéro de département de l'établissement.
+
+                              Pour retrouver le nom de l'établissement, vous pouvez utiliser l'[API "Annuaire de l'éducation nationale"](https://api.gouv.fr/les-api/api-annuaire-education) ou le site https://annuaire-education.fr.
+                            type: string
+                            pattern: "^\\d{7}\\w$"
+                            example: 0210015C
+                          code_ministere_tutelle:
+                            title: Code de l'établissement auprès du ministère de
+                              tutelle
+                            description: Code ministère de tutelle principale composé
+                              de 2 chiffres, selon la BCN
+                            type: string
+                            example: '06'
+                            nullable: true
+                        required:
+                        - code_uai
+                        - code_ministere_tutelle
+                      annee_scolaire:
+                        title: Année scolaire
+                        description: Année scolaire de l'élève au format AAAA-AAAA.
+                        type: string
+                        pattern: "^\\d{4}$|^\\d{4}-\\d{4}$"
+                        example: 2022-2023
+                      est_scolarise:
+                        title: Est scolarisé
+                        description: Indique si l'élève est scolarisé dans un établissement.
+                        type: boolean
+                        example: true
+                      statut_eleve:
+                        title: Statut de l'élève
+                        description: |
+                          Indique le statut sous lequel l'élève est scolarisé dans l'établissement. Les valeurs sont susceptibles d'évoluer :
+
+                          - ST : Scolaire, il s'agit du statut de base renvoyé pour près de 95% des élèves.
+                          - AP : Apprenti
+                          - CQ : Contrat de qualification
+                          - FC : Formation continue
+                          - ED : Enseignement à distance
+                          - IN : Candidat individuel
+                          - FQ : Stagiaire de la formation Professionnelle
+                          - SC : Scolaire ou formation initiale
+                          - CP : Contrat de professionnalisation.
+                          - NC : Non connu ou non communiqué.
+                        type: object
+                        properties:
+                          code:
+                            title: Code
+                            description: Code du statut sous lequel l'élève est scolarisé
+                              dans l'établissement.
+                            type: string
+                            example: ST
+                          libelle:
+                            title: Libellé
+                            description: Libellé du statut sous lequel l'élève est
+                              scolarisé dans l'établissement.
+                            type: string
+                            example: SCOLAIRE
+                        required:
+                        - code
+                        - libelle
+                      est_boursier:
+                        description: |
+                          Indique si l'élève est boursier dans l'établissement. Les bourses concernent uniquement les élèves des collèges et lycées.
+
+                          ⚠️ Si le statut boursier est à "false" avant mi-octobre, cela ne signifie pas forcément que l'élève n'est pas boursier. Il peut s'agir d'un faux négatif lié à une absence de l'information en base. Pour en savoir plus consulter la fiche métier : https://particulier.api.gouv.fr/catalogue/education_nationale/statut_eleve_scolarise#faq_entry_answer_1_api_particulier_endpoint_education_nationale_statut_eleve_scolarise.
+
+                          Ce champs prend la valeur null lorsque l'on ne sait pas si l'élève est boursier ou non
+                        type: boolean
+                        example: true
+                        nullable: false
+                      echelon_bourse:
+                        description: |
+                          Indique l'échelon de la bourse de l'élève. Est à "null" quand "est_boursier" est "false". Les bourses concernent uniquement les élèves des collèges et lycées.
+
+                          Il existe trois échelons de bourses pour les collégiens (1 à 3) et six échelons pour les lycéens (1 à 6), correspondant aux montants reçus par l'élève pour l'année scolaire. Pour en savoir plus, consulter la FAQ : https://particulier.api.gouv.fr/catalogue/education_nationale/statut_eleve_scolarise#faq_entry_answer_2_api_particulier_endpoint_education_nationale_statut_eleve_scolarise"
+                        type: integer
+                        example: 1
+                        nullable: true
+                        enum:
+                        -
+                        - 1
+                        - 2
+                        - 3
+                        - 4
+                        - 5
+                        - 6
+                    required:
+                    - regime_pensionnat
+                    - identite
+                    - module_elementaire_formation
+                    - etablissement
+                    - annee_scolaire
+                    - est_scolarise
+                    - statut_eleve
+                    - est_boursier
+                    - echelon_bourse
+                    additionalProperties: false
+                  links:
+                    type: object
+                  meta:
+                    type: object
+                required:
+                - data
+                - links
+                - meta
+        '404':
+          description: Non trouvee par perimetre
+          content:
+            application/json:
+              examples:
+                entite_non_trouvee_30003:
+                  value:
+                    errors:
+                    - code: '30003'
+                      title: Entité non trouvée
+                      detail: Aucun eleve n'a pu etre trouve avec les criteres de
+                        recherche fournis
+                      source:
+                      meta:
+                        provider: MEN
+                  summary: Entité non trouvée
+                  description: Aucun eleve n'a pu etre trouve avec les criteres de
+                    recherche fournis
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '422':
+          description: Paramètre(s) invalide(s)
+          content:
+            application/json:
+              examples:
+                unprocessable_content_error_code_etablissement_et_perimetre_error:
+                  value:
+                    errors:
+                    - code: '00419'
+                      title: Entité non traitable
+                      detail: Les paramètres codeEtablissement et périmètre (codesBcnRegions/codesBcnDepartements)
+                        sont mutuellement exclusifs
+                      source:
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Les paramètres codeEtablissement et périmètre (codesBcnRegions/codesBcnDepartements)
+                    sont mutuellement exclusifs
+                missing_mandatory_params_recipient_error:
+                  value:
+                    errors:
+                    - code: '00203'
+                      title: Entité non traitable
+                      detail: Le paramètre recipient est obligatoire
+                      source:
+                        parameter: recipient
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Le paramètre recipient est obligatoire
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '502':
+          description: Erreur du fournisseur
+          content:
+            application/json:
+              examples:
+                provider_unknown_error:
+                  value:
+                    errors:
+                    - code: '30999'
+                      title: Erreur inconnue du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et inconnue de notre service. L'équipe technique
+                        a été notifiée de cette erreur pour investigation.
+                      source:
+                      meta:
+                        provider: MEN
+                  summary: Erreur inconnue du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et inconnue de notre service. L'équipe technique
+                    a été notifiée de cette erreur pour investigation.
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '504':
+          description: Erreur d'intermédiaire
+          content:
+            application/json:
+              examples:
+                timeout_error:
+                  value:
+                    errors:
+                    - code: '30002'
+                      title: Intermédiaire hors-délai
+                      detail: Temps d’attente d’une réponse du fournisseur de données
+                        écoulé.
+                      source:
+                      meta:
+                        provider: MEN
+                  summary: Intermédiaire hors-délai
+                  description: Temps d’attente d’une réponse du fournisseur de données
+                    écoulé.
+                provider_unavailable_error:
+                  value:
+                    errors:
+                    - code: '30001'
+                      title: Service non disponible
+                      detail: Service du fournisseur de données temporairement indisponible
+                        ou en maintenance.
+                      source:
+                      meta:
+                        provider: MEN
+                  summary: Service non disponible
+                  description: Service du fournisseur de données temporairement indisponible
+                    ou en maintenance.
+                network_error:
+                  value:
+                    errors:
+                    - code: '00501'
+                      title: Erreur réseau
+                      detail: Problème de connexion au serveur distant. L'erreur peut
+                        venir soit du fournisseur, soit de API Entreprise. Il s'agit
+                        souvent d'une erreur temporaire.
+                      source:
+                      meta:
+                        retry_in: 10
+                  summary: Erreur réseau
+                  description: Problème de connexion au serveur distant. L'erreur
+                    peut venir soit du fournisseur, soit de API Entreprise. Il s'agit
+                    souvent d'une erreur temporaire.
+                dns_resolution_error:
+                  value:
+                    errors:
+                    - code: '30004'
+                      title: Erreur de résolution DNS
+                      detail: Problème de résolution DNS de l'adresse du serveur
+                      source:
+                      meta:
+                        provider: MEN
+                  summary: Erreur de résolution DNS
+                  description: Problème de résolution DNS de l'adresse du serveur
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '409':
+          description: Conflit
+          content:
+            application/json:
+              examples:
+                conflict_error:
+                  value:
+                    errors:
+                    - code: '00015'
+                      title: Conflit
+                      detail: Une requête associé à votre jeton est déjà en cours
+                        de traitement pour ces paramètres. Veuillez attendre la fin
+                        du traitement avant d'effectuer une nouvelle requête.
+                      source:
+                      meta: {}
+                  summary: Conflit
+                  description: Une requête associé à votre jeton est déjà en cours
+                    de traitement pour ces paramètres. Veuillez attendre la fin du
+                    traitement avant d'effectuer une nouvelle requête.
+              schema:
+                "$ref": "#/components/schemas/Error"
   "/v3/mesri/statut_etudiant/identite":
     get:
       summary: "[Identité] Statut étudiant"

--- a/site/config/endpoints/api_particulier/education_nationale_statut_eleve.yml
+++ b/site/config/endpoints/api_particulier/education_nationale_statut_eleve.yml
@@ -3,23 +3,23 @@
   opening: protected
   new_version: true
   old_endpoint_uids:
-    - 'education_nationale/statut_eleve_scolarise_v3'
-  path: '/v4/men/scolarites/identite'
+    - 'education_nationale/statut_eleve_scolarise_v4'
+  path: '/v5/men/scolarites/identite'
   ping_url: &men_scolarite_ping_url 'https://particulier.api.gouv.fr/api/men_scolarite/ping'
-  position: 500
+  position: 499
   alert: &men_scolarite_alert
     title: "💡 Données de bourse bientôt disponibles"
     description: |+
       Le statut boursier et l'échelon de bourse de l'élève seront bientôt redistribués par le fournisseur de données. La mise en production de ces nouvelles données est attendue pour juin.
   historique: |+
-    **Ce que change le passage à la V.4 par rapport à la V.3 :**
+    **Ce que change le passage à la V.5 par rapport à la V.4 :**
 
-    - Ajout de nouvelles modalités de périmètre géographique : en plus du code UAI de l'établissement, il est désormais possible d'interroger l'API avec un code région ou un code département.
+    - Ajout du **régime de pensionnat** de l'élève (externe, demi-pensionnaire, interne, etc.).
 
     **Ce qui ne change pas :**
 
-    - Les données renvoyées restent identiques.
-    - La modalité d'appel par code UAI de l'établissement reste disponible.
+    - Les données précédemment renvoyées restent identiques.
+    - Les modalités d'appel restent les mêmes.
   perimeter: &men_scolarite_perimeter
     entity_type_description: |+
       Cette API concerne les **✅ élèves de la maternelle, du primaire, du collège et du lycée**.
@@ -67,6 +67,7 @@
     description: |+
       Cette API **indique si l'élève est scolarisé et sous quel statut** pour l'[année scolaire en cours et bientôt N+1](#annee-scolaire-donnees).
       Le **statut boursier ainsi que l'échelon de bourse** est également précisé le cas échéant.
+      Le **régime de pensionnat** (externe, demi-pensionnaire, interne, etc.) est disponible à partir de la V.5.
   provider_uids: &men_scolarite_provider_uids
     - 'education_nationale'
   keywords: &men_scolarite_keywords []
@@ -109,11 +110,66 @@
     - q: <a name="definition-echelons-bourse"></a>À quoi correspondent les échelons de bourse ?
       a:
         "Il existe trois échelons de bourses pour les collégiens, de 1 à 3 et six échelons pour les lycéens, de 1 à 6. Chaque échelon de bourse indique **le montant reçu par l'élève pour l'année scolaire**. Le montant de la bourse dépend d'un barème en fonction du revenu fiscal et du nombre enfants à charge du foyer."
+    - q: <a name="definition-regime-pensionnat"></a>À quoi correspondent les codes de régime de pensionnat ?
+      a: |+
+        Le régime de pensionnat indique le mode d'hébergement et de restauration de l'élève dans son établissement. Il est codé sur un caractère selon la nomenclature BCN (Base Centrale de Nomenclatures) :
+
+        | Code | Libellé | Description |
+        |------|---------|-------------|
+        | 0 | Externe libre | L'élève ne prend pas de repas dans l'établissement et n'est pas tenu d'y rester en dehors des heures de cours. |
+        | 1 | Externe surveillé | L'élève ne prend pas de repas dans l'établissement mais reste dans l'établissement entre les cours (études surveillées). |
+        | 2 | Demi-pensionnaire dans l'établissement | L'élève prend le repas du midi dans l'établissement où il est scolarisé. |
+        | 3 | Interne dans l'établissement | L'élève est hébergé et prend ses repas dans l'établissement où il est scolarisé. |
+        | 4 | Interne externé | L'élève est inscrit en internat mais ne dort pas dans l'établissement (par exemple, retour au domicile le soir). |
+        | 5 | Interne hébergé | L'élève est hébergé dans un autre établissement que celui où il est scolarisé (internat d'un établissement voisin). |
+        | 6 | Demi-pensionnaire hors l'établissement | L'élève prend le repas du midi dans un autre établissement que celui où il est scolarisé. |
+
+        Cette donnée est notamment utile pour le calcul des **bourses départementales**, dont le montant peut varier selon le régime de pensionnat de l'élève.
+
+- uid: 'education_nationale/statut_eleve_scolarise_v4'
+  opening: protected
+  new_endpoint_uids:
+    - 'education_nationale/statut_eleve_scolarise'
+  old_endpoint_uids:
+    - 'education_nationale/statut_eleve_scolarise_v3'
+  path: '/v4/men/scolarites/identite'
+  ping_url: *men_scolarite_ping_url
+  position: 500
+  alert: *men_scolarite_alert
+  historique: |+
+    **Ce que change le passage à la V.4 par rapport à la V.3 :**
+
+    - Ajout de nouvelles modalités de périmètre géographique : en plus du code UAI de l'établissement, il est désormais possible d'interroger l'API avec un code région ou un code département.
+
+    **Ce qui ne change pas :**
+
+    - Les données renvoyées restent identiques.
+    - La modalité d'appel par code UAI de l'établissement reste disponible.
+  perimeter: *men_scolarite_perimeter
+  parameters_details:
+    description: |+
+      Cette API propose une modalité d'appel :
+      <p class="fr-badge fr-badge--brown-cafe-creme">Identité pivot</p>
+      **Avec les données d'identité** : Nom<sup>\*</sup>, prénom<sup>\*</sup>, sexe<sup>\*</sup> et date de naissance de l'élève<sup>\*</sup>, l'année scolaire<sup>\*</sup> souhaitée, ainsi qu'un périmètre géographique<sup>\*\*</sup> :
+      - soit le code UAI de l'établissement ;
+      - soit le code région ;
+      - soit le code département.
+
+      <span class="fr-text--xs">
+      <sup>\*</sup> Obligatoire.
+      <sup>\*\*</sup> Un seul des trois paramètres de périmètre géographique doit être renseigné.
+      </span>
+  data: *men_scolarite_data
+  provider_uids: *men_scolarite_provider_uids
+  keywords: *men_scolarite_keywords
+  call_id: *men_scolarite_call_id
+  parameters: *men_scolarite_parameters
+  faq: *men_scolarite_faq
 
 - uid: 'education_nationale/statut_eleve_scolarise_v3'
   opening: protected
   new_endpoint_uids:
-    - 'education_nationale/statut_eleve_scolarise'
+    - 'education_nationale/statut_eleve_scolarise_v4'
   old_endpoint_uids:
     - 'education_nationale/v2/statut_eleve_scolarise'
   path: '/v3/men/scolarites/identite'


### PR DESCRIPTION
Add `regime_pensionnat` field (code + label) to the MEN scolarites API through a new `men_regime_pensionnat` scope and a new V5 endpoint version.

The `code-regime` data already existed in the upstream MENJ API but was not exposed. Departments need it to calculate departmental scholarship amounts (e.g. amount x3 if the student is a boarder).

Exposed BCN codes: 0 (Externe libre), 1 (Externe surveillé), 2 (Demi-pensionnaire dans l'établissement), 3 (Interne dans l'établissement), 4 (Interne externé), 5 (Interne hébergé), 6 (Demi-pensionnaire hors l'établissement).

SIADE:
- BuildResource: extract code-regime + code-to-label mapping
- New men_regime_pensionnat scope in authorizations.yml
- V5 serializer inheriting from V4 with regime_pensionnat
- Swagger data: v5_attributes with regime_pensionnat
- Specs: build_resource, V5 serializer, V5 request

Site:
- Endpoint config: new V5 entry, V4 renamed, historique updated
- FAQ: detailed description of all 7 regime codes
- OpenAPI spec updated

Ref: API-6593, API-6591