### PR TITLE
Update all etalab/siade_staging_data references to datagouv/apistration

### DIFF
--- a/mocks/README.md
+++ b/mocks/README.md
@@ -1,6 +1,6 @@
 # Données de tests API Entreprise v3+ & API Particulier / Utilisation de l'environnement de test
 
-[![Tests](https://github.com/etalab/siade_staging_data/actions/workflows/tests.yml/badge.svg)](https://github.com/etalab/siade_staging_data/actions/workflows/tests.yml)
+[![Tests](https://github.com/datagouv/apistration/actions/workflows/tests.yml/badge.svg)](https://github.com/datagouv/apistration/actions/workflows/tests.yml)
 
 Ce dépôt contient l'ensemble des données de tests pour les environnements de bac
 à sable d'API Entreprise (seulement pour la v3+)
@@ -29,7 +29,7 @@ Particulier ( https://staging.particulier.api.gouv.fr ).
 Récupération d'un jeton:
 
 ```sh
-token=`curl https://raw.githubusercontent.com/etalab/siade_staging_data/develop/tokens/default`
+token=`curl https://raw.githubusercontent.com/datagouv/apistration/develop/mocks/tokens/default`
 ```
 
 Test d'API Entreprise:
@@ -55,12 +55,12 @@ Les exemples sont dans les accordéons "Commande cURL" dans les dossiers de
 
 ### <a name="1endpoint-1dossier"></a> Un dossier de cas de tests pour chaque endpoint :
 
-Chaque endpoint de l'API Entreprise ou de l'API Particulier, pour lesquels des cas de tests ont été proposés, possède un dossier dans [`payloads/`](https://github.com/etalab/siade_staging_data/tree/develop/payloads), où sont regroupés ses cas de tests.
+Chaque endpoint de l'API Entreprise ou de l'API Particulier, pour lesquels des cas de tests ont été proposés, possède un dossier dans [`payloads/`](https://github.com/datagouv/apistration/tree/develop/mocks/payloads), où sont regroupés ses cas de tests.
 
 Le nom de ce dossier a la forme suivante : `bouquetapi_version_endpointname`.
 
 Une table de correspondance _url de l'endpoint_ <-> _nom du dossier_ est disponible à la
-racine du dossier [`payloads/`](https://github.com/etalab/siade_staging_data/tree/develop/payloads) : [README.md](./payloads/README.md) (généré
+racine du dossier [`payloads/`](https://github.com/datagouv/apistration/tree/develop/mocks/payloads) : [README.md](./payloads/README.md) (généré
 automatiquement par `bin/generate_payload_readme.rb`)
 
 **Pour API Entreprise :**
@@ -69,7 +69,7 @@ Nom type du dossier d'un endpoint : `api_entreprise_version_endpointname`
 
 > Par exemple : `api_entreprise_v3_insee_unite_legale`
 
-➡️ [Liens des dossiers d'endpoints de l'API Entreprise](https://github.com/etalab/siade_staging_data/blob/develop/payloads/README.md#api-entreprise-v3)
+➡️ [Liens des dossiers d'endpoints de l'API Entreprise](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/README.md#api-entreprise-v3)
 
 **Pour API Particulier :**
 
@@ -77,7 +77,7 @@ Nom type du sous-dossier d'une payload : `api_particulier_version_endpointname`
 
 > Par exemple : `api_particulier_v2_dgfip_svair`
 
-➡️ [Liens des dossiers d'endpoints de l'API Particulier](https://github.com/etalab/siade_staging_data/blob/develop/payloads/README.md#api-particulier)
+➡️ [Liens des dossiers d'endpoints de l'API Particulier](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/README.md#api-particulier)
 
 ### <a name="format-cas-test"></a> Format des cas de test :
 
@@ -272,10 +272,10 @@ bundle exec ruby bin/reload_mock_backend.rb
 
 - Pour un endpoint ayant déjà un dossier dans [`payloads/`](./payloads) :
   - Si vous êtes à l'aise avec Github, vous pouvez ajouter vous-même les fichiers des cas de tests que vous souhaitez, au travers d'une Pull Request ;
-  - Autrement, vous pouvez ouvrir un ticket pour que l'on vous accompagne sur l'implémentation : [Ajout de nouvelles données](https://github.com/etalab/siade_staging_data/issues/new?template=ajout-payloads.md)
+  - Autrement, vous pouvez ouvrir un ticket pour que l'on vous accompagne sur l'implémentation : [Ajout de nouvelles données](https://github.com/datagouv/apistration/issues/new?template=ajout-payloads.md)
 - Pour un endpoint n'ayant pas encore de dossier dans [`payloads/`](./payloads) :
   - Si vous êtes à l'aise avec Github, vous pouvez créer un dossier dans [`future_payloads/`](./future_payloads) à l'aide d'une Pull Request ;
-  - Autrement, vous pouvez ouvrir un ticket pour que l'on vous accompagne sur l'implémentation : [Ajout d'un endpoint manquant](https://github.com/etalab/siade_staging_data/issues/new?template=proposer-une-am-lioration.md).
+  - Autrement, vous pouvez ouvrir un ticket pour que l'on vous accompagne sur l'implémentation : [Ajout d'un endpoint manquant](https://github.com/datagouv/apistration/issues/new?template=proposer-une-am-lioration.md).
 
 ## <a name="developpement"></a> Développement
 
@@ -329,4 +329,4 @@ Pour utiliser les fichiers openapi locaux (dossier `openapi_files`), utilisez la
   être nécessaires.
 
 Si ces limitations sont problématiques pour votre développement et intégration,
-nous vous invitons à [ouvrir un ticket](https://github.com/etalab/siade_staging_data/issues/new).
+nous vous invitons à [ouvrir un ticket](https://github.com/datagouv/apistration/issues/new).

--- a/mocks/bin/test_using_docker.sh
+++ b/mocks/bin/test_using_docker.sh
@@ -6,8 +6,8 @@ SCRIPT_NAME="$(basename "$SCRIPT")"
 SCRIPT_PATH="$(realpath "$(dirname "$SCRIPT")")"
 PROJECT_PATH="$(realpath "$SCRIPT_PATH/..")"
 RUBY_VERSION="$(cat "$PROJECT_PATH/.ruby-version" | head -n1)"
-TMP_FOLDER="/tmp/siade_staging_data_test_bundler_cache"
-CONTAINER_NAME="siade_staging_data_test"
+TMP_FOLDER="/tmp/apistration_mocks_test_bundler_cache"
+CONTAINER_NAME="apistration_mocks_test"
 
 mkdir -p "$TMP_FOLDER" || exit 1
 

--- a/mocks/openapi_files/api_entreprise.yaml
+++ b/mocks/openapi_files/api_entreprise.yaml
@@ -9,7 +9,7 @@ info:
     d'une clé d'accès (jeton).\n\n### Comment tester l'API ?\n\nIl est possible de
     tester les API via notre environnement de **staging** qui vous retournera systématiquement
     des données fictives. Référez vous à la [documentation](https://entreprise.api.gouv.fr/developpeurs#tester-api-preproduction).\n\nIl
-    est nécessaire d'utiliser un jeton de staging. Plus d'infos ici: https://github.com/etalab/siade_staging_data/tree/develop/tokens\n
+    est nécessaire d'utiliser un jeton de staging. Plus d'infos ici: https://github.com/datagouv/apistration/tree/develop/mocks/tokens\n
     \     "
   termsOfService: https://entreprise.api.gouv.fr/cgu/
   contact:
@@ -398,7 +398,7 @@ paths:
                           enregistrée dans le système. Elle est donc variable d'une
                           entreprise à l'autre. \n \n Plus d'informations sur le site
                           de l'URSSAF : https://www.urssaf.fr/portail/home/employeur/declarer-et-payer/obtenir-une-attestation/attestation-de-vigilance.html"
-                        example: https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v4_acoss_attestations_sociales/attestation_vigilance_test.pdf
+                        example: https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v4_acoss_attestations_sociales/attestation_vigilance_test.pdf
                       expires_in:
                         type: integer
                         example: 7889238
@@ -915,7 +915,7 @@ paths:
                               title: URL Certificat
                               description: URL de téléchargement du certificat
                               type: string
-                              example: https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_ademe_certificats_rge/exemple-ademe-rge-certificat_qualibat.pdf
+                              example: https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_ademe_certificats_rge/exemple-ademe-rge-certificat_qualibat.pdf
                             nom_certificat:
                               title: Nom du certificat
                               description: libéllé du certificat
@@ -2793,7 +2793,7 @@ paths:
                         nullable: true
                         description: Ce lien délivre l'attestation au format PDF.
                           Ce document est automatiquement supprimé après 10 minutes.
-                        example: https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_cibtp_attestation_cotisations_conges_payes_chomage_intemperies/test_cibtp_certificat.pdf
+                        example: https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_cibtp_attestation_cotisations_conges_payes_chomage_intemperies/test_cibtp_certificat.pdf
                       expires_in:
                         title: Expiration du lien
                         description: Nombre de secondes avant expiration du document
@@ -3173,7 +3173,7 @@ paths:
                         title: Lien vers le certificat CNETP
                         description: Ce lien délivre l'attestation au format PDF.
                           Ce document est automatiquement supprimé après 24h.
-                        example: https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_cnetp_attestation_cotisations_conges_payes_chomage_intemperies/test_cnetp_certificat.pdf
+                        example: https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_cnetp_attestation_cotisations_conges_payes_chomage_intemperies/test_cnetp_certificat.pdf
                       expires_in:
                         type: integer
                         example: 7889238
@@ -11613,7 +11613,7 @@ paths:
                         title: Lien vers la carte professionnelle
                         description: Ce document est automatiquement supprimé au bout
                           de 3 mois.
-                        example: https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_fntp_carte_professionnelle_travaux_publics/carte_professionnelle_tp_test.pdf
+                        example: https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_fntp_carte_professionnelle_travaux_publics/carte_professionnelle_tp_test.pdf
                       expires_in:
                         type: integer
                         example: 7889238
@@ -35523,7 +35523,7 @@ paths:
                         title: Lien vers l'attestation de cotisation retraite ProBTP
                         description: Ce document est automatiquement supprimé au bout
                           de 3 mois.
-                        example: https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_probtp_attestations_cotisation_retraite/test_probtp_attestation.pdf
+                        example: https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_probtp_attestations_cotisation_retraite/test_probtp_attestation.pdf
                       expires_in:
                         type: integer
                         example: 7889238
@@ -36341,7 +36341,7 @@ paths:
                         title: Lien vers la certification batiment Qualibat
                         description: Cette URL permet de télécharger la certification
                           Qualibat au format PDF.
-                        example: https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v4_qualibat_certifications_batiment/exemple-qualibat.pdf
+                        example: https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v4_qualibat_certifications_batiment/exemple-qualibat.pdf
                       expires_in:
                         type: integer
                         example: 7889238
@@ -36823,7 +36823,7 @@ paths:
                         type: string
                         description: Cette URL permet de télécharger la certification
                           Qualibat au format PDF.
-                        example: https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v4_qualibat_certifications_batiment/exemple-qualibat.pdf
+                        example: https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v4_qualibat_certifications_batiment/exemple-qualibat.pdf
                       document_url_expires_in:
                         title: Nombre de secondes avant expiration du document référencé
                           dans 'document_url'
@@ -37371,7 +37371,7 @@ paths:
                               description: Ce lien délivre le certificat Qualifelec
                                 de l'entreprise au format PDF tel qu'accessible depuis
                                 le site https://www.qualifelec.fr/.
-                              example: https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_qualifelec_certificats/exemple-certificat-qualifelec-bac-a-sable.jpg
+                              example: https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_qualifelec_certificats/exemple-certificat-qualifelec-bac-a-sable.jpg
                             numero:
                               title: Numéro du certificat
                               type: number
@@ -38499,7 +38499,7 @@ paths:
                         nullable: true
                         description: Ce lien délivre l'attestation de vigilance de
                           l'entreprise au format PDF.
-                        example: https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v4_acoss_attestations_sociales/attestation_vigilance_test.pdf
+                        example: https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v4_acoss_attestations_sociales/attestation_vigilance_test.pdf
                       document_url_expires_in:
                         title: Nombre de secondes avant expiration du document référencé
                           dans 'document_url'

--- a/mocks/openapi_files/api_particulier.yaml
+++ b/mocks/openapi_files/api_particulier.yaml
@@ -22,7 +22,7 @@ info:
 
     Pour récupérer le jeton de production un portail développeur est mis à votre disposition à l'adresse suivante : [https://particulier.api.gouv.fr/compte](https://particulier.api.gouv.fr/compte)
 
-    Pour effectuer vos tests sur le bac à sable, référez-vous à ce dépôt github: [etalab/siade_staging_data](https://github.com/etalab/siade_staging_data/) (l'ancien système basé sur Airtable n'est plus maintenu et va être remplacé par le nouveau système). Un jeton nommé default est disponible ici: [tokens](https://github.com/etalab/siade_staging_data/tree/develop/tokens)
+    Pour effectuer vos tests sur le bac à sable, référez-vous à ce dépôt github: [datagouv/apistration](https://github.com/datagouv/apistration/tree/develop/mocks/) (l'ancien système basé sur Airtable n'est plus maintenu et va être remplacé par le nouveau système). Un jeton nommé default est disponible ici: [tokens](https://github.com/datagouv/apistration/tree/develop/mocks/tokens)
 
     ### Accéder à la version 2 de l'API
 
@@ -3306,7 +3306,7 @@ paths:
         \n\n Retourne également des informations sur les dates d'ouverture des droits.
         \n Pour plus d'informations sur cette API et obtenir un accès en avant-première,
         veuillez contacter l'équipe API Particulier. \n **Données disponibles en bac
-        à sable :** [Liste de payloads de test](https://github.com/etalab/siade_staging_data/blob/develop/payloads/complementaire_sante_solidaire)"
+        à sable :** [Liste de payloads de test](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/complementaire_sante_solidaire)"
       responses:
         '401':
           description: Non autorisé
@@ -3684,7 +3684,7 @@ paths:
         \n\n Retourne également des informations sur les dates d'ouverture des droits.
         \n Pour plus d'informations sur cette API et obtenir un accès en avant-première,
         veuillez contacter l'équipe API Particulier. \n **Données disponibles en bac
-        à sable :** [Liste de payloads de test](https://github.com/etalab/siade_staging_data/blob/develop/payloads/complementaire_sante_solidaire)"
+        à sable :** [Liste de payloads de test](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/complementaire_sante_solidaire)"
       responses:
         '403':
           description: Accès interdit
@@ -6112,7 +6112,7 @@ paths:
       description: "Quotient familial délivré par la CAF ou la MSA et composition
         de la famille de l'allocataire. \n Pour plus d'informations sur cette API
         et obtenir un accès en avant-première, veuillez contacter l'équipe API Particulier.
-        \n **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_cnav_quotient_familial_v2)"
+        \n **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_cnav_quotient_familial_v2)"
       responses:
         '401':
           description: Non autorisé
@@ -6717,7 +6717,7 @@ paths:
       description: "Quotient familial délivré par la CAF ou la MSA et composition
         de la famille de l'allocataire. \n Pour plus d'informations sur cette API
         et obtenir un accès en avant-première, veuillez contacter l'équipe API Particulier.
-        \n **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_cnav_quotient_familial_v2)"
+        \n **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_cnav_quotient_familial_v2)"
       responses:
         '403':
           description: Accès interdit
@@ -11321,7 +11321,7 @@ paths:
       description: |
         Statut demandeur d'emploi, données relatives à l'inscription FranceTravail, ainsi que données d'identité de contact.
         **Paramètres d'appel :** Nom d’utilisateur France Travail choisi par le particulier lors de la création de son espace personnel en ligne
-        **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_pole_emploi_statut)
+        **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_pole_emploi_statut)
       responses:
         '401':
           description: Non autorisé

--- a/mocks/openapi_files/api_particulier_v2.yaml
+++ b/mocks/openapi_files/api_particulier_v2.yaml
@@ -23,7 +23,7 @@ info:
 
     Pour récupérer le jeton de production un portail développeur est mis à votre disposition à l'adresse suivante : [https://particulier.api.gouv.fr/compte](https://particulier.api.gouv.fr/compte)
 
-    Pour effectuer vos tests sur le bac à sable, référez-vous à ce dépôt github: [etalab/siade_staging_data](https://github.com/etalab/siade_staging_data/) (l'ancien système basé sur Airtable n'est plus maintenu et va être remplacé par le nouveau système). Un jeton nommé default est disponible ici: [tokens](https://github.com/etalab/siade_staging_data/tree/develop/tokens)
+    Pour effectuer vos tests sur le bac à sable, référez-vous à ce dépôt github: [datagouv/apistration](https://github.com/datagouv/apistration/tree/develop/mocks/) (l'ancien système basé sur Airtable n'est plus maintenu et va être remplacé par le nouveau système). Un jeton nommé default est disponible ici: [tokens](https://github.com/datagouv/apistration/tree/develop/mocks/tokens)
 
     ### Accéder à la version 3 de l'API
 
@@ -719,7 +719,7 @@ paths:
         \n\n Retourne également des informations sur les dates d'ouverture des droits.
         \n Pour plus d'informations sur cette API et obtenir un accès en avant-première,
         veuillez contacter l'équipe API Particulier. \n **Données disponibles en bac
-        à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/complementaire_sante_solidaire)
+        à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/complementaire_sante_solidaire)
         \n L'API peut être appellée avec les données identité pivot ou avec un jeton
         FranceConnect."
       responses:
@@ -1279,7 +1279,7 @@ paths:
       description: "Quotient familial et composition de la famille d'un allocataire
         du régime agricole (régime général à venir). \n Pour plus d'informations sur
         cette API et obtenir un accès en avant-première, veuillez contacter l'équipe
-        API Particulier. \n **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_cnav_quotient_familial_v2)
+        API Particulier. \n **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_cnav_quotient_familial_v2)
         \n L'API peut être appellée avec les données identité pivot ou avec un jeton
         FranceConnect."
       responses:
@@ -2310,7 +2310,7 @@ paths:
 
         **Paramètres d'appel :** numéro d'allocataire et code postal
 
-        **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_cnaf_quotient_familial)
+        **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_cnaf_quotient_familial)
       parameters:
       - name: Cache-Control
         in: header
@@ -2566,7 +2566,7 @@ paths:
       description: |-
         Données d'identité, de contact et de statut du demandeur d'emploi.
         **Paramètres d'appel :** Nom d’utilisateur France Travail choisi par le particulier lors de la création de son espace personnel en ligne
-        **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_pole_emploi_statut)
+        **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_pole_emploi_statut)
       parameters:
       - name: identifiant
         required: true
@@ -2875,7 +2875,7 @@ paths:
          - INE, l'identifiant national étudiant ;
          - l'état civil de l'étudiant: nom, prénom, date de naissance, sexe et lieu de naissance.
 
-        **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_mesri_student_status)
+        **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_mesri_student_status)
       security:
       - franceConnectToken: []
         apiKey: []
@@ -3060,7 +3060,7 @@ paths:
          - INE, l'identifiant national étudiant ;
          - l'état civil de l'étudiant: nom, prénom, date de naissance, sexe (optionnel) et lieu de naissance (optionnel).
 
-        **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_cnous_student_scholarship)
+        **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_cnous_student_scholarship)
       security:
       - franceConnectToken: []
         apiKey: []

--- a/mocks/payloads/api_entreprise_v3_ademe_certificats_rge/200.yml
+++ b/mocks/payloads/api_entreprise_v3_ademe_certificats_rge/200.yml
@@ -7,7 +7,7 @@ payload: |-
     "data": [
       {
         "data": {
-          "url": "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_ademe_certificats_rge/exemple-ademe-rge-certificat_qualibat.pdf",
+          "url": "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_ademe_certificats_rge/exemple-ademe-rge-certificat_qualibat.pdf",
           "nom_certificat": "Qualisol CESI",
           "domaine": "Fenêtres, volets, portes extérieures 2020",
           "meta_domaine": "anciens domaines avant 2021",
@@ -29,7 +29,7 @@ payload: |-
       },
       {
         "data": {
-          "url": "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_ademe_certificats_rge/exemple-ademe-rge-certificat_qualifelec.pdf",
+          "url": "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_ademe_certificats_rge/exemple-ademe-rge-certificat_qualifelec.pdf",
           "nom_certificat": "Qualisol CESI",
           "domaine": "Fenêtres, volets, portes extérieures 2020",
           "meta_domaine": "anciens domaines avant 2021",

--- a/mocks/payloads/api_entreprise_v3_ademe_certificats_rge/README.md
+++ b/mocks/payloads/api_entreprise_v3_ademe_certificats_rge/README.md
@@ -25,7 +25,7 @@
     "data": [
       {
         "data": {
-          "url": "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_ademe_certificats_rge/exemple-ademe-rge-certificat_qualibat.pdf",
+          "url": "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_ademe_certificats_rge/exemple-ademe-rge-certificat_qualibat.pdf",
           "nom_certificat": "Qualisol CESI",
           "domaine": "Fenêtres, volets, portes extérieures 2020",
           "meta_domaine": "anciens domaines avant 2021",
@@ -47,7 +47,7 @@
       },
       {
         "data": {
-          "url": "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_ademe_certificats_rge/exemple-ademe-rge-certificat_qualifelec.pdf",
+          "url": "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_ademe_certificats_rge/exemple-ademe-rge-certificat_qualifelec.pdf",
           "nom_certificat": "Qualisol CESI",
           "domaine": "Fenêtres, volets, portes extérieures 2020",
           "meta_domaine": "anciens domaines avant 2021",

--- a/mocks/payloads/api_entreprise_v3_ademe_certificats_rge/summary.csv
+++ b/mocks/payloads/api_entreprise_v3_ademe_certificats_rge/summary.csv
@@ -3,7 +3,7 @@ Titre,Description,Paramètres,Status,Réponse
   ""data"": [
     {
       ""data"": {
-        ""url"": ""https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_ademe_certificats_rge/exemple-ademe-rge-certificat_qualibat.pdf"",
+        ""url"": ""https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_ademe_certificats_rge/exemple-ademe-rge-certificat_qualibat.pdf"",
         ""nom_certificat"": ""Qualisol CESI"",
         ""domaine"": ""Fenêtres, volets, portes extérieures 2020"",
         ""meta_domaine"": ""anciens domaines avant 2021"",
@@ -25,7 +25,7 @@ Titre,Description,Paramètres,Status,Réponse
     },
     {
       ""data"": {
-        ""url"": ""https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_ademe_certificats_rge/exemple-ademe-rge-certificat_qualifelec.pdf"",
+        ""url"": ""https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_ademe_certificats_rge/exemple-ademe-rge-certificat_qualifelec.pdf"",
         ""nom_certificat"": ""Qualisol CESI"",
         ""domaine"": ""Fenêtres, volets, portes extérieures 2020"",
         ""meta_domaine"": ""anciens domaines avant 2021"",

--- a/mocks/payloads/api_entreprise_v3_cibtp_attestation_cotisations_conges_payes_chomage_intemperies/200.yaml
+++ b/mocks/payloads/api_entreprise_v3_cibtp_attestation_cotisations_conges_payes_chomage_intemperies/200.yaml
@@ -6,7 +6,7 @@ description: 'Appel réussi'
 payload: |-
   {
     "data": {
-      "document_url": "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_cibtp_attestation_cotisations_conges_payes_chomage_intemperies/test_cibtp_certificat.pdf",
+      "document_url": "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_cibtp_attestation_cotisations_conges_payes_chomage_intemperies/test_cibtp_certificat.pdf",
       "expires_in": 600
     },
     "links": {

--- a/mocks/payloads/api_entreprise_v3_cibtp_attestation_cotisations_conges_payes_chomage_intemperies/README.md
+++ b/mocks/payloads/api_entreprise_v3_cibtp_attestation_cotisations_conges_payes_chomage_intemperies/README.md
@@ -23,7 +23,7 @@
   ```json
   {
     "data": {
-      "document_url": "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_cibtp_attestation_cotisations_conges_payes_chomage_intemperies/test_cibtp_certificat.pdf",
+      "document_url": "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_cibtp_attestation_cotisations_conges_payes_chomage_intemperies/test_cibtp_certificat.pdf",
       "expires_in": 600
     },
     "links": {},

--- a/mocks/payloads/api_entreprise_v3_cibtp_attestation_cotisations_conges_payes_chomage_intemperies/summary.csv
+++ b/mocks/payloads/api_entreprise_v3_cibtp_attestation_cotisations_conges_payes_chomage_intemperies/summary.csv
@@ -1,7 +1,7 @@
 Titre,Description,Paramètres,Status,Réponse
 ,Appel réussi,"{""siret"":""13002526500013""}",200,"{
   ""data"": {
-    ""document_url"": ""https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_cibtp_attestation_cotisations_conges_payes_chomage_intemperies/test_cibtp_certificat.pdf"",
+    ""document_url"": ""https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_cibtp_attestation_cotisations_conges_payes_chomage_intemperies/test_cibtp_certificat.pdf"",
     ""expires_in"": 600
   },
   ""links"": {

--- a/mocks/payloads/api_entreprise_v3_cnetp_attestation_cotisations_conges_payes_chomage_intemperies/200.yaml
+++ b/mocks/payloads/api_entreprise_v3_cnetp_attestation_cotisations_conges_payes_chomage_intemperies/200.yaml
@@ -6,7 +6,7 @@ description: 'Appel réussi'
 payload: |-
   {
     "data": {
-      "document_url": "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_cnetp_attestation_cotisations_conges_payes_chomage_intemperies/test_cnetp_certificat.pdf",
+      "document_url": "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_cnetp_attestation_cotisations_conges_payes_chomage_intemperies/test_cnetp_certificat.pdf",
       "expires_in": 600
     },
     "links": {

--- a/mocks/payloads/api_entreprise_v3_cnetp_attestation_cotisations_conges_payes_chomage_intemperies/README.md
+++ b/mocks/payloads/api_entreprise_v3_cnetp_attestation_cotisations_conges_payes_chomage_intemperies/README.md
@@ -23,7 +23,7 @@
   ```json
   {
     "data": {
-      "document_url": "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_cnetp_attestation_cotisations_conges_payes_chomage_intemperies/test_cnetp_certificat.pdf",
+      "document_url": "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_cnetp_attestation_cotisations_conges_payes_chomage_intemperies/test_cnetp_certificat.pdf",
       "expires_in": 600
     },
     "links": {},

--- a/mocks/payloads/api_entreprise_v3_cnetp_attestation_cotisations_conges_payes_chomage_intemperies/summary.csv
+++ b/mocks/payloads/api_entreprise_v3_cnetp_attestation_cotisations_conges_payes_chomage_intemperies/summary.csv
@@ -1,7 +1,7 @@
 Titre,Description,Paramètres,Status,Réponse
 ,Appel réussi,"{""siren"":""130025265""}",200,"{
   ""data"": {
-    ""document_url"": ""https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_cnetp_attestation_cotisations_conges_payes_chomage_intemperies/test_cnetp_certificat.pdf"",
+    ""document_url"": ""https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_cnetp_attestation_cotisations_conges_payes_chomage_intemperies/test_cnetp_certificat.pdf"",
     ""expires_in"": 600
   },
   ""links"": {

--- a/mocks/payloads/api_entreprise_v3_fntp_carte_professionnelle_travaux_publics/200.yml
+++ b/mocks/payloads/api_entreprise_v3_fntp_carte_professionnelle_travaux_publics/200.yml
@@ -6,7 +6,7 @@ description: 'Appel réussi'
 payload: |-
   {
     "data": {
-      "document_url": "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_fntp_carte_professionnelle_travaux_publics/carte_professionnelle_tp_test.pdf",
+      "document_url": "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_fntp_carte_professionnelle_travaux_publics/carte_professionnelle_tp_test.pdf",
       "expires_in": 7889238
     },
     "links": {},

--- a/mocks/payloads/api_entreprise_v3_fntp_carte_professionnelle_travaux_publics/README.md
+++ b/mocks/payloads/api_entreprise_v3_fntp_carte_professionnelle_travaux_publics/README.md
@@ -23,7 +23,7 @@
   ```json
   {
     "data": {
-      "document_url": "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_fntp_carte_professionnelle_travaux_publics/carte_professionnelle_tp_test.pdf",
+      "document_url": "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_fntp_carte_professionnelle_travaux_publics/carte_professionnelle_tp_test.pdf",
       "expires_in": 7889238
     },
     "links": {},

--- a/mocks/payloads/api_entreprise_v3_fntp_carte_professionnelle_travaux_publics/summary.csv
+++ b/mocks/payloads/api_entreprise_v3_fntp_carte_professionnelle_travaux_publics/summary.csv
@@ -1,7 +1,7 @@
 Titre,Description,Paramètres,Status,Réponse
 ,Appel réussi,"{""siren"":""130025265""}",200,"{
   ""data"": {
-    ""document_url"": ""https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_fntp_carte_professionnelle_travaux_publics/carte_professionnelle_tp_test.pdf"",
+    ""document_url"": ""https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_fntp_carte_professionnelle_travaux_publics/carte_professionnelle_tp_test.pdf"",
     ""expires_in"": 7889238
   },
   ""links"": {},

--- a/mocks/payloads/api_entreprise_v3_inpi_rne_actes_bilans/200.yaml
+++ b/mocks/payloads/api_entreprise_v3_inpi_rne_actes_bilans/200.yaml
@@ -18,7 +18,7 @@ payload: |-
               "type_decision": "Augmentation du capital social"
             }
           ],
-          "url": "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_inpi_rne_actes_bilans/exemple-bilan-inpi.pdf"
+          "url": "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_inpi_rne_actes_bilans/exemple-bilan-inpi.pdf"
         }
       ],
       "bilans": [
@@ -29,7 +29,7 @@ payload: |-
           "date_cloture": "2022-12-31",
           "date_mise_a_jour": "2023-11-01",
           "type": "bilan complet",
-          "url": "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_inpi_rne_actes_bilans/exemple-bilan-inpi.pdf"
+          "url": "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_inpi_rne_actes_bilans/exemple-bilan-inpi.pdf"
         },
         {
           "id": "65419234a1f7d1f2ba09bd8d",
@@ -38,7 +38,7 @@ payload: |-
           "date_cloture": "2021-12-31",
           "date_mise_a_jour": "2022-11-05",
           "type": "bilan complet",
-          "url": "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_inpi_rne_actes_bilans/exemple-bilan-inpi.pdf"
+          "url": "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_inpi_rne_actes_bilans/exemple-bilan-inpi.pdf"
         },
         {
           "id": "65419234a1f7d1f2ba09bd8e",
@@ -47,7 +47,7 @@ payload: |-
           "date_cloture": "2020-12-31",
           "date_mise_a_jour": "2021-11-10",
           "type": "bilan simplifié",
-          "url": "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_inpi_rne_actes_bilans/exemple-bilan-inpi.pdf"
+          "url": "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_inpi_rne_actes_bilans/exemple-bilan-inpi.pdf"
         }
       ]
     },

--- a/mocks/payloads/api_entreprise_v3_inpi_rne_actes_bilans/README.md
+++ b/mocks/payloads/api_entreprise_v3_inpi_rne_actes_bilans/README.md
@@ -35,7 +35,7 @@
               "type_decision": "Augmentation du capital social"
             }
           ],
-          "url": "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_inpi_rne_actes_bilans/exemple-bilan-inpi.pdf"
+          "url": "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_inpi_rne_actes_bilans/exemple-bilan-inpi.pdf"
         }
       ],
       "bilans": [
@@ -46,7 +46,7 @@
           "date_cloture": "2022-12-31",
           "date_mise_a_jour": "2023-11-01",
           "type": "bilan complet",
-          "url": "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_inpi_rne_actes_bilans/exemple-bilan-inpi.pdf"
+          "url": "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_inpi_rne_actes_bilans/exemple-bilan-inpi.pdf"
         },
         {
           "id": "65419234a1f7d1f2ba09bd8d",
@@ -55,7 +55,7 @@
           "date_cloture": "2021-12-31",
           "date_mise_a_jour": "2022-11-05",
           "type": "bilan complet",
-          "url": "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_inpi_rne_actes_bilans/exemple-bilan-inpi.pdf"
+          "url": "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_inpi_rne_actes_bilans/exemple-bilan-inpi.pdf"
         },
         {
           "id": "65419234a1f7d1f2ba09bd8e",
@@ -64,7 +64,7 @@
           "date_cloture": "2020-12-31",
           "date_mise_a_jour": "2021-11-10",
           "type": "bilan simplifié",
-          "url": "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_inpi_rne_actes_bilans/exemple-bilan-inpi.pdf"
+          "url": "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_inpi_rne_actes_bilans/exemple-bilan-inpi.pdf"
         }
       ]
     },

--- a/mocks/payloads/api_entreprise_v3_inpi_rne_actes_bilans/summary.csv
+++ b/mocks/payloads/api_entreprise_v3_inpi_rne_actes_bilans/summary.csv
@@ -13,7 +13,7 @@ Titre,Description,Paramètres,Status,Réponse
             ""type_decision"": ""Augmentation du capital social""
           }
         ],
-        ""url"": ""https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_inpi_rne_actes_bilans/exemple-bilan-inpi.pdf""
+        ""url"": ""https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_inpi_rne_actes_bilans/exemple-bilan-inpi.pdf""
       }
     ],
     ""bilans"": [
@@ -24,7 +24,7 @@ Titre,Description,Paramètres,Status,Réponse
         ""date_cloture"": ""2022-12-31"",
         ""date_mise_a_jour"": ""2023-11-01"",
         ""type"": ""bilan complet"",
-        ""url"": ""https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_inpi_rne_actes_bilans/exemple-bilan-inpi.pdf""
+        ""url"": ""https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_inpi_rne_actes_bilans/exemple-bilan-inpi.pdf""
       },
       {
         ""id"": ""65419234a1f7d1f2ba09bd8d"",
@@ -33,7 +33,7 @@ Titre,Description,Paramètres,Status,Réponse
         ""date_cloture"": ""2021-12-31"",
         ""date_mise_a_jour"": ""2022-11-05"",
         ""type"": ""bilan complet"",
-        ""url"": ""https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_inpi_rne_actes_bilans/exemple-bilan-inpi.pdf""
+        ""url"": ""https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_inpi_rne_actes_bilans/exemple-bilan-inpi.pdf""
       },
       {
         ""id"": ""65419234a1f7d1f2ba09bd8e"",
@@ -42,7 +42,7 @@ Titre,Description,Paramètres,Status,Réponse
         ""date_cloture"": ""2020-12-31"",
         ""date_mise_a_jour"": ""2021-11-10"",
         ""type"": ""bilan simplifié"",
-        ""url"": ""https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_inpi_rne_actes_bilans/exemple-bilan-inpi.pdf""
+        ""url"": ""https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_inpi_rne_actes_bilans/exemple-bilan-inpi.pdf""
       }
     ]
   },

--- a/mocks/payloads/api_entreprise_v3_probtp_attestations_cotisation_retraite/200.yml
+++ b/mocks/payloads/api_entreprise_v3_probtp_attestations_cotisation_retraite/200.yml
@@ -8,7 +8,7 @@ payload: |-
     "data": 
     {
 
-        "document_url": "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_probtp_attestations_cotisation_retraite/test_probtp_attestation.pdf",
+        "document_url": "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_probtp_attestations_cotisation_retraite/test_probtp_attestation.pdf",
         "expires_in": 7889238
 
     },

--- a/mocks/payloads/api_entreprise_v3_probtp_attestations_cotisation_retraite/README.md
+++ b/mocks/payloads/api_entreprise_v3_probtp_attestations_cotisation_retraite/README.md
@@ -23,7 +23,7 @@
   ```json
   {
     "data": {
-      "document_url": "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_probtp_attestations_cotisation_retraite/test_probtp_attestation.pdf",
+      "document_url": "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_probtp_attestations_cotisation_retraite/test_probtp_attestation.pdf",
       "expires_in": 7889238
     },
     "links": {},

--- a/mocks/payloads/api_entreprise_v3_probtp_attestations_cotisation_retraite/summary.csv
+++ b/mocks/payloads/api_entreprise_v3_probtp_attestations_cotisation_retraite/summary.csv
@@ -3,7 +3,7 @@ Titre,Description,Paramètres,Status,Réponse
   ""data"": 
   {
 
-      ""document_url"": ""https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_probtp_attestations_cotisation_retraite/test_probtp_attestation.pdf"",
+      ""document_url"": ""https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_probtp_attestations_cotisation_retraite/test_probtp_attestation.pdf"",
       ""expires_in"": 7889238
 
   },

--- a/mocks/payloads/api_entreprise_v3_qualibat_certifications_batiment/200.yaml
+++ b/mocks/payloads/api_entreprise_v3_qualibat_certifications_batiment/200.yaml
@@ -6,7 +6,7 @@ status: 200
 payload: |-
   {
     "data": {
-      "document_url": "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v4_qualibat_certifications_batiment/exemple-qualibat.pdf",
+      "document_url": "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v4_qualibat_certifications_batiment/exemple-qualibat.pdf",
       "expires_in": 7889238
     },
     "links": {},

--- a/mocks/payloads/api_entreprise_v3_qualibat_certifications_batiment/README.md
+++ b/mocks/payloads/api_entreprise_v3_qualibat_certifications_batiment/README.md
@@ -23,7 +23,7 @@
   ```json
   {
     "data": {
-      "document_url": "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v4_qualibat_certifications_batiment/exemple-qualibat.pdf",
+      "document_url": "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v4_qualibat_certifications_batiment/exemple-qualibat.pdf",
       "expires_in": 7889238
     },
     "links": {},

--- a/mocks/payloads/api_entreprise_v3_qualibat_certifications_batiment/summary.csv
+++ b/mocks/payloads/api_entreprise_v3_qualibat_certifications_batiment/summary.csv
@@ -1,7 +1,7 @@
 Titre,Description,Paramètres,Status,Réponse
 ,Certification Qualibat trouvée,"{""siret"":""30613890001294""}",200,"{
   ""data"": {
-    ""document_url"": ""https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v4_qualibat_certifications_batiment/exemple-qualibat.pdf"",
+    ""document_url"": ""https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v4_qualibat_certifications_batiment/exemple-qualibat.pdf"",
     ""expires_in"": 7889238
   },
   ""links"": {},

--- a/mocks/payloads/api_entreprise_v3_qualifelec_certificats/200-certification-qualifelec_2-certificats_sans-domaine.yaml
+++ b/mocks/payloads/api_entreprise_v3_qualifelec_certificats/200-certification-qualifelec_2-certificats_sans-domaine.yaml
@@ -17,7 +17,7 @@ payload: |-
     "data":[
         {
           "data":{
-              "document_url":"https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_qualifelec_certificats/exemple-certificat-qualifelec-bac-a-sable.jpg",
+              "document_url":"https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_qualifelec_certificats/exemple-certificat-qualifelec-bac-a-sable.jpg",
               "numero": 2840,
               "rge":false,
               "date_debut":"2023-02-01",
@@ -66,7 +66,7 @@ payload: |-
         },
         {
           "data":{
-              "document_url":"https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_qualifelec_certificats/exemple-certificat-qualifelec-bac-a-sable.jpg",
+              "document_url":"https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_qualifelec_certificats/exemple-certificat-qualifelec-bac-a-sable.jpg",
               "numero": 2841,
               "rge":false,
               "date_debut":"2023-08-01",

--- a/mocks/payloads/api_entreprise_v3_qualifelec_certificats/200-certification-qualifelec_probatoire_rge.yaml
+++ b/mocks/payloads/api_entreprise_v3_qualifelec_certificats/200-certification-qualifelec_probatoire_rge.yaml
@@ -17,7 +17,7 @@ payload: |-
     "data":[
         {
           "data":{
-              "document_url":"https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_qualifelec_certificats/exemple-certificat-qualifelec-bac-a-sable.jpg",
+              "document_url":"https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_qualifelec_certificats/exemple-certificat-qualifelec-bac-a-sable.jpg",
               "numero": 2840,
               "rge":true,
               "date_debut":"2023-02-01",

--- a/mocks/payloads/api_entreprise_v3_qualifelec_certificats/200-certification-qualifelec_rge_sans-domaine.yaml
+++ b/mocks/payloads/api_entreprise_v3_qualifelec_certificats/200-certification-qualifelec_rge_sans-domaine.yaml
@@ -16,7 +16,7 @@ payload: |-
     "data":[
         {
           "data":{
-              "document_url":"https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_qualifelec_certificats/exemple-certificat-qualifelec-bac-a-sable.jpg",
+              "document_url":"https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_qualifelec_certificats/exemple-certificat-qualifelec-bac-a-sable.jpg",
               "numero": 2840,
               "rge":true,
               "date_debut":"2023-02-01",

--- a/mocks/payloads/api_entreprise_v3_qualifelec_certificats/README.md
+++ b/mocks/payloads/api_entreprise_v3_qualifelec_certificats/README.md
@@ -33,7 +33,7 @@ Ce cas permet de tester :
     "data": [
       {
         "data": {
-          "document_url": "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_qualifelec_certificats/exemple-certificat-qualifelec-bac-a-sable.jpg",
+          "document_url": "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_qualifelec_certificats/exemple-certificat-qualifelec-bac-a-sable.jpg",
           "numero": 2840,
           "rge": false,
           "date_debut": "2023-02-01",
@@ -80,7 +80,7 @@ Ce cas permet de tester :
       },
       {
         "data": {
-          "document_url": "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_qualifelec_certificats/exemple-certificat-qualifelec-bac-a-sable.jpg",
+          "document_url": "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_qualifelec_certificats/exemple-certificat-qualifelec-bac-a-sable.jpg",
           "numero": 2841,
           "rge": false,
           "date_debut": "2023-08-01",
@@ -181,7 +181,7 @@ Ce cas permet de tester :
     "data": [
       {
         "data": {
-          "document_url": "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_qualifelec_certificats/exemple-certificat-qualifelec-bac-a-sable.jpg",
+          "document_url": "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_qualifelec_certificats/exemple-certificat-qualifelec-bac-a-sable.jpg",
           "numero": 2840,
           "rge": true,
           "date_debut": "2023-02-01",
@@ -290,7 +290,7 @@ Ce cas permet de tester :
     "data": [
       {
         "data": {
-          "document_url": "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_qualifelec_certificats/exemple-certificat-qualifelec-bac-a-sable.jpg",
+          "document_url": "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_qualifelec_certificats/exemple-certificat-qualifelec-bac-a-sable.jpg",
           "numero": 2840,
           "rge": true,
           "date_debut": "2023-02-01",

--- a/mocks/payloads/api_entreprise_v3_qualifelec_certificats/summary.csv
+++ b/mocks/payloads/api_entreprise_v3_qualifelec_certificats/summary.csv
@@ -11,7 +11,7 @@ Ce cas permet de tester :
   ""data"":[
       {
         ""data"":{
-            ""document_url"":""https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_qualifelec_certificats/exemple-certificat-qualifelec-bac-a-sable.jpg"",
+            ""document_url"":""https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_qualifelec_certificats/exemple-certificat-qualifelec-bac-a-sable.jpg"",
             ""numero"": 2840,
             ""rge"":false,
             ""date_debut"":""2023-02-01"",
@@ -60,7 +60,7 @@ Ce cas permet de tester :
       },
       {
         ""data"":{
-            ""document_url"":""https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_qualifelec_certificats/exemple-certificat-qualifelec-bac-a-sable.jpg"",
+            ""document_url"":""https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_qualifelec_certificats/exemple-certificat-qualifelec-bac-a-sable.jpg"",
             ""numero"": 2841,
             ""rge"":false,
             ""date_debut"":""2023-08-01"",
@@ -126,7 +126,7 @@ Ce cas permet de tester :
   ""data"":[
       {
         ""data"":{
-            ""document_url"":""https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_qualifelec_certificats/exemple-certificat-qualifelec-bac-a-sable.jpg"",
+            ""document_url"":""https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_qualifelec_certificats/exemple-certificat-qualifelec-bac-a-sable.jpg"",
             ""numero"": 2840,
             ""rge"":true,
             ""date_debut"":""2023-02-01"",
@@ -200,7 +200,7 @@ Ce cas permet de tester :
   ""data"":[
       {
         ""data"":{
-            ""document_url"":""https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_qualifelec_certificats/exemple-certificat-qualifelec-bac-a-sable.jpg"",
+            ""document_url"":""https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_qualifelec_certificats/exemple-certificat-qualifelec-bac-a-sable.jpg"",
             ""numero"": 2840,
             ""rge"":true,
             ""date_debut"":""2023-02-01"",

--- a/mocks/payloads/api_entreprise_v4_acoss_attestations_sociales/README.md
+++ b/mocks/payloads/api_entreprise_v4_acoss_attestations_sociales/README.md
@@ -23,7 +23,7 @@
   ```json
   {
     "data": {
-      "document_url": "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v4_acoss_attestations_sociales/attestation_vigilance_test.pdf",
+      "document_url": "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v4_acoss_attestations_sociales/attestation_vigilance_test.pdf",
       "document_url_expires_in": 86400,
       "date_debut_validite": "2023-01-31",
       "date_fin_validite": "2023-07-31",

--- a/mocks/payloads/api_entreprise_v4_acoss_attestations_sociales/attestation_delivree.yaml
+++ b/mocks/payloads/api_entreprise_v4_acoss_attestations_sociales/attestation_delivree.yaml
@@ -6,7 +6,7 @@ status: 200
 payload: |-
   {
     "data": {
-      "document_url": "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v4_acoss_attestations_sociales/attestation_vigilance_test.pdf",
+      "document_url": "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v4_acoss_attestations_sociales/attestation_vigilance_test.pdf",
       "document_url_expires_in": 86400,
       "date_debut_validite": "2023-01-31",
       "date_fin_validite": "2023-07-31",

--- a/mocks/payloads/api_entreprise_v4_acoss_attestations_sociales/summary.csv
+++ b/mocks/payloads/api_entreprise_v4_acoss_attestations_sociales/summary.csv
@@ -1,7 +1,7 @@
 Titre,Description,Paramètres,Status,Réponse
 ,Entreprise à jour de ses cotisations,"{""siren"":""000000001""}",200,"{
   ""data"": {
-    ""document_url"": ""https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v4_acoss_attestations_sociales/attestation_vigilance_test.pdf"",
+    ""document_url"": ""https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v4_acoss_attestations_sociales/attestation_vigilance_test.pdf"",
     ""document_url_expires_in"": 86400,
     ""date_debut_validite"": ""2023-01-31"",
     ""date_fin_validite"": ""2023-07-31"",

--- a/mocks/payloads/api_entreprise_v4_qualibat_certifications_batiment/200.yml
+++ b/mocks/payloads/api_entreprise_v4_qualibat_certifications_batiment/200.yml
@@ -6,7 +6,7 @@ status: 200
 payload: |-
   {
     "data": {
-      "document_url": "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v4_qualibat_certifications_batiment/exemple-qualibat.pdf",
+      "document_url": "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v4_qualibat_certifications_batiment/exemple-qualibat.pdf",
       "document_url_expires_in": 86400,
       "date_emission": "2023-01-01",
       "date_fin_validite": "2024-02-02",

--- a/mocks/payloads/api_entreprise_v4_qualibat_certifications_batiment/README.md
+++ b/mocks/payloads/api_entreprise_v4_qualibat_certifications_batiment/README.md
@@ -23,7 +23,7 @@
   ```json
   {
     "data": {
-      "document_url": "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v4_qualibat_certifications_batiment/exemple-qualibat.pdf",
+      "document_url": "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v4_qualibat_certifications_batiment/exemple-qualibat.pdf",
       "document_url_expires_in": 86400,
       "date_emission": "2023-01-01",
       "date_fin_validite": "2024-02-02",

--- a/mocks/payloads/api_entreprise_v4_qualibat_certifications_batiment/summary.csv
+++ b/mocks/payloads/api_entreprise_v4_qualibat_certifications_batiment/summary.csv
@@ -1,7 +1,7 @@
 Titre,Description,Paramètres,Status,Réponse
 ,Entreprise trouvée QUALIBAT,"{""siret"":""30613890001294""}",200,"{
   ""data"": {
-    ""document_url"": ""https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v4_qualibat_certifications_batiment/exemple-qualibat.pdf"",
+    ""document_url"": ""https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v4_qualibat_certifications_batiment/exemple-qualibat.pdf"",
     ""document_url_expires_in"": 86400,
     ""date_emission"": ""2023-01-01"",
     ""date_fin_validite"": ""2024-02-02"",

--- a/siade/config/swagger_data/acoss.yml
+++ b/siade/config/swagger_data/acoss.yml
@@ -10,6 +10,6 @@ acoss:
       \n
       \n
       Plus d'informations sur le site de l'URSSAF : https://www.urssaf.fr/portail/home/employeur/declarer-et-payer/obtenir-une-attestation/attestation-de-vigilance.html"
-      example: "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v4_acoss_attestations_sociales/attestation_vigilance_test.pdf"
+      example: "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v4_acoss_attestations_sociales/attestation_vigilance_test.pdf"
     document_url_expires_in:
       title: "Nombre de secondes avant expiration du lien URL"

--- a/siade/config/swagger_data/ademe.yml
+++ b/siade/config/swagger_data/ademe.yml
@@ -15,7 +15,7 @@ ademe:
         title: "URL Certificat"
         description: "URL de téléchargement du certificat"
         type: "string"
-        example: "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_ademe_certificats_rge/exemple-ademe-rge-certificat_qualibat.pdf"
+        example: "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_ademe_certificats_rge/exemple-ademe-rge-certificat_qualibat.pdf"
       nom_certificat:
         title: "Nom du certificat"
         description: "libéllé du certificat"

--- a/siade/config/swagger_data/cibtp.yml
+++ b/siade/config/swagger_data/cibtp.yml
@@ -10,7 +10,7 @@ cibtp:
         type: 'string'
         nullable: true
         description: "Ce lien délivre l'attestation au format PDF. Ce document est automatiquement supprimé après 10 minutes."
-        example: "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_cibtp_attestation_cotisations_conges_payes_chomage_intemperies/test_cibtp_certificat.pdf"
+        example: "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_cibtp_attestation_cotisations_conges_payes_chomage_intemperies/test_cibtp_certificat.pdf"
       expires_in:
         title: "Expiration du lien"
         description: "Nombre de secondes avant expiration du document référencé dans 'document_url'. Il s'agit d'une expiration technique. Ce champ n'est pas une date de fin de validité de l'attestation"

--- a/siade/config/swagger_data/cnav.yml
+++ b/siade/config/swagger_data/cnav.yml
@@ -177,7 +177,7 @@ cnav:
       \n
       Pour plus d'informations sur cette API et obtenir un accès en avant-première, veuillez contacter l'équipe API Particulier.
       \n
-      **Données disponibles en bac à sable :** [Liste de payloads de test](https://github.com/etalab/siade_staging_data/blob/develop/payloads/complementaire_sante_solidaire)"
+      **Données disponibles en bac à sable :** [Liste de payloads de test](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/complementaire_sante_solidaire)"
     tags:
       - Statut Complémentaire Santé Solidaire (C2S)
     attributes:
@@ -228,7 +228,7 @@ cnav:
       \n
       Pour plus d'informations sur cette API et obtenir un accès en avant-première, veuillez contacter l'équipe API Particulier.
       \n
-      **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_cnav_quotient_familial_v2)"
+      **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_cnav_quotient_familial_v2)"
     cache_duration: "La durée du cache est de 24 heure."
     tags:
       - Quotient familial CAF & MSA
@@ -613,7 +613,7 @@ cnav:
         \n
         Pour plus d'informations sur cette API et obtenir un accès en avant-première, veuillez contacter l'équipe API Particulier.
         \n
-        **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/complementaire_sante_solidaire)"
+        **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/complementaire_sante_solidaire)"
       tags:
         - Statut Complémentaire Santé Solidaire (C2S)
       parameters:
@@ -654,7 +654,7 @@ cnav:
         \n
         Pour plus d'informations sur cette API et obtenir un accès en avant-première, veuillez contacter l'équipe API Particulier.
         \n
-        **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_cnav_quotient_familial_v2)"
+        **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_cnav_quotient_familial_v2)"
       cache_duration: "La durée du cache est de 24 heure."
       tags:
         - Quotient familial MSA & CAF

--- a/siade/config/swagger_data/cnetp.yml
+++ b/siade/config/swagger_data/cnetp.yml
@@ -7,4 +7,4 @@ cnetp:
     document_url_properties:
       title: "Lien vers le certificat CNETP"
       description: "Ce lien délivre l'attestation au format PDF. Ce document est automatiquement supprimé après 24h."
-      example: "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_cnetp_attestation_cotisations_conges_payes_chomage_intemperies/test_cnetp_certificat.pdf"
+      example: "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_cnetp_attestation_cotisations_conges_payes_chomage_intemperies/test_cnetp_certificat.pdf"

--- a/siade/config/swagger_data/fntp.yml
+++ b/siade/config/swagger_data/fntp.yml
@@ -7,4 +7,4 @@ fntp:
     document_url_properties:
       title: "Lien vers la carte professionnelle"
       description: "Ce document est automatiquement supprimé au bout de 3 mois."
-      example: "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_fntp_carte_professionnelle_travaux_publics/carte_professionnelle_tp_test.pdf"
+      example: "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_fntp_carte_professionnelle_travaux_publics/carte_professionnelle_tp_test.pdf"

--- a/siade/config/swagger_data/france_travail.yml
+++ b/siade/config/swagger_data/france_travail.yml
@@ -13,7 +13,7 @@ france_travail:
     description: |
         Statut demandeur d'emploi, données relatives à l'inscription FranceTravail, ainsi que données d'identité de contact.
         **Paramètres d'appel :** Nom d’utilisateur France Travail choisi par le particulier lors de la création de son espace personnel en ligne
-        **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_pole_emploi_statut)
+        **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_pole_emploi_statut)
 
     tags:
       - Statut demandeurs d'emploi

--- a/siade/config/swagger_data/probtp.yml
+++ b/siade/config/swagger_data/probtp.yml
@@ -7,7 +7,7 @@ probtp:
     document_url_properties:
       title: "Lien vers l'attestation de cotisation retraite ProBTP"
       description: "Ce document est automatiquement supprimé au bout de 3 mois."
-      example: "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_probtp_attestations_cotisation_retraite/test_probtp_attestation.pdf"
+      example: "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_probtp_attestations_cotisation_retraite/test_probtp_attestation.pdf"
   conformites_cotisations_retraite:
     title: "Conformité cotisations retraite complémentaire"
     description: "Régularité des cotisations de retraite complémentaire auprès de la Protection Sociale du Bâtiment et des Travaux publics (ProBTP)."

--- a/siade/config/swagger_data/qualibat.yml
+++ b/siade/config/swagger_data/qualibat.yml
@@ -10,14 +10,14 @@ qualibat:
     document_url_properties:
       title: "Lien vers la certification batiment Qualibat"
       description: "Cette URL permet de télécharger la certification Qualibat au format PDF."
-      example: "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v4_qualibat_certifications_batiment/exemple-qualibat.pdf"
+      example: "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v4_qualibat_certifications_batiment/exemple-qualibat.pdf"
 
     properties:
       document_url:
         title: "Lien vers la certification batiment Qualibat"
         type: "string"
         description: "Cette URL permet de télécharger la certification Qualibat au format PDF."
-        example: "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v4_qualibat_certifications_batiment/exemple-qualibat.pdf"
+        example: "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v4_qualibat_certifications_batiment/exemple-qualibat.pdf"
       document_url_expires_in:
         title: "Nombre de secondes avant expiration du document référencé dans 'document_url'"
         description: "Il s'agit d'une expiration technique: cette valeur n'a aucun lien avec les dates de fin de validité ou d'émission."

--- a/siade/config/swagger_data/qualifelec.yaml
+++ b/siade/config/swagger_data/qualifelec.yaml
@@ -21,7 +21,7 @@ qualifelec:
         title: "URL de téléchargement du certificat Qualifelec"
         type: string
         description: "Ce lien délivre le certificat Qualifelec de l'entreprise au format PDF tel qu'accessible depuis le site https://www.qualifelec.fr/."
-        example: "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_qualifelec_certificats/exemple-certificat-qualifelec-bac-a-sable.jpg"
+        example: "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_qualifelec_certificats/exemple-certificat-qualifelec-bac-a-sable.jpg"
       numero:
         title: 'Numéro du certificat'
         type: "number"

--- a/siade/config/swagger_data/urssaf.yml
+++ b/siade/config/swagger_data/urssaf.yml
@@ -68,7 +68,7 @@ urssaf:
         type: 'string'
         nullable: true
         description: "Ce lien délivre l'attestation de vigilance de l'entreprise au format PDF."
-        example: "https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v4_acoss_attestations_sociales/attestation_vigilance_test.pdf"
+        example: "https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v4_acoss_attestations_sociales/attestation_vigilance_test.pdf"
       document_url_expires_in:
         title: "Nombre de secondes avant expiration du document référencé dans 'document_url'"
         description: "Il s'agit d'une expiration technique: cette valeur n'a aucun lien avec les dates de debut ou de fin de validité."

--- a/siade/docs/fonctionnement_staging.md
+++ b/siade/docs/fonctionnement_staging.md
@@ -18,12 +18,12 @@ Ce service tente séquentiellement:
 
 Pour 1., `MockDataBackend` utilise l'identifiant `operation_id` (générer à
 l'aide du chemin du controller) ainsi que les paramètres d'appel afin
-d'identifier dans le dépôt [siade_staging_data](https://github.com/etalab/siade_staging_data)
+d'identifier dans le dépôt [apistration](https://github.com/datagouv/apistration/tree/develop/mocks)
 la payload correspondante.
 
 Par exemple pour le endpoint `/v2/etudiants` de API Particulier, avec en
 paramètres `ine=1234567890G`, la réponse renvoyée correspond à cette
-[payload](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_mesri_student_status/ine.yaml)
+[payload](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_mesri_student_status/ine.yaml)
 
 Il est possible via ce système de simuler des réponses (couple `(status, payload)`)
 différentes en fonction des paramètres.

--- a/siade/spec/services/mock_service_spec.rb
+++ b/siade/spec/services/mock_service_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe MockService, type: :service do
             status: 200,
             payload: {
               'data' => {
-                'document_url' => 'https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v4_acoss_attestations_sociales/attestation_vigilance_test.pdf',
+                'document_url' => 'https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v4_acoss_attestations_sociales/attestation_vigilance_test.pdf',
                 'expires_in' => 7_889_238
               },
               'links' => {},

--- a/siade/spec/swagger_helper.rb
+++ b/siade/spec/swagger_helper.rb
@@ -108,7 +108,7 @@ RSpec.configure do |config|
 
 Il est possible de tester les API via notre environnement de **staging** qui vous retournera systématiquement des données fictives. Référez vous à la [documentation](https://entreprise.api.gouv.fr/developpeurs#tester-api-preproduction).
 
-Il est nécessaire d'utiliser un jeton de staging. Plus d'infos ici: https://github.com/etalab/siade_staging_data/tree/develop/tokens
+Il est nécessaire d'utiliser un jeton de staging. Plus d'infos ici: https://github.com/datagouv/apistration/tree/develop/mocks/tokens
       ",
         termsOfService: 'https://entreprise.api.gouv.fr/cgu/',
         contact:
@@ -192,7 +192,7 @@ Le bac à sable et l'API de production sont appelables par deux adresses distinc
 
 Pour récupérer le jeton de production un portail développeur est mis à votre disposition à l'adresse suivante : [https://particulier.api.gouv.fr/compte](https://particulier.api.gouv.fr/compte)
 
-Pour effectuer vos tests sur le bac à sable, référez-vous à ce dépôt github: [etalab/siade_staging_data](https://github.com/etalab/siade_staging_data/) (l'ancien système basé sur Airtable n'est plus maintenu et va être remplacé par le nouveau système). Un jeton nommé default est disponible ici: [tokens](https://github.com/etalab/siade_staging_data/tree/develop/tokens)
+Pour effectuer vos tests sur le bac à sable, référez-vous à ce dépôt github: [datagouv/apistration](https://github.com/datagouv/apistration/tree/develop/mocks/) (l'ancien système basé sur Airtable n'est plus maintenu et va être remplacé par le nouveau système). Un jeton nommé default est disponible ici: [tokens](https://github.com/datagouv/apistration/tree/develop/mocks/tokens)
 
 ### Accéder à la version 3 de l'API
 
@@ -288,7 +288,7 @@ Le bac à sable et l'API de production sont appelables par deux adresses distinc
 
 Pour récupérer le jeton de production un portail développeur est mis à votre disposition à l'adresse suivante : [https://particulier.api.gouv.fr/compte](https://particulier.api.gouv.fr/compte)
 
-Pour effectuer vos tests sur le bac à sable, référez-vous à ce dépôt github: [etalab/siade_staging_data](https://github.com/etalab/siade_staging_data/) (l'ancien système basé sur Airtable n'est plus maintenu et va être remplacé par le nouveau système). Un jeton nommé default est disponible ici: [tokens](https://github.com/etalab/siade_staging_data/tree/develop/tokens)
+Pour effectuer vos tests sur le bac à sable, référez-vous à ce dépôt github: [datagouv/apistration](https://github.com/datagouv/apistration/tree/develop/mocks/) (l'ancien système basé sur Airtable n'est plus maintenu et va être remplacé par le nouveau système). Un jeton nommé default est disponible ici: [tokens](https://github.com/datagouv/apistration/tree/develop/mocks/tokens)
 
 ### Accéder à la version 2 de l'API
 

--- a/siade/swagger/api_particulier_open_api_static/v2.yaml
+++ b/siade/swagger/api_particulier_open_api_static/v2.yaml
@@ -23,7 +23,7 @@ info:
 
     Pour récupérer le jeton de production un portail développeur est mis à votre disposition à l'adresse suivante : [https://particulier.api.gouv.fr/compte](https://particulier.api.gouv.fr/compte)
 
-    Pour effectuer vos tests sur le bac à sable, référez-vous à ce dépôt github: [etalab/siade_staging_data](https://github.com/etalab/siade_staging_data/) (l'ancien système basé sur Airtable n'est plus maintenu et va être remplacé par le nouveau système). Un jeton nommé default est disponible ici: [tokens](https://github.com/etalab/siade_staging_data/tree/develop/tokens)
+    Pour effectuer vos tests sur le bac à sable, référez-vous à ce dépôt github: [datagouv/apistration](https://github.com/datagouv/apistration/tree/develop/mocks/) (l'ancien système basé sur Airtable n'est plus maintenu et va être remplacé par le nouveau système). Un jeton nommé default est disponible ici: [tokens](https://github.com/datagouv/apistration/tree/develop/mocks/tokens)
 
     ### Accéder à la version 3 de l'API
 
@@ -719,7 +719,7 @@ paths:
         \n\n Retourne également des informations sur les dates d'ouverture des droits.
         \n Pour plus d'informations sur cette API et obtenir un accès en avant-première,
         veuillez contacter l'équipe API Particulier. \n **Données disponibles en bac
-        à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/complementaire_sante_solidaire)
+        à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/complementaire_sante_solidaire)
         \n L'API peut être appellée avec les données identité pivot ou avec un jeton
         FranceConnect."
       responses:
@@ -1279,7 +1279,7 @@ paths:
       description: "Quotient familial et composition de la famille d'un allocataire
         du régime agricole (régime général à venir). \n Pour plus d'informations sur
         cette API et obtenir un accès en avant-première, veuillez contacter l'équipe
-        API Particulier. \n **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_cnav_quotient_familial_v2)
+        API Particulier. \n **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_cnav_quotient_familial_v2)
         \n L'API peut être appellée avec les données identité pivot ou avec un jeton
         FranceConnect."
       responses:
@@ -2310,7 +2310,7 @@ paths:
 
         **Paramètres d'appel :** numéro d'allocataire et code postal
 
-        **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_cnaf_quotient_familial)
+        **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_cnaf_quotient_familial)
       parameters:
       - name: Cache-Control
         in: header
@@ -2566,7 +2566,7 @@ paths:
       description: |-
         Données d'identité, de contact et de statut du demandeur d'emploi.
         **Paramètres d'appel :** Nom d’utilisateur France Travail choisi par le particulier lors de la création de son espace personnel en ligne
-        **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_pole_emploi_statut)
+        **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_pole_emploi_statut)
       parameters:
       - name: identifiant
         required: true
@@ -2875,7 +2875,7 @@ paths:
          - INE, l'identifiant national étudiant ;
          - l'état civil de l'étudiant: nom, prénom, date de naissance, sexe et lieu de naissance.
 
-        **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_mesri_student_status)
+        **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_mesri_student_status)
       security:
       - franceConnectToken: []
         apiKey: []
@@ -3060,7 +3060,7 @@ paths:
          - INE, l'identifiant national étudiant ;
          - l'état civil de l'étudiant: nom, prénom, date de naissance, sexe (optionnel) et lieu de naissance (optionnel).
 
-        **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_cnous_student_scholarship)
+        **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_cnous_student_scholarship)
       security:
       - franceConnectToken: []
         apiKey: []

--- a/siade/swagger/openapi-entreprise.yaml
+++ b/siade/swagger/openapi-entreprise.yaml
@@ -9,7 +9,7 @@ info:
     d'une clé d'accès (jeton).\n\n### Comment tester l'API ?\n\nIl est possible de
     tester les API via notre environnement de **staging** qui vous retournera systématiquement
     des données fictives. Référez vous à la [documentation](https://entreprise.api.gouv.fr/developpeurs#tester-api-preproduction).\n\nIl
-    est nécessaire d'utiliser un jeton de staging. Plus d'infos ici: https://github.com/etalab/siade_staging_data/tree/develop/tokens\n
+    est nécessaire d'utiliser un jeton de staging. Plus d'infos ici: https://github.com/datagouv/apistration/tree/develop/mocks/tokens\n
     \     "
   termsOfService: https://entreprise.api.gouv.fr/cgu/
   contact:
@@ -398,7 +398,7 @@ paths:
                           enregistrée dans le système. Elle est donc variable d'une
                           entreprise à l'autre. \n \n Plus d'informations sur le site
                           de l'URSSAF : https://www.urssaf.fr/portail/home/employeur/declarer-et-payer/obtenir-une-attestation/attestation-de-vigilance.html"
-                        example: https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v4_acoss_attestations_sociales/attestation_vigilance_test.pdf
+                        example: https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v4_acoss_attestations_sociales/attestation_vigilance_test.pdf
                       expires_in:
                         type: integer
                         example: 7889238
@@ -915,7 +915,7 @@ paths:
                               title: URL Certificat
                               description: URL de téléchargement du certificat
                               type: string
-                              example: https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_ademe_certificats_rge/exemple-ademe-rge-certificat_qualibat.pdf
+                              example: https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_ademe_certificats_rge/exemple-ademe-rge-certificat_qualibat.pdf
                             nom_certificat:
                               title: Nom du certificat
                               description: libéllé du certificat
@@ -2793,7 +2793,7 @@ paths:
                         nullable: true
                         description: Ce lien délivre l'attestation au format PDF.
                           Ce document est automatiquement supprimé après 10 minutes.
-                        example: https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_cibtp_attestation_cotisations_conges_payes_chomage_intemperies/test_cibtp_certificat.pdf
+                        example: https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_cibtp_attestation_cotisations_conges_payes_chomage_intemperies/test_cibtp_certificat.pdf
                       expires_in:
                         title: Expiration du lien
                         description: Nombre de secondes avant expiration du document
@@ -3173,7 +3173,7 @@ paths:
                         title: Lien vers le certificat CNETP
                         description: Ce lien délivre l'attestation au format PDF.
                           Ce document est automatiquement supprimé après 24h.
-                        example: https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_cnetp_attestation_cotisations_conges_payes_chomage_intemperies/test_cnetp_certificat.pdf
+                        example: https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_cnetp_attestation_cotisations_conges_payes_chomage_intemperies/test_cnetp_certificat.pdf
                       expires_in:
                         type: integer
                         example: 7889238
@@ -11613,7 +11613,7 @@ paths:
                         title: Lien vers la carte professionnelle
                         description: Ce document est automatiquement supprimé au bout
                           de 3 mois.
-                        example: https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_fntp_carte_professionnelle_travaux_publics/carte_professionnelle_tp_test.pdf
+                        example: https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_fntp_carte_professionnelle_travaux_publics/carte_professionnelle_tp_test.pdf
                       expires_in:
                         type: integer
                         example: 7889238
@@ -35523,7 +35523,7 @@ paths:
                         title: Lien vers l'attestation de cotisation retraite ProBTP
                         description: Ce document est automatiquement supprimé au bout
                           de 3 mois.
-                        example: https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_probtp_attestations_cotisation_retraite/test_probtp_attestation.pdf
+                        example: https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_probtp_attestations_cotisation_retraite/test_probtp_attestation.pdf
                       expires_in:
                         type: integer
                         example: 7889238
@@ -36341,7 +36341,7 @@ paths:
                         title: Lien vers la certification batiment Qualibat
                         description: Cette URL permet de télécharger la certification
                           Qualibat au format PDF.
-                        example: https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v4_qualibat_certifications_batiment/exemple-qualibat.pdf
+                        example: https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v4_qualibat_certifications_batiment/exemple-qualibat.pdf
                       expires_in:
                         type: integer
                         example: 7889238
@@ -36823,7 +36823,7 @@ paths:
                         type: string
                         description: Cette URL permet de télécharger la certification
                           Qualibat au format PDF.
-                        example: https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v4_qualibat_certifications_batiment/exemple-qualibat.pdf
+                        example: https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v4_qualibat_certifications_batiment/exemple-qualibat.pdf
                       document_url_expires_in:
                         title: Nombre de secondes avant expiration du document référencé
                           dans 'document_url'
@@ -37371,7 +37371,7 @@ paths:
                               description: Ce lien délivre le certificat Qualifelec
                                 de l'entreprise au format PDF tel qu'accessible depuis
                                 le site https://www.qualifelec.fr/.
-                              example: https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_qualifelec_certificats/exemple-certificat-qualifelec-bac-a-sable.jpg
+                              example: https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_qualifelec_certificats/exemple-certificat-qualifelec-bac-a-sable.jpg
                             numero:
                               title: Numéro du certificat
                               type: number
@@ -38499,7 +38499,7 @@ paths:
                         nullable: true
                         description: Ce lien délivre l'attestation de vigilance de
                           l'entreprise au format PDF.
-                        example: https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v4_acoss_attestations_sociales/attestation_vigilance_test.pdf
+                        example: https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v4_acoss_attestations_sociales/attestation_vigilance_test.pdf
                       document_url_expires_in:
                         title: Nombre de secondes avant expiration du document référencé
                           dans 'document_url'

--- a/siade/swagger/openapi-particulier.yaml
+++ b/siade/swagger/openapi-particulier.yaml
@@ -22,7 +22,7 @@ info:
 
     Pour récupérer le jeton de production un portail développeur est mis à votre disposition à l'adresse suivante : [https://particulier.api.gouv.fr/compte](https://particulier.api.gouv.fr/compte)
 
-    Pour effectuer vos tests sur le bac à sable, référez-vous à ce dépôt github: [etalab/siade_staging_data](https://github.com/etalab/siade_staging_data/) (l'ancien système basé sur Airtable n'est plus maintenu et va être remplacé par le nouveau système). Un jeton nommé default est disponible ici: [tokens](https://github.com/etalab/siade_staging_data/tree/develop/tokens)
+    Pour effectuer vos tests sur le bac à sable, référez-vous à ce dépôt github: [datagouv/apistration](https://github.com/datagouv/apistration/tree/develop/mocks/) (l'ancien système basé sur Airtable n'est plus maintenu et va être remplacé par le nouveau système). Un jeton nommé default est disponible ici: [tokens](https://github.com/datagouv/apistration/tree/develop/mocks/tokens)
 
     ### Accéder à la version 2 de l'API
 
@@ -3306,7 +3306,7 @@ paths:
         \n\n Retourne également des informations sur les dates d'ouverture des droits.
         \n Pour plus d'informations sur cette API et obtenir un accès en avant-première,
         veuillez contacter l'équipe API Particulier. \n **Données disponibles en bac
-        à sable :** [Liste de payloads de test](https://github.com/etalab/siade_staging_data/blob/develop/payloads/complementaire_sante_solidaire)"
+        à sable :** [Liste de payloads de test](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/complementaire_sante_solidaire)"
       responses:
         '401':
           description: Non autorisé
@@ -3684,7 +3684,7 @@ paths:
         \n\n Retourne également des informations sur les dates d'ouverture des droits.
         \n Pour plus d'informations sur cette API et obtenir un accès en avant-première,
         veuillez contacter l'équipe API Particulier. \n **Données disponibles en bac
-        à sable :** [Liste de payloads de test](https://github.com/etalab/siade_staging_data/blob/develop/payloads/complementaire_sante_solidaire)"
+        à sable :** [Liste de payloads de test](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/complementaire_sante_solidaire)"
       responses:
         '403':
           description: Accès interdit
@@ -6112,7 +6112,7 @@ paths:
       description: "Quotient familial délivré par la CAF ou la MSA et composition
         de la famille de l'allocataire. \n Pour plus d'informations sur cette API
         et obtenir un accès en avant-première, veuillez contacter l'équipe API Particulier.
-        \n **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_cnav_quotient_familial_v2)"
+        \n **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_cnav_quotient_familial_v2)"
       responses:
         '401':
           description: Non autorisé
@@ -6717,7 +6717,7 @@ paths:
       description: "Quotient familial délivré par la CAF ou la MSA et composition
         de la famille de l'allocataire. \n Pour plus d'informations sur cette API
         et obtenir un accès en avant-première, veuillez contacter l'équipe API Particulier.
-        \n **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_cnav_quotient_familial_v2)"
+        \n **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_cnav_quotient_familial_v2)"
       responses:
         '403':
           description: Accès interdit
@@ -11321,7 +11321,7 @@ paths:
       description: |
         Statut demandeur d'emploi, données relatives à l'inscription FranceTravail, ainsi que données d'identité de contact.
         **Paramètres d'appel :** Nom d’utilisateur France Travail choisi par le particulier lors de la création de son espace personnel en ligne
-        **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_pole_emploi_statut)
+        **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_pole_emploi_statut)
       responses:
         '401':
           description: Non autorisé

--- a/siade/swagger/openapi-particulierv2.yaml
+++ b/siade/swagger/openapi-particulierv2.yaml
@@ -23,7 +23,7 @@ info:
 
     Pour récupérer le jeton de production un portail développeur est mis à votre disposition à l'adresse suivante : [https://particulier.api.gouv.fr/compte](https://particulier.api.gouv.fr/compte)
 
-    Pour effectuer vos tests sur le bac à sable, référez-vous à ce dépôt github: [etalab/siade_staging_data](https://github.com/etalab/siade_staging_data/) (l'ancien système basé sur Airtable n'est plus maintenu et va être remplacé par le nouveau système). Un jeton nommé default est disponible ici: [tokens](https://github.com/etalab/siade_staging_data/tree/develop/tokens)
+    Pour effectuer vos tests sur le bac à sable, référez-vous à ce dépôt github: [datagouv/apistration](https://github.com/datagouv/apistration/tree/develop/mocks/) (l'ancien système basé sur Airtable n'est plus maintenu et va être remplacé par le nouveau système). Un jeton nommé default est disponible ici: [tokens](https://github.com/datagouv/apistration/tree/develop/mocks/tokens)
 
     ### Accéder à la version 3 de l'API
 
@@ -800,7 +800,7 @@ paths:
         \n\n Retourne également des informations sur les dates d'ouverture des droits.
         \n Pour plus d'informations sur cette API et obtenir un accès en avant-première,
         veuillez contacter l'équipe API Particulier. \n **Données disponibles en bac
-        à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/complementaire_sante_solidaire)"
+        à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/complementaire_sante_solidaire)"
       responses:
         '200':
           description: Complementaire Santé Solidaire trouvée
@@ -1441,7 +1441,7 @@ paths:
       description: "Quotient familial et composition de la famille d'un allocataire
         du régime agricole (régime général à venir). \n Pour plus d'informations sur
         cette API et obtenir un accès en avant-première, veuillez contacter l'équipe
-        API Particulier. \n **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_cnav_quotient_familial_v2)"
+        API Particulier. \n **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_cnav_quotient_familial_v2)"
       responses:
         '200':
           description: Quotient Familial trouvé

--- a/site/app/models/abstract_endpoint.rb
+++ b/site/app/models/abstract_endpoint.rb
@@ -200,7 +200,7 @@ class AbstractEndpoint
   end
 
   def test_cases_external_url
-    "https://github.com/etalab/siade_staging_data/tree/develop/payloads/#{operation_id}"
+    "https://github.com/datagouv/apistration/tree/develop/mocks/payloads/#{operation_id}"
   end
 
   def operation_id

--- a/site/config/api-entreprise-v3-openapi.yml
+++ b/site/config/api-entreprise-v3-openapi.yml
@@ -9,7 +9,7 @@ info:
     d'une clé d'accès (jeton).\n\n### Comment tester l'API ?\n\nIl est possible de
     tester les API via notre environnement de **staging** qui vous retournera systématiquement
     des données fictives. Référez vous à la [documentation](https://entreprise.api.gouv.fr/developpeurs#tester-api-preproduction).\n\nIl
-    est nécessaire d'utiliser un jeton de staging. Plus d'infos ici: https://github.com/etalab/siade_staging_data/tree/develop/tokens\n
+    est nécessaire d'utiliser un jeton de staging. Plus d'infos ici: https://github.com/datagouv/apistration/tree/develop/mocks/tokens\n
     \     "
   termsOfService: https://entreprise.api.gouv.fr/cgu/
   contact:
@@ -398,7 +398,7 @@ paths:
                           enregistrée dans le système. Elle est donc variable d'une
                           entreprise à l'autre. \n \n Plus d'informations sur le site
                           de l'URSSAF : https://www.urssaf.fr/portail/home/employeur/declarer-et-payer/obtenir-une-attestation/attestation-de-vigilance.html"
-                        example: https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v4_acoss_attestations_sociales/attestation_vigilance_test.pdf
+                        example: https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v4_acoss_attestations_sociales/attestation_vigilance_test.pdf
                       expires_in:
                         type: integer
                         example: 7889238
@@ -915,7 +915,7 @@ paths:
                               title: URL Certificat
                               description: URL de téléchargement du certificat
                               type: string
-                              example: https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_ademe_certificats_rge/exemple-ademe-rge-certificat_qualibat.pdf
+                              example: https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_ademe_certificats_rge/exemple-ademe-rge-certificat_qualibat.pdf
                             nom_certificat:
                               title: Nom du certificat
                               description: libéllé du certificat
@@ -2793,7 +2793,7 @@ paths:
                         nullable: true
                         description: Ce lien délivre l'attestation au format PDF.
                           Ce document est automatiquement supprimé après 10 minutes.
-                        example: https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_cibtp_attestation_cotisations_conges_payes_chomage_intemperies/test_cibtp_certificat.pdf
+                        example: https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_cibtp_attestation_cotisations_conges_payes_chomage_intemperies/test_cibtp_certificat.pdf
                       expires_in:
                         title: Expiration du lien
                         description: Nombre de secondes avant expiration du document
@@ -3173,7 +3173,7 @@ paths:
                         title: Lien vers le certificat CNETP
                         description: Ce lien délivre l'attestation au format PDF.
                           Ce document est automatiquement supprimé après 24h.
-                        example: https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_cnetp_attestation_cotisations_conges_payes_chomage_intemperies/test_cnetp_certificat.pdf
+                        example: https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_cnetp_attestation_cotisations_conges_payes_chomage_intemperies/test_cnetp_certificat.pdf
                       expires_in:
                         type: integer
                         example: 7889238
@@ -11613,7 +11613,7 @@ paths:
                         title: Lien vers la carte professionnelle
                         description: Ce document est automatiquement supprimé au bout
                           de 3 mois.
-                        example: https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_fntp_carte_professionnelle_travaux_publics/carte_professionnelle_tp_test.pdf
+                        example: https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_fntp_carte_professionnelle_travaux_publics/carte_professionnelle_tp_test.pdf
                       expires_in:
                         type: integer
                         example: 7889238
@@ -35523,7 +35523,7 @@ paths:
                         title: Lien vers l'attestation de cotisation retraite ProBTP
                         description: Ce document est automatiquement supprimé au bout
                           de 3 mois.
-                        example: https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_probtp_attestations_cotisation_retraite/test_probtp_attestation.pdf
+                        example: https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_probtp_attestations_cotisation_retraite/test_probtp_attestation.pdf
                       expires_in:
                         type: integer
                         example: 7889238
@@ -36341,7 +36341,7 @@ paths:
                         title: Lien vers la certification batiment Qualibat
                         description: Cette URL permet de télécharger la certification
                           Qualibat au format PDF.
-                        example: https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v4_qualibat_certifications_batiment/exemple-qualibat.pdf
+                        example: https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v4_qualibat_certifications_batiment/exemple-qualibat.pdf
                       expires_in:
                         type: integer
                         example: 7889238
@@ -36823,7 +36823,7 @@ paths:
                         type: string
                         description: Cette URL permet de télécharger la certification
                           Qualibat au format PDF.
-                        example: https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v4_qualibat_certifications_batiment/exemple-qualibat.pdf
+                        example: https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v4_qualibat_certifications_batiment/exemple-qualibat.pdf
                       document_url_expires_in:
                         title: Nombre de secondes avant expiration du document référencé
                           dans 'document_url'
@@ -37371,7 +37371,7 @@ paths:
                               description: Ce lien délivre le certificat Qualifelec
                                 de l'entreprise au format PDF tel qu'accessible depuis
                                 le site https://www.qualifelec.fr/.
-                              example: https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v3_qualifelec_certificats/exemple-certificat-qualifelec-bac-a-sable.jpg
+                              example: https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v3_qualifelec_certificats/exemple-certificat-qualifelec-bac-a-sable.jpg
                             numero:
                               title: Numéro du certificat
                               type: number
@@ -38499,7 +38499,7 @@ paths:
                         nullable: true
                         description: Ce lien délivre l'attestation de vigilance de
                           l'entreprise au format PDF.
-                        example: https://raw.githubusercontent.com/etalab/siade_staging_data/refs/heads/develop/payloads/api_entreprise_v4_acoss_attestations_sociales/attestation_vigilance_test.pdf
+                        example: https://raw.githubusercontent.com/datagouv/apistration/refs/heads/develop/mocks/payloads/api_entreprise_v4_acoss_attestations_sociales/attestation_vigilance_test.pdf
                       document_url_expires_in:
                         title: Nombre de secondes avant expiration du document référencé
                           dans 'document_url'

--- a/site/config/api-particulier-openapi-v2.yml
+++ b/site/config/api-particulier-openapi-v2.yml
@@ -23,7 +23,7 @@ info:
 
     Pour récupérer le jeton de production un portail développeur est mis à votre disposition à l'adresse suivante : [https://particulier.api.gouv.fr/compte](https://particulier.api.gouv.fr/compte)
 
-    Pour effectuer vos tests sur le bac à sable, référez-vous à ce dépôt github: [etalab/siade_staging_data](https://github.com/etalab/siade_staging_data/) (l'ancien système basé sur Airtable n'est plus maintenu et va être remplacé par le nouveau système). Un jeton nommé default est disponible ici: [tokens](https://github.com/etalab/siade_staging_data/tree/develop/tokens)
+    Pour effectuer vos tests sur le bac à sable, référez-vous à ce dépôt github: [datagouv/apistration](https://github.com/datagouv/apistration/tree/develop/mocks/) (l'ancien système basé sur Airtable n'est plus maintenu et va être remplacé par le nouveau système). Un jeton nommé default est disponible ici: [tokens](https://github.com/datagouv/apistration/tree/develop/mocks/tokens)
 
     ### Accéder à la version 3 de l'API
 
@@ -719,7 +719,7 @@ paths:
         \n\n Retourne également des informations sur les dates d'ouverture des droits.
         \n Pour plus d'informations sur cette API et obtenir un accès en avant-première,
         veuillez contacter l'équipe API Particulier. \n **Données disponibles en bac
-        à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/complementaire_sante_solidaire)
+        à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/complementaire_sante_solidaire)
         \n L'API peut être appellée avec les données identité pivot ou avec un jeton
         FranceConnect."
       responses:
@@ -1279,7 +1279,7 @@ paths:
       description: "Quotient familial et composition de la famille d'un allocataire
         du régime agricole (régime général à venir). \n Pour plus d'informations sur
         cette API et obtenir un accès en avant-première, veuillez contacter l'équipe
-        API Particulier. \n **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_cnav_quotient_familial_v2)
+        API Particulier. \n **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_cnav_quotient_familial_v2)
         \n L'API peut être appellée avec les données identité pivot ou avec un jeton
         FranceConnect."
       responses:
@@ -2310,7 +2310,7 @@ paths:
 
         **Paramètres d'appel :** numéro d'allocataire et code postal
 
-        **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_cnaf_quotient_familial)
+        **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_cnaf_quotient_familial)
       parameters:
       - name: Cache-Control
         in: header
@@ -2566,7 +2566,7 @@ paths:
       description: |-
         Données d'identité, de contact et de statut du demandeur d'emploi.
         **Paramètres d'appel :** Nom d’utilisateur France Travail choisi par le particulier lors de la création de son espace personnel en ligne
-        **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_pole_emploi_statut)
+        **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_pole_emploi_statut)
       parameters:
       - name: identifiant
         required: true
@@ -2875,7 +2875,7 @@ paths:
          - INE, l'identifiant national étudiant ;
          - l'état civil de l'étudiant: nom, prénom, date de naissance, sexe et lieu de naissance.
 
-        **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_mesri_student_status)
+        **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_mesri_student_status)
       security:
       - franceConnectToken: []
         apiKey: []
@@ -3060,7 +3060,7 @@ paths:
          - INE, l'identifiant national étudiant ;
          - l'état civil de l'étudiant: nom, prénom, date de naissance, sexe (optionnel) et lieu de naissance (optionnel).
 
-        **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_cnous_student_scholarship)
+        **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_cnous_student_scholarship)
       security:
       - franceConnectToken: []
         apiKey: []

--- a/site/config/api-particulier-openapi-v3.yml
+++ b/site/config/api-particulier-openapi-v3.yml
@@ -22,7 +22,7 @@ info:
 
     Pour récupérer le jeton de production un portail développeur est mis à votre disposition à l'adresse suivante : [https://particulier.api.gouv.fr/compte](https://particulier.api.gouv.fr/compte)
 
-    Pour effectuer vos tests sur le bac à sable, référez-vous à ce dépôt github: [etalab/siade_staging_data](https://github.com/etalab/siade_staging_data/) (l'ancien système basé sur Airtable n'est plus maintenu et va être remplacé par le nouveau système). Un jeton nommé default est disponible ici: [tokens](https://github.com/etalab/siade_staging_data/tree/develop/tokens)
+    Pour effectuer vos tests sur le bac à sable, référez-vous à ce dépôt github: [datagouv/apistration](https://github.com/datagouv/apistration/tree/develop/mocks/) (l'ancien système basé sur Airtable n'est plus maintenu et va être remplacé par le nouveau système). Un jeton nommé default est disponible ici: [tokens](https://github.com/datagouv/apistration/tree/develop/mocks/tokens)
 
     ### Accéder à la version 2 de l'API
 
@@ -3306,7 +3306,7 @@ paths:
         \n\n Retourne également des informations sur les dates d'ouverture des droits.
         \n Pour plus d'informations sur cette API et obtenir un accès en avant-première,
         veuillez contacter l'équipe API Particulier. \n **Données disponibles en bac
-        à sable :** [Liste de payloads de test](https://github.com/etalab/siade_staging_data/blob/develop/payloads/complementaire_sante_solidaire)"
+        à sable :** [Liste de payloads de test](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/complementaire_sante_solidaire)"
       responses:
         '401':
           description: Non autorisé
@@ -3684,7 +3684,7 @@ paths:
         \n\n Retourne également des informations sur les dates d'ouverture des droits.
         \n Pour plus d'informations sur cette API et obtenir un accès en avant-première,
         veuillez contacter l'équipe API Particulier. \n **Données disponibles en bac
-        à sable :** [Liste de payloads de test](https://github.com/etalab/siade_staging_data/blob/develop/payloads/complementaire_sante_solidaire)"
+        à sable :** [Liste de payloads de test](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/complementaire_sante_solidaire)"
       responses:
         '403':
           description: Accès interdit
@@ -6112,7 +6112,7 @@ paths:
       description: "Quotient familial délivré par la CAF ou la MSA et composition
         de la famille de l'allocataire. \n Pour plus d'informations sur cette API
         et obtenir un accès en avant-première, veuillez contacter l'équipe API Particulier.
-        \n **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_cnav_quotient_familial_v2)"
+        \n **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_cnav_quotient_familial_v2)"
       responses:
         '401':
           description: Non autorisé
@@ -6717,7 +6717,7 @@ paths:
       description: "Quotient familial délivré par la CAF ou la MSA et composition
         de la famille de l'allocataire. \n Pour plus d'informations sur cette API
         et obtenir un accès en avant-première, veuillez contacter l'équipe API Particulier.
-        \n **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_cnav_quotient_familial_v2)"
+        \n **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_cnav_quotient_familial_v2)"
       responses:
         '403':
           description: Accès interdit
@@ -11321,7 +11321,7 @@ paths:
       description: |
         Statut demandeur d'emploi, données relatives à l'inscription FranceTravail, ainsi que données d'identité de contact.
         **Paramètres d'appel :** Nom d’utilisateur France Travail choisi par le particulier lors de la création de son espace personnel en ligne
-        **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_pole_emploi_statut)
+        **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_pole_emploi_statut)
       responses:
         '401':
           description: Non autorisé

--- a/site/config/api-particulier-openapi.yml
+++ b/site/config/api-particulier-openapi.yml
@@ -23,7 +23,7 @@ info:
 
     Pour récupérer le jeton de production un portail développeur est mis à votre disposition à l'adresse suivante : [https://particulier.api.gouv.fr/compte](https://particulier.api.gouv.fr/compte)
 
-    Pour effectuer vos tests sur le bac à sable, référez-vous à ce dépôt github: [etalab/siade_staging_data](https://github.com/etalab/siade_staging_data/) (l'ancien système basé sur Airtable n'est plus maintenu et va être remplacé par le nouveau système). Un jeton nommé default est disponible ici: [tokens](https://github.com/etalab/siade_staging_data/tree/develop/tokens)
+    Pour effectuer vos tests sur le bac à sable, référez-vous à ce dépôt github: [datagouv/apistration](https://github.com/datagouv/apistration/tree/develop/mocks/) (l'ancien système basé sur Airtable n'est plus maintenu et va être remplacé par le nouveau système). Un jeton nommé default est disponible ici: [tokens](https://github.com/datagouv/apistration/tree/develop/mocks/tokens)
 
     ### Accéder à la version 3 de l'API
 
@@ -719,7 +719,7 @@ paths:
         \n\n Retourne également des informations sur les dates d'ouverture des droits.
         \n Pour plus d'informations sur cette API et obtenir un accès en avant-première,
         veuillez contacter l'équipe API Particulier. \n **Données disponibles en bac
-        à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/complementaire_sante_solidaire)
+        à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/complementaire_sante_solidaire)
         \n L'API peut être appellée avec les données identité pivot ou avec un jeton
         FranceConnect."
       responses:
@@ -1279,7 +1279,7 @@ paths:
       description: "Quotient familial et composition de la famille d'un allocataire
         du régime agricole (régime général à venir). \n Pour plus d'informations sur
         cette API et obtenir un accès en avant-première, veuillez contacter l'équipe
-        API Particulier. \n **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_cnav_quotient_familial_v2)
+        API Particulier. \n **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_cnav_quotient_familial_v2)
         \n L'API peut être appellée avec les données identité pivot ou avec un jeton
         FranceConnect."
       responses:
@@ -2310,7 +2310,7 @@ paths:
 
         **Paramètres d'appel :** numéro d'allocataire et code postal
 
-        **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_cnaf_quotient_familial)
+        **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_cnaf_quotient_familial)
       parameters:
       - name: Cache-Control
         in: header
@@ -2566,7 +2566,7 @@ paths:
       description: |-
         Données d'identité, de contact et de statut du demandeur d'emploi.
         **Paramètres d'appel :** Nom d’utilisateur France Travail choisi par le particulier lors de la création de son espace personnel en ligne
-        **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_pole_emploi_statut)
+        **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_pole_emploi_statut)
       parameters:
       - name: identifiant
         required: true
@@ -2875,7 +2875,7 @@ paths:
          - INE, l'identifiant national étudiant ;
          - l'état civil de l'étudiant: nom, prénom, date de naissance, sexe et lieu de naissance.
 
-        **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_mesri_student_status)
+        **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_mesri_student_status)
       security:
       - franceConnectToken: []
         apiKey: []
@@ -3060,7 +3060,7 @@ paths:
          - INE, l'identifiant national étudiant ;
          - l'état civil de l'étudiant: nom, prénom, date de naissance, sexe (optionnel) et lieu de naissance (optionnel).
 
-        **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_cnous_student_scholarship)
+        **Données disponibles en bac à sable :** [liste](https://github.com/datagouv/apistration/blob/develop/mocks/payloads/api_particulier_v2_cnous_student_scholarship)
       security:
       - franceConnectToken: []
         apiKey: []

--- a/site/config/locales/api_entreprise/documentation.fr.yml
+++ b/site/config/locales/api_entreprise/documentation.fr.yml
@@ -323,13 +323,13 @@ fr:
 
                   - **Une URL :** L''environnement de staging est appelable avec `https://staging.entreprise.api.gouv.fr`.
 
-                  - **Les jetons d'accès** : Pour être fidèle au fonctionnement de l'API en production, cet environnement de test nécessite aussi un jeton d'accès, mais celui-ci, contrairement aux [jetons de production](#récupérer-le-jeton-jwt), est public car la donnée renvoyée en bac à sable est fictive. Un jeton ayant tous les droits est accessible [ici](https://github.com/etalab/siade_staging_data/blob/develop/tokens/default){:target="_blank"}. Pour générer un jeton spécifique, veuillez vous référer à ce [tutoriel](https://github.com/etalab/siade_staging_data/tree/develop/tokens){:target="_blank"}.
+                  - **Les jetons d'accès** : Pour être fidèle au fonctionnement de l'API en production, cet environnement de test nécessite aussi un jeton d'accès, mais celui-ci, contrairement aux [jetons de production](#récupérer-le-jeton-jwt), est public car la donnée renvoyée en bac à sable est fictive. Un jeton ayant tous les droits est accessible [ici](https://github.com/datagouv/apistration/blob/develop/mocks/tokens/default){:target="_blank"}. Pour générer un jeton spécifique, veuillez vous référer à ce [tutoriel](https://github.com/datagouv/apistration/tree/develop/mocks/tokens){:target="_blank"}.
                   
-                  - **Les données fictives de réponse :** Les données retournées par cet environnement de test sont totalement fictives et disponibles depuis [ce dépôt](https://github.com/etalab/siade_staging_data/tree/develop/payloads){:target="_blank"}.
+                  - **Les données fictives de réponse :** Les données retournées par cet environnement de test sont totalement fictives et disponibles depuis [ce dépôt](https://github.com/datagouv/apistration/tree/develop/mocks/payloads){:target="_blank"}.
 
                   - **Pour rappel, le fichier OpenAPI est disponible depuis le [swagger](<%= developers_openapi_path %>)**, avec le bouton "Download" situé en début de page.
 
-                  **Pour en savoir plus, veuillez consulter le [README du dépôt Github](https://github.com/etalab/siade_staging_data){:target="_blank"}.**
+                  **Pour en savoir plus, veuillez consulter le [README du dépôt Github](https://github.com/datagouv/apistration/tree/develop/mocks){:target="_blank"}.**
 
               - title: Récupérer le jeton JWT&nbsp;🔑
                 anchor: 'récupérer-le-jeton-jwt'

--- a/site/config/locales/api_particulier/documentation.fr.yml
+++ b/site/config/locales/api_particulier/documentation.fr.yml
@@ -556,15 +556,15 @@ fr:
 
                   - **Une URL :** L''environnement de staging est appelable avec `https://staging.particulier.api.gouv.fr`.
 
-                  - **Les jetons d'accès** : Pour être fidèle au fonctionnement de l'API en production, cet environnement de test nécessite aussi un jeton d'accès, mais celui-ci, contrairement aux [jetons de production](#récupérer-le-jeton-jwt), est public car la donnée renvoyée en bac à sable est fictive. Un jeton ayant tous les droits est accessible [ici](https://github.com/etalab/siade_staging_data/blob/develop/tokens/default){:target="_blank"}. Pour générer un jeton spécifique, veuillez vous référer à ce [tutoriel](https://github.com/etalab/siade_staging_data/tree/develop/tokens){:target="_blank"}.
+                  - **Les jetons d'accès** : Pour être fidèle au fonctionnement de l'API en production, cet environnement de test nécessite aussi un jeton d'accès, mais celui-ci, contrairement aux [jetons de production](#récupérer-le-jeton-jwt), est public car la donnée renvoyée en bac à sable est fictive. Un jeton ayant tous les droits est accessible [ici](https://github.com/datagouv/apistration/blob/develop/mocks/tokens/default){:target="_blank"}. Pour générer un jeton spécifique, veuillez vous référer à ce [tutoriel](https://github.com/datagouv/apistration/tree/develop/mocks/tokens){:target="_blank"}.
 
                   - **Les paramètres d'appel** : Chaque cas de test documente les paramètres d'appel nécessaires. Vous pouvez aussi tester l'API avec la [modalité d'appel FranceConnect](<%= cas_usages_path(uid:'modalite_appel_france_connect') %>) en utilisant de faux jetons FranceConnect fournis dans le staging.
 
-                  - **Les données fictives de réponse :** Les données retournées par cet environnement de test sont totalement fictives et disponibles depuis [ce dépôt](https://github.com/etalab/siade_staging_data/tree/develop/payloads){:target="_blank"}.
+                  - **Les données fictives de réponse :** Les données retournées par cet environnement de test sont totalement fictives et disponibles depuis [ce dépôt](https://github.com/datagouv/apistration/tree/develop/mocks/payloads){:target="_blank"}.
 
                   - **Pour rappel, le fichier OpenAPI est disponible depuis le [swagger](<%= developers_openapi_path %>)**, avec le bouton "Download" situé en début de page.
 
-                  **Pour en savoir plus, veuillez consulter le [README du dépôt Github](https://github.com/etalab/siade_staging_data){:target="_blank"}.**
+                  **Pour en savoir plus, veuillez consulter le [README du dépôt Github](https://github.com/datagouv/apistration/tree/develop/mocks){:target="_blank"}.**
 
 
               - title: Récupérer le jeton JWT&nbsp;🔑

--- a/site/spec/models/api_particulier/endpoint_v2_spec.rb
+++ b/site/spec/models/api_particulier/endpoint_v2_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe APIParticulier::EndpointV2 do
   describe '#test_cases_external_url' do
     subject { described_class.find(uid).test_cases_external_url }
 
-    it { is_expected.to eq('https://github.com/etalab/siade_staging_data/tree/develop/payloads/api_particulier_v2_cnav_quotient_familial_v2') }
+    it { is_expected.to eq('https://github.com/datagouv/apistration/tree/develop/mocks/payloads/api_particulier_v2_cnav_quotient_familial_v2') }
   end
 
   describe '#redoc_anchor' do

--- a/site/spec/support/shared_examples/models/endpoint.rb
+++ b/site/spec/support/shared_examples/models/endpoint.rb
@@ -45,7 +45,7 @@ RSpec.shared_examples 'an endpoint model' do |uid_method, opts = {}|
   describe '#test_cases_external_url' do
     subject { described_class.find(default_uid).test_cases_external_url }
 
-    it { is_expected.to match(%r{https://github.com/etalab/siade_staging_data/tree/develop/payloads/}) }
+    it { is_expected.to match(%r{https://github.com/datagouv/apistration/tree/develop/mocks/payloads/}) }
   end
 
   describe '#redoc_anchor' do


### PR DESCRIPTION
Now that mocks live in this monorepo, all GitHub links (tree, blob, raw.githubusercontent) point to datagouv/apistration/…/mocks/ instead of the former etalab/siade_staging_data repository. 