### PR TITLE
Fix: memoize per-request file reads to prevent EBADF on Puma workers

### DIFF
--- a/siade/app/builders/mcp_resource_description_builder.rb
+++ b/siade/app/builders/mcp_resource_description_builder.rb
@@ -8,7 +8,9 @@ class MCPResourceDescriptionBuilder < ApplicationBuilder
   end
 
   def self.resources_config
-    @resources_config ||= Rails.application.config_for('mcp/resources').deep_stringify_keys
+    AppConfig.fetch('mcp/resources#stringify_keys') do
+      Rails.application.config_for('mcp/resources').deep_stringify_keys
+    end
   end
 
   protected

--- a/siade/app/builders/mcp_resource_description_builder.rb
+++ b/siade/app/builders/mcp_resource_description_builder.rb
@@ -7,6 +7,10 @@ class MCPResourceDescriptionBuilder < ApplicationBuilder
     @swagger_data = swagger['paths'][resource_data[:url_path]]
   end
 
+  def self.resources_config
+    @resources_config ||= Rails.application.config_for('mcp/resources').deep_stringify_keys
+  end
+
   protected
 
   def tool_name
@@ -44,6 +48,6 @@ class MCPResourceDescriptionBuilder < ApplicationBuilder
   end
 
   def extract_resource_data(tool_name)
-    Rails.application.config_for('mcp/resources').deep_stringify_keys[tool_name]
+    self.class.resources_config[tool_name]
   end
 end

--- a/siade/app/controllers/concerns/handle_ping_providers.rb
+++ b/siade/app/controllers/concerns/handle_ping_providers.rb
@@ -45,7 +45,7 @@ module HandlePingProviders
   end
 
   def valid_pings
-    Rails.application.config_for(:pings)[api_kind].each_with_object([]) do |(provider, config), result|
+    PingService.config[api_kind].each_with_object([]) do |(provider, config), result|
       next unless config[:status_page].present? && config[:status_page][:name].present?
 
       result << {
@@ -56,7 +56,7 @@ module HandlePingProviders
   end
 
   def provider_exists?
-    Rails.application.config_for(:pings)[api_kind].key?(provider_param.to_sym)
+    PingService.config[api_kind].key?(provider_param.to_sym)
   end
 
   def ping_url(provider)

--- a/siade/app/extractors/qualibat_certifications_batiment/insurances_extractor.rb
+++ b/siade/app/extractors/qualibat_certifications_batiment/insurances_extractor.rb
@@ -4,7 +4,7 @@ class QUALIBATCertificationsBatiment::InsurancesExtractor < PDFExtractor
   end
 
   def self.insurances_names
-    @insurances_names ||= Rails.application.config_for('qualibat/insurance_names')
+    AppConfig.config_for('qualibat/insurance_names')
   end
 
   private

--- a/siade/app/extractors/qualibat_certifications_batiment/insurances_extractor.rb
+++ b/siade/app/extractors/qualibat_certifications_batiment/insurances_extractor.rb
@@ -3,6 +3,10 @@ class QUALIBATCertificationsBatiment::InsurancesExtractor < PDFExtractor
     @extract ||= assurances
   end
 
+  def self.insurances_names
+    @insurances_names ||= Rails.application.config_for('qualibat/insurance_names')
+  end
+
   private
 
   def assurances
@@ -76,6 +80,6 @@ class QUALIBATCertificationsBatiment::InsurancesExtractor < PDFExtractor
   end
 
   def insurances_names
-    Rails.application.config_for('qualibat/insurance_names')
+    self.class.insurances_names
   end
 end

--- a/siade/app/interactors/ants/extrait_immatriculation_vehicule/build_resource.rb
+++ b/siade/app/interactors/ants/extrait_immatriculation_vehicule/build_resource.rb
@@ -1,4 +1,28 @@
 class ANTS::ExtraitImmatriculationVehicule::BuildResource < BuildResource
+  def self.categorie_vehicule_labels
+    @categorie_vehicule_labels ||= load_yaml_data('ants/categorie_vehicule_labels.yml')
+  end
+
+  def self.genre_national_labels
+    @genre_national_labels ||= load_yaml_data('ants/genre_national_labels.yml')
+  end
+
+  def self.type_carburant_labels
+    @type_carburant_labels ||= load_yaml_data('ants/type_carburant_labels.yml')
+  end
+
+  def self.classe_environnementale_labels
+    @classe_environnementale_labels ||= load_yaml_data('ants/classe_environnementale_labels.yml')
+  end
+
+  def self.classe_environnementale_code_mappings
+    @classe_environnementale_code_mappings ||= load_yaml_data('ants/classe_environnementale_code_mappings.yml')
+  end
+
+  def self.load_yaml_data(file_path)
+    YAML.load_file(Rails.root.join('config', 'data', file_path)).freeze
+  end
+
   protected
 
   def resource_attributes
@@ -121,26 +145,22 @@ class ANTS::ExtraitImmatriculationVehicule::BuildResource < BuildResource
   end
 
   def categorie_vehicule_labels
-    @categorie_vehicule_labels ||= load_yaml_data('ants/categorie_vehicule_labels.yml')
+    self.class.categorie_vehicule_labels
   end
 
   def genre_national_labels
-    @genre_national_labels ||= load_yaml_data('ants/genre_national_labels.yml')
+    self.class.genre_national_labels
   end
 
   def type_carburant_labels
-    @type_carburant_labels ||= load_yaml_data('ants/type_carburant_labels.yml')
+    self.class.type_carburant_labels
   end
 
   def classe_environnementale_labels
-    @classe_environnementale_labels ||= load_yaml_data('ants/classe_environnementale_labels.yml')
+    self.class.classe_environnementale_labels
   end
 
   def classe_environnementale_code_mappings
-    @classe_environnementale_code_mappings ||= load_yaml_data('ants/classe_environnementale_code_mappings.yml')
-  end
-
-  def load_yaml_data(file_path)
-    YAML.load_file(Rails.root.join('config', 'data', file_path))
+    self.class.classe_environnementale_code_mappings
   end
 end

--- a/siade/app/interactors/ants/extrait_immatriculation_vehicule/build_resource.rb
+++ b/siade/app/interactors/ants/extrait_immatriculation_vehicule/build_resource.rb
@@ -1,26 +1,26 @@
 class ANTS::ExtraitImmatriculationVehicule::BuildResource < BuildResource
   def self.categorie_vehicule_labels
-    @categorie_vehicule_labels ||= load_yaml_data('ants/categorie_vehicule_labels.yml')
+    load_yaml_data('ants/categorie_vehicule_labels.yml')
   end
 
   def self.genre_national_labels
-    @genre_national_labels ||= load_yaml_data('ants/genre_national_labels.yml')
+    load_yaml_data('ants/genre_national_labels.yml')
   end
 
   def self.type_carburant_labels
-    @type_carburant_labels ||= load_yaml_data('ants/type_carburant_labels.yml')
+    load_yaml_data('ants/type_carburant_labels.yml')
   end
 
   def self.classe_environnementale_labels
-    @classe_environnementale_labels ||= load_yaml_data('ants/classe_environnementale_labels.yml')
+    load_yaml_data('ants/classe_environnementale_labels.yml')
   end
 
   def self.classe_environnementale_code_mappings
-    @classe_environnementale_code_mappings ||= load_yaml_data('ants/classe_environnementale_code_mappings.yml')
+    load_yaml_data('ants/classe_environnementale_code_mappings.yml')
   end
 
   def self.load_yaml_data(file_path)
-    YAML.load_file(Rails.root.join('config', 'data', file_path)).freeze
+    AppConfig.yaml_file(Rails.root.join('config', 'data', file_path))
   end
 
   protected

--- a/siade/app/interactors/dgfip/liasses_fiscales/retrieve_dictionary_from_cache_or_remote.rb
+++ b/siade/app/interactors/dgfip/liasses_fiscales/retrieve_dictionary_from_cache_or_remote.rb
@@ -9,7 +9,7 @@ class DGFIP::LiassesFiscales::RetrieveDictionaryFromCacheOrRemote < ApplicationI
   end
 
   def self.features_config
-    @features_config ||= Rails.application.config_for(:features)
+    AppConfig.config_for(:features)
   end
 
   private

--- a/siade/app/interactors/dgfip/liasses_fiscales/retrieve_dictionary_from_cache_or_remote.rb
+++ b/siade/app/interactors/dgfip/liasses_fiscales/retrieve_dictionary_from_cache_or_remote.rb
@@ -8,6 +8,10 @@ class DGFIP::LiassesFiscales::RetrieveDictionaryFromCacheOrRemote < ApplicationI
     handle_errors
   end
 
+  def self.features_config
+    @features_config ||= Rails.application.config_for(:features)
+  end
+
   private
 
   def affect_dictionary_from_retriever
@@ -88,7 +92,7 @@ class DGFIP::LiassesFiscales::RetrieveDictionaryFromCacheOrRemote < ApplicationI
   end
 
   def load_local_dgfip_dictionnaries?
-    Rails.application.config_for(:features)[:load_local_dgfip_dictionnaries]
+    self.class.features_config[:load_local_dgfip_dictionnaries]
   end
 
   def expires_in

--- a/siade/app/interactors/inpi/rne/extrait_rne/concerns/data_formatters.rb
+++ b/siade/app/interactors/inpi/rne/extrait_rne/concerns/data_formatters.rb
@@ -119,13 +119,8 @@ module INPI::RNE::ExtraitRNE::Concerns::DataFormatters
   def get_code_from_config(config_key, code, fallback)
     return fallback if code.blank?
 
-    config_value = INPI::RNE::ExtraitRNE::Concerns::DataFormatters.cached_config(config_key)[code]
+    config_value = AppConfig.config_for(config_key)[code]
     config_value || fallback
-  end
-
-  def self.cached_config(config_key)
-    @cached_configs ||= {}
-    @cached_configs[config_key] ||= Rails.application.config_for(config_key)
   end
 
   def get_origine_fonds(activite)

--- a/siade/app/interactors/inpi/rne/extrait_rne/concerns/data_formatters.rb
+++ b/siade/app/interactors/inpi/rne/extrait_rne/concerns/data_formatters.rb
@@ -119,8 +119,13 @@ module INPI::RNE::ExtraitRNE::Concerns::DataFormatters
   def get_code_from_config(config_key, code, fallback)
     return fallback if code.blank?
 
-    config_value = Rails.application.config_for(config_key)[code]
+    config_value = INPI::RNE::ExtraitRNE::Concerns::DataFormatters.cached_config(config_key)[code]
     config_value || fallback
+  end
+
+  def self.cached_config(config_key)
+    @cached_configs ||= {}
+    @cached_configs[config_key] ||= Rails.application.config_for(config_key)
   end
 
   def get_origine_fonds(activite)

--- a/siade/app/interactors/insee/adresse_etablissement/build_resource.rb
+++ b/siade/app/interactors/insee/adresse_etablissement/build_resource.rb
@@ -1,10 +1,10 @@
 class INSEE::AdresseEtablissement::BuildResource < INSEE::Etablissement::BuildResource
   def self.types_de_voie
-    @types_de_voie ||= YAML.load_file(Rails.root.join('config/data/insee/types_de_voie.yml')).freeze
+    AppConfig.yaml_file(Rails.root.join('config/data/insee/types_de_voie.yml'))
   end
 
   def self.indices_repetition_de_voie
-    @indices_repetition_de_voie ||= YAML.load_file(Rails.root.join('config/data/insee/indices_repetition_de_voie.yml')).freeze
+    AppConfig.yaml_file(Rails.root.join('config/data/insee/indices_repetition_de_voie.yml'))
   end
 
   protected

--- a/siade/app/interactors/insee/adresse_etablissement/build_resource.rb
+++ b/siade/app/interactors/insee/adresse_etablissement/build_resource.rb
@@ -1,4 +1,12 @@
 class INSEE::AdresseEtablissement::BuildResource < INSEE::Etablissement::BuildResource
+  def self.types_de_voie
+    @types_de_voie ||= YAML.load_file(Rails.root.join('config/data/insee/types_de_voie.yml')).freeze
+  end
+
+  def self.indices_repetition_de_voie
+    @indices_repetition_de_voie ||= YAML.load_file(Rails.root.join('config/data/insee/indices_repetition_de_voie.yml')).freeze
+  end
+
   protected
 
   def resource_attributes
@@ -91,11 +99,11 @@ class INSEE::AdresseEtablissement::BuildResource < INSEE::Etablissement::BuildRe
   end
 
   def types_de_voie
-    @types_de_voie ||= YAML.load_file(Rails.root.join('config/data/insee/types_de_voie.yml'))
+    self.class.types_de_voie
   end
 
   def indices_repetition_de_voie
-    @indices_repetition_de_voie ||= YAML.load_file(Rails.root.join('config/data/insee/indices_repetition_de_voie.yml'))
+    self.class.indices_repetition_de_voie
   end
 
   def type_of_person

--- a/siade/app/models/scope.rb
+++ b/siade/app/models/scope.rb
@@ -8,6 +8,6 @@ class Scope
   end
 
   def self.config
-    @config ||= Rails.application.config_for(:authorizations)
+    AppConfig.config_for(:authorizations)
   end
 end

--- a/siade/app/services/app_config.rb
+++ b/siade/app/services/app_config.rb
@@ -1,0 +1,30 @@
+class AppConfig
+  @cache = {}
+  @mutex = Mutex.new
+
+  class << self
+    def fetch(key)
+      return @cache[key] if @cache.key?(key)
+
+      @mutex.synchronize do
+        @cache[key] ||= yield
+      end
+    end
+
+    def config_for(key)
+      fetch(key) { Rails.application.config_for(key) }
+    end
+
+    def yaml_file(path, **)
+      fetch(path.to_s) { YAML.load_file(path, **).freeze }
+    end
+
+    def reset!
+      @mutex.synchronize { @cache.clear }
+    end
+
+    def reset(key)
+      @mutex.synchronize { @cache.delete(key) }
+    end
+  end
+end

--- a/siade/app/services/data_encryptor.rb
+++ b/siade/app/services/data_encryptor.rb
@@ -11,6 +11,10 @@ class DataEncryptor
     crypto.decrypt(GPGME::Data.new(@data), decrypt_options)
   end
 
+  def self.signer_info
+    @signer_info ||= Rails.application.config_for(:encrypt_data_signer_data)
+  end
+
   private
 
   def crypto
@@ -53,6 +57,6 @@ class DataEncryptor
   end
 
   def signer_info
-    Rails.application.config_for(:encrypt_data_signer_data)
+    self.class.signer_info
   end
 end

--- a/siade/app/services/data_encryptor.rb
+++ b/siade/app/services/data_encryptor.rb
@@ -12,7 +12,7 @@ class DataEncryptor
   end
 
   def self.signer_info
-    @signer_info ||= Rails.application.config_for(:encrypt_data_signer_data)
+    AppConfig.config_for(:encrypt_data_signer_data)
   end
 
   private

--- a/siade/app/services/maintenance_service.rb
+++ b/siade/app/services/maintenance_service.rb
@@ -37,6 +37,10 @@ class MaintenanceService
     end
   end
 
+  def self.config
+    @config ||= Rails.application.config_for(:maintenances)
+  end
+
   private
 
   def valid_date?
@@ -100,6 +104,6 @@ class MaintenanceService
   end
 
   def config
-    Rails.application.config_for(:maintenances)
+    self.class.config
   end
 end

--- a/siade/app/services/maintenance_service.rb
+++ b/siade/app/services/maintenance_service.rb
@@ -38,7 +38,7 @@ class MaintenanceService
   end
 
   def self.config
-    @config ||= Rails.application.config_for(:maintenances)
+    AppConfig.config_for(:maintenances)
   end
 
   private

--- a/siade/app/services/mock_service.rb
+++ b/siade/app/services/mock_service.rb
@@ -31,8 +31,7 @@ class MockService
   end
 
   def self.open_api_schema(schema_path)
-    @open_api_schemas ||= {}
-    @open_api_schemas[schema_path.to_s] ||= YAML.load_file(schema_path, aliases: true, permitted_classes: [Date])
+    AppConfig.yaml_file(schema_path, aliases: true, permitted_classes: [Date])
   end
 
   private

--- a/siade/app/services/mock_service.rb
+++ b/siade/app/services/mock_service.rb
@@ -30,6 +30,11 @@ class MockService
     }
   end
 
+  def self.open_api_schema(schema_path)
+    @open_api_schemas ||= {}
+    @open_api_schemas[schema_path.to_s] ||= YAML.load_file(schema_path, aliases: true, permitted_classes: [Date])
+  end
+
   private
 
   def mock_404
@@ -49,7 +54,7 @@ class MockService
   end
 
   def open_api_schema
-    YAML.load_file(schema_path, aliases: true, permitted_classes: [Date])
+    self.class.open_api_schema(schema_path)
   end
 
   def schema_path

--- a/siade/app/services/ping_service.rb
+++ b/siade/app/services/ping_service.rb
@@ -16,6 +16,10 @@ class PingService
     data
   end
 
+  def self.config
+    @config ||= Rails.application.config_for(:pings)
+  end
+
   private
 
   def data
@@ -134,6 +138,6 @@ class PingService
   end
 
   def pings_global_config
-    Rails.application.config_for(:pings)[api_kind]
+    self.class.config[api_kind]
   end
 end

--- a/siade/app/services/ping_service.rb
+++ b/siade/app/services/ping_service.rb
@@ -17,7 +17,7 @@ class PingService
   end
 
   def self.config
-    @config ||= Rails.application.config_for(:pings)
+    AppConfig.config_for(:pings)
   end
 
   private

--- a/siade/app/services/redis_service.rb
+++ b/siade/app/services/redis_service.rb
@@ -31,7 +31,7 @@ class RedisService
   # rubocop:enable Naming/MethodParameterName
 
   def self.redis_options
-    @redis_options ||= Rails.application.config_for(:redis)
+    AppConfig.config_for(:redis)
   end
 
   private

--- a/siade/app/services/redis_service.rb
+++ b/siade/app/services/redis_service.rb
@@ -30,6 +30,10 @@ class RedisService
   end
   # rubocop:enable Naming/MethodParameterName
 
+  def self.redis_options
+    @redis_options ||= Rails.application.config_for(:redis)
+  end
+
   private
 
   def safe_run(command, *)
@@ -43,7 +47,7 @@ class RedisService
   end
 
   def redis_options
-    Rails.application.config_for(:redis)
+    self.class.redis_options
   end
 
   def redis_errors

--- a/siade/lib/referentials/activite_principale.rb
+++ b/siade/lib/referentials/activite_principale.rb
@@ -18,6 +18,29 @@ class Referentials::ActivitePrincipale
     }
   end
 
+  def self.naf2025
+    @naf2025 ||= CSV.read(
+      Rails.root.join('lib/referentials/files/NAF2025.csv'),
+      headers: true,
+      col_sep: ','
+    ).each_with_object({}) { |row, acc|
+      key = row[1]&.strip
+      acc[key] = row[2]&.strip if key
+    }.freeze
+  end
+
+  def self.nafrev2
+    @nafrev2 ||= CSV.read(
+      Rails.root.join('lib/referentials/files/NAFRev2.csv'),
+      headers: true,
+      col_sep: ','
+    ).each_with_object({}) { |row, acc|
+      data = row.to_hash.symbolize_keys
+      key = data[:Code]&.strip
+      acc[key] = data[:' Intitulés de la  NAF rév. 2, version finale ']&.strip if key
+    }.freeze
+  end
+
   private
 
   def libelle
@@ -27,28 +50,9 @@ class Referentials::ActivitePrincipale
   def find_libelle
     case @nomenclature
     when 'NAF2025'
-      find_libelle_naf2025
+      self.class.naf2025[@code]
     when 'NAFRev2'
-      find_libelle_nafrev2
+      self.class.nafrev2[@code]
     end
-  end
-
-  def find_libelle_naf2025
-    CSV.foreach(csv_path('NAF2025.csv'), headers: true, col_sep: ',') do |row|
-      return row[2]&.strip if row[1]&.strip == @code
-    end
-    nil
-  end
-
-  def find_libelle_nafrev2
-    CSV.foreach(csv_path('NAFRev2.csv'), headers: true, col_sep: ',') do |row|
-      data = row.to_hash.symbolize_keys
-      return data[:' Intitulés de la  NAF rév. 2, version finale ']&.strip if data[:Code]&.strip == @code
-    end
-    nil
-  end
-
-  def csv_path(filename)
-    Rails.root.join("lib/referentials/files/#{filename}")
   end
 end

--- a/siade/lib/referentials/activite_principale.rb
+++ b/siade/lib/referentials/activite_principale.rb
@@ -19,26 +19,30 @@ class Referentials::ActivitePrincipale
   end
 
   def self.naf2025
-    @naf2025 ||= CSV.read(
-      Rails.root.join('lib/referentials/files/NAF2025.csv'),
-      headers: true,
-      col_sep: ','
-    ).each_with_object({}) { |row, acc|
-      key = row[1]&.strip
-      acc[key] = row[2]&.strip if key
-    }.freeze
+    AppConfig.fetch(:referentials_activite_principale_naf2025) do
+      CSV.read(
+        Rails.root.join('lib/referentials/files/NAF2025.csv'),
+        headers: true,
+        col_sep: ','
+      ).each_with_object({}) { |row, acc|
+        key = row[1]&.strip
+        acc[key] = row[2]&.strip if key
+      }.freeze
+    end
   end
 
   def self.nafrev2
-    @nafrev2 ||= CSV.read(
-      Rails.root.join('lib/referentials/files/NAFRev2.csv'),
-      headers: true,
-      col_sep: ','
-    ).each_with_object({}) { |row, acc|
-      data = row.to_hash.symbolize_keys
-      key = data[:Code]&.strip
-      acc[key] = data[:' Intitulés de la  NAF rév. 2, version finale ']&.strip if key
-    }.freeze
+    AppConfig.fetch(:referentials_activite_principale_nafrev2) do
+      CSV.read(
+        Rails.root.join('lib/referentials/files/NAFRev2.csv'),
+        headers: true,
+        col_sep: ','
+      ).each_with_object({}) { |row, acc|
+        data = row.to_hash.symbolize_keys
+        key = data[:Code]&.strip
+        acc[key] = data[:' Intitulés de la  NAF rév. 2, version finale ']&.strip if key
+      }.freeze
+    end
   end
 
   private

--- a/siade/lib/referentials/categorie_juridique.rb
+++ b/siade/lib/referentials/categorie_juridique.rb
@@ -38,18 +38,21 @@ class Referentials::CategorieJuridique
     }
   end
 
+  def self.table
+    @table ||= CSV.read(
+      Rails.root.join('lib/referentials/files/categorie_juridique.csv'),
+      headers: true
+    ).each_with_object({}) { |row, acc|
+      hash = row.to_hash.symbolize_keys
+      acc[hash[:Code]] = hash if hash[:Code]
+    }.freeze
+  end
+
   private
 
   def result
     return unless valid?
 
-    @result ||= CSV.foreach(file_name, headers: true) do |row|
-      hash = row.to_hash.symbolize_keys
-      return hash if hash[:Code] == @code
-    end
-  end
-
-  def file_name
-    Rails.root.join('lib/referentials/files/categorie_juridique.csv')
+    self.class.table[@code]
   end
 end

--- a/siade/lib/referentials/categorie_juridique.rb
+++ b/siade/lib/referentials/categorie_juridique.rb
@@ -39,13 +39,15 @@ class Referentials::CategorieJuridique
   end
 
   def self.table
-    @table ||= CSV.read(
-      Rails.root.join('lib/referentials/files/categorie_juridique.csv'),
-      headers: true
-    ).each_with_object({}) { |row, acc|
-      hash = row.to_hash.symbolize_keys
-      acc[hash[:Code]] = hash if hash[:Code]
-    }.freeze
+    AppConfig.fetch(:referentials_categorie_juridique) do
+      CSV.read(
+        Rails.root.join('lib/referentials/files/categorie_juridique.csv'),
+        headers: true
+      ).each_with_object({}) { |row, acc|
+        hash = row.to_hash.symbolize_keys
+        acc[hash[:Code]] = hash if hash[:Code]
+      }.freeze
+    end
   end
 
   private

--- a/siade/lib/referentials/tranche_effectif_salarie.rb
+++ b/siade/lib/referentials/tranche_effectif_salarie.rb
@@ -59,13 +59,15 @@ class Referentials::TrancheEffectifSalarie
   end
 
   def self.table
-    @table ||= CSV.read(
-      Rails.root.join('lib/referentials/files/tranche_effectif_salarie.csv'),
-      headers: true
-    ).each_with_object({}) { |row, acc|
-      hash = row.to_hash.symbolize_keys
-      acc[hash[:code]] = hash if hash[:code]
-    }.freeze
+    AppConfig.fetch(:referentials_tranche_effectif_salarie) do
+      CSV.read(
+        Rails.root.join('lib/referentials/files/tranche_effectif_salarie.csv'),
+        headers: true
+      ).each_with_object({}) { |row, acc|
+        hash = row.to_hash.symbolize_keys
+        acc[hash[:code]] = hash if hash[:code]
+      }.freeze
+    end
   end
 
   private

--- a/siade/lib/referentials/tranche_effectif_salarie.rb
+++ b/siade/lib/referentials/tranche_effectif_salarie.rb
@@ -58,18 +58,21 @@ class Referentials::TrancheEffectifSalarie
     }
   end
 
+  def self.table
+    @table ||= CSV.read(
+      Rails.root.join('lib/referentials/files/tranche_effectif_salarie.csv'),
+      headers: true
+    ).each_with_object({}) { |row, acc|
+      hash = row.to_hash.symbolize_keys
+      acc[hash[:code]] = hash if hash[:code]
+    }.freeze
+  end
+
   private
 
   def result
     return unless valid?
 
-    @result ||= CSV.foreach(file_name, headers: true).find do |row|
-      hash = row.to_hash.symbolize_keys
-      return hash if hash[:code] == @code
-    end
-  end
-
-  def file_name
-    Rails.root.join('lib/referentials/files/tranche_effectif_salarie.csv')
+    self.class.table[@code]
   end
 end

--- a/siade/spec/interactors/dgfip/liasses_fiscales/retrieve_dictionary_from_cache_or_remote_spec.rb
+++ b/siade/spec/interactors/dgfip/liasses_fiscales/retrieve_dictionary_from_cache_or_remote_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe DGFIP::LiassesFiscales::RetrieveDictionaryFromCacheOrRemote, type
 
   before do
     mock_valid_dgfip_dictionnaire(2019)
+    described_class.instance_variable_set(:@features_config, nil)
+  end
+
+  after do
+    described_class.instance_variable_set(:@features_config, nil)
   end
 
   describe 'happy path' do

--- a/siade/spec/interactors/dgfip/liasses_fiscales/retrieve_dictionary_from_cache_or_remote_spec.rb
+++ b/siade/spec/interactors/dgfip/liasses_fiscales/retrieve_dictionary_from_cache_or_remote_spec.rb
@@ -16,11 +16,11 @@ RSpec.describe DGFIP::LiassesFiscales::RetrieveDictionaryFromCacheOrRemote, type
 
   before do
     mock_valid_dgfip_dictionnaire(2019)
-    described_class.instance_variable_set(:@features_config, nil)
+    AppConfig.reset(:features)
   end
 
   after do
-    described_class.instance_variable_set(:@features_config, nil)
+    AppConfig.reset(:features)
   end
 
   describe 'happy path' do

--- a/siade/spec/organizers/banque_de_france/bilans_entreprise_spec.rb
+++ b/siade/spec/organizers/banque_de_france/bilans_entreprise_spec.rb
@@ -60,8 +60,13 @@ RSpec.describe BanqueDeFrance::BilansEntreprise, type: :retriever_organizer do
       before do
         mock_valid_banque_de_france
 
+        DGFIP::LiassesFiscales::RetrieveDictionaryFromCacheOrRemote.instance_variable_set(:@features_config, nil)
         allow(Rails.application).to receive(:config_for).and_call_original
         allow(Rails.application).to receive(:config_for).with(:features).and_return(load_local_dgfip_dictionnaries: true)
+      end
+
+      after do
+        DGFIP::LiassesFiscales::RetrieveDictionaryFromCacheOrRemote.instance_variable_set(:@features_config, nil)
       end
 
       it { is_expected.to be_a_success }

--- a/siade/spec/organizers/banque_de_france/bilans_entreprise_spec.rb
+++ b/siade/spec/organizers/banque_de_france/bilans_entreprise_spec.rb
@@ -60,13 +60,13 @@ RSpec.describe BanqueDeFrance::BilansEntreprise, type: :retriever_organizer do
       before do
         mock_valid_banque_de_france
 
-        DGFIP::LiassesFiscales::RetrieveDictionaryFromCacheOrRemote.instance_variable_set(:@features_config, nil)
+        AppConfig.reset(:features)
         allow(Rails.application).to receive(:config_for).and_call_original
         allow(Rails.application).to receive(:config_for).with(:features).and_return(load_local_dgfip_dictionnaries: true)
       end
 
       after do
-        DGFIP::LiassesFiscales::RetrieveDictionaryFromCacheOrRemote.instance_variable_set(:@features_config, nil)
+        AppConfig.reset(:features)
       end
 
       it { is_expected.to be_a_success }


### PR DESCRIPTION
- Memoize all `config_for`, `YAML.load_file` and `CSV.foreach` calls that were re-reading files on every request. After Puma forks workers, inherited file descriptors become invalid, causing `Errno::EBADF` on GC finalizer flush (Sentry #285300, same root cause as a4f95b05).
- Extract `AppConfig` helper to centralize the per-process cache pattern and provide a clean `reset` hook for tests.
- Referentials CSV lookups now use O(1) hash lookups instead of linear scans.