### PR TITLE
Add 7-day cooldown to all dependabot update groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,8 @@ updates:
       day: "monday"
       time: "05:00"
       interval: "weekly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "bundler"
     groups:
       production-dependencies:
@@ -32,9 +34,13 @@ updates:
       day: "monday"
       time: "05:00"
       interval: "weekly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       day: "monday"
       time: "05:00"
       interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Wait at least 7 days after a new version release before proposing an update, mitigating supply chain attacks by letting time for compromised packages to be detected and pulled.

Ref: https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns