### PR TITLE
Fix duplicate token display on /compte/demandes

### DIFF
--- a/site/app/views/shared/authorization_requests/index.html.erb
+++ b/site/app/views/shared/authorization_requests/index.html.erb
@@ -51,25 +51,13 @@
               </span>
             </div>
             <div class="fr-col-12 fr-col-sm-4">
-              <% if authorization_request.token %>
-                <div id="<%= dom_id(authorization_request.token) %>">
-                  <%= render partial: 'shared/tokens/detail_short',
-                    locals: {
-                      token: authorization_request.token.decorate
-                    }
-                  %>
+              <% displayed_tokens = authorization_request.tokens.active.to_a %>
+              <% displayed_tokens = [authorization_request.token].compact if displayed_tokens.empty? %>
+              <% displayed_tokens.each_with_index do |token, index| %>
+                <div id="<%= dom_id(token) %>" class="<%= 'fr-pt-6v' if index.positive? %>">
+                  <%= render partial: 'shared/tokens/detail_short', locals: { token: token.decorate } %>
                 </div>
               <% end %>
-
-              <% authorization_request.tokens.blacklisted_later.decorate.each do |banned_token| %>
-                <div id="<%= dom_id(banned_token) %>" class="fr-pt-6v">
-                  <%= render partial: 'shared/tokens/detail_short',
-                    locals: {
-                      token: banned_token.decorate
-                    }
-                  %>
-                </div>
-            <% end %>
             </div>
             <div class="fr-col-12 fr-col-sm">
               <% authorization_request_expected_actions(authorization_request, current_user).each do |action| %>

--- a/site/spec/features/api_particulier/authorization_request_index_spec.rb
+++ b/site/spec/features/api_particulier/authorization_request_index_spec.rb
@@ -63,8 +63,8 @@ RSpec.describe 'displays authorization requests', app: :api_particulier do
         ]
       end
 
-      let!(:token_active) { create(:token, authorization_request:, exp: 70.days.from_now) }
       let!(:token_blacklisted_later) { create(:token, :blacklisted, blacklisted_at: 1.day.from_now, authorization_request:) }
+      let!(:token_active) { create(:token, authorization_request:, exp: 70.days.from_now) }
       let!(:authorization_request_active) do
         create(
           :authorization_request,


### PR DESCRIPTION
On the authorization requests index page, when a request had both an active token and a token scheduled for ban (`blacklisted_at` in the future), the banned token could be rendered twice and the valid one was hidden. The `active` scope includes `blacklisted_later` tokens (they remain usable until the ban date), so `has_one :active_token` arbitrarily returned either one — in practice the oldest, i.e. typically the banned one in production. That same token was then re-rendered by the dedicated `blacklisted_later` loop.

Simplification: iterate directly over `tokens.active` to display every usable token (valid + soon-to-be-banned), with a fallback on `authorization_request.token` to preserve the status display on archived, expired, or fully-banned requests.

The index spec is adjusted to create the `blacklisted_later` token before the active one, reproducing the production insertion order which would have caused the previous implementation to fail.