### PR TITLE
Bandeau d'annonce + maintenance ProConnect du 23/04

### DIFF
--- a/site/app/services/announcement_banner.rb
+++ b/site/app/services/announcement_banner.rb
@@ -1,0 +1,32 @@
+require 'singleton'
+
+class AnnouncementBanner
+  include Singleton
+
+  def active?
+    return false unless start_time && end_time
+
+    Time.zone.now.between?(start_time, end_time)
+  end
+
+  def title = config[:title]
+  def description = config[:description]
+
+  def start_time = parse(config[:start])
+  def end_time = parse(config[:end])
+
+  private
+
+  def parse(value)
+    return nil if value.blank?
+
+    Time.use_zone(Time.zone) do
+      parsed = Chronic.parse(value.to_s) or return nil
+      Time.zone.local(parsed.year, parsed.month, parsed.day, parsed.hour, parsed.min, parsed.sec)
+    end
+  end
+
+  def config
+    @config ||= Rails.application.config_for(:announcement_banner)
+  end
+end

--- a/site/app/views/layouts/api_entreprise/application.html.erb
+++ b/site/app/views/layouts/api_entreprise/application.html.erb
@@ -24,6 +24,7 @@
     <%= render partial: 'shared/development_warning' %>
     <%= render partial: 'shared/impersonate' %>
     <%= render partial: 'shared/matomo' %>
+    <%= render partial: 'shared/announcement_banner' %>
     <%= render partial: 'shared/api_entreprise/header' %>
 
     <% if content_for?(:no_container) %>

--- a/site/app/views/layouts/api_particulier/application.html.erb
+++ b/site/app/views/layouts/api_particulier/application.html.erb
@@ -24,6 +24,7 @@
     <%= render partial: 'shared/development_warning' %>
     <%= render partial: 'shared/impersonate' %>
     <%= render partial: 'shared/matomo' %>
+    <%= render partial: 'shared/announcement_banner' %>
     <%= render partial: 'shared/api_particulier/header' %>
 
     <% if content_for?(:no_container) %>

--- a/site/app/views/shared/_announcement_banner.html.erb
+++ b/site/app/views/shared/_announcement_banner.html.erb
@@ -1,0 +1,14 @@
+<% banner = AnnouncementBanner.instance %>
+<% if banner.active? %>
+  <div class="fr-notice fr-notice--info">
+    <div class="fr-container">
+      <div class="fr-notice__body">
+        <p>
+          <span class="fr-notice__title"><%= banner.title %></span>
+          <span class="fr-notice__desc"><%= banner.description %></span>
+        </p>
+        <button title="Masquer le message" onclick="const notice = this.parentNode.parentNode.parentNode; notice.parentNode.removeChild(notice)" type="button" class="fr-btn--close fr-btn">Masquer le message</button>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/site/config/announcement_banner.yml
+++ b/site/config/announcement_banner.yml
@@ -1,0 +1,5 @@
+shared:
+  start:
+  end:
+  title:
+  description:

--- a/site/config/announcement_banner.yml
+++ b/site/config/announcement_banner.yml
@@ -1,5 +1,10 @@
 shared:
-  start:
-  end:
-  title:
-  description:
+  start: "2026-04-22 00:00"
+  end: "2026-04-23 19:30"
+  title: "Maintenance ProConnect le jeudi 23 avril 2026 à 18h00"
+  description: "Une opération de maintenance sera effectuée par ProConnect,
+    le service de connexion à API Entreprise et API Particulier,
+    le jeudi 23 avril 2026 à partir de 18h00. Aucune connexion ne sera
+    possible alors, et ce pour une durée d’1h environ : nous vous
+    conseillons de ne pas utiliser le service durant ce laps de temps,
+    afin d’éviter tout désagrément."

--- a/site/docs/announcement_banner.md
+++ b/site/docs/announcement_banner.md
@@ -1,0 +1,24 @@
+# Bandeau d'annonce
+
+Bandeau DSFR `warning` (refermable) affiché sur toutes les pages
+d'API Entreprise et d'API Particulier, pour prévenir d'un événement
+temporaire (maintenance ProConnect, etc).
+
+## Utilisation
+
+Éditer [`config/announcement_banner.yml`](../config/announcement_banner.yml) :
+
+```yaml
+shared:
+  start: "2026-04-23 17:50"
+  end: "2026-04-23 19:30"
+  title: "Maintenance ProConnect ce soir à 18h"
+  description: "..."
+```
+
+Dates parsées par [Chronic](https://github.com/mojombo/chronic) :
+formats variés acceptés (`"2026-04-23 17:50"`, `"April 23 2026 at 6pm"`…),
+fuseau serveur (Paris).
+
+Le bandeau s'affiche uniquement entre `start` et `end`. Pour le
+désactiver sans redéployer : mettre `end` dans le passé.

--- a/site/spec/services/announcement_banner_spec.rb
+++ b/site/spec/services/announcement_banner_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+RSpec.describe AnnouncementBanner do
+  include ActiveSupport::Testing::TimeHelpers
+
+  subject(:banner) { described_class.instance }
+
+  let(:banner_config) do
+    {
+      start: '2026-04-23 14:00',
+      end: '2026-04-23 19:30',
+      title: 'Maintenance ProConnect ce soir à 18h',
+      description: 'Une opération de maintenance aura lieu ce soir.'
+    }
+  end
+
+  before do
+    banner.instance_variable_set(:@config, nil)
+    allow(Rails.application).to receive(:config_for).with(:announcement_banner).and_return(banner_config)
+  end
+
+  describe '#active?' do
+    subject { banner.active? }
+
+    context 'when current time is within the window' do
+      before { travel_to(Time.zone.parse('2026-04-23 16:00')) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when current time is before the window' do
+      before { travel_to(Time.zone.parse('2026-04-23 13:59')) }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when current time is after the window' do
+      before { travel_to(Time.zone.parse('2026-04-23 19:31')) }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when start and end are blank' do
+      let(:banner_config) { { start: nil, end: nil, title: nil, description: nil } }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#title' do
+    it { expect(banner.title).to eq('Maintenance ProConnect ce soir à 18h') }
+  end
+
+  describe '#description' do
+    it { expect(banner.description).to be_present }
+  end
+
+  describe 'config/announcement_banner.yml' do
+    before do
+      banner.instance_variable_set(:@config, nil)
+      allow(Rails.application).to receive(:config_for).with(:announcement_banner).and_call_original
+    end
+
+    it 'loads without error' do
+      expect { banner.active? }.not_to raise_error
+    end
+
+    it 'parses start and end as valid chronological times when present' do
+      config = Rails.application.config_for(:announcement_banner)
+
+      if config[:start].present?
+        expect(banner.start_time).to be_a(Time)
+        expect(banner.end_time).to be_a(Time)
+        expect(banner.start_time).to be < banner.end_time
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Nouveau service `AnnouncementBanner` (Singleton dans `app/services/`) qui affiche un bandeau DSFR `warning` refermable en tête de toutes les pages d'API Entreprise et d'API Particulier, piloté par un seul fichier `config/announcement_banner.yml`
- Annonce de la maintenance ProConnect du jeudi 23 avril 2026 à 18h00, bandeau visible dès la veille 00h00 jusqu'à la fin de la fenêtre (19h30).

Inspiré de https://github.com/etalab/data_pass/pull/1506.

<img width="1280" height="720" alt="announcement_banner_entreprise_v2" src="https://github.com/user-attachments/assets/6253855f-a48c-407f-8c5f-67c40441fdcb" />


