### PR TITLE
Fix CSS civility payload: bénéficiaire sans participation né à l'étranger

### DIFF
--- a/mocks/payloads/api_particulier_v3_cnav_complementaire_sante_solidaire_with_civility/200-beneficiaire_sans_participation-masculin-pays_etranger.yaml
+++ b/mocks/payloads/api_particulier_v3_cnav_complementaire_sante_solidaire_with_civility/200-beneficiaire_sans_participation-masculin-pays_etranger.yaml
@@ -8,7 +8,6 @@ description: |-
   - [Param. appel] Deux prénoms
   - [Réponse] statut bénéficiaire de la complémentaire santé solidaire SANS participation financière
 params:
-  codeCogInseeCommuneNaissance: '08481'
   codeCogInseePaysNaissance: '99127'
   sexeEtatCivil: 'M'
   nomNaissance: 'DUPONT'
@@ -17,6 +16,7 @@ params:
     - 'PAUL'
   anneeDateNaissance: 1984
   moisDateNaissance: 12
+  jourDateNaissance: 1
 status: 200
 payload: |-
   {

--- a/mocks/payloads/api_particulier_v3_cnav_complementaire_sante_solidaire_with_civility/README.md
+++ b/mocks/payloads/api_particulier_v3_cnav_complementaire_sante_solidaire_with_civility/README.md
@@ -78,7 +78,6 @@ Ce cas permet de tester :
 
   ```json
   {
-    "codeCogInseeCommuneNaissance": "08481",
     "codeCogInseePaysNaissance": "99127",
     "sexeEtatCivil": "M",
     "nomNaissance": "DUPONT",
@@ -87,7 +86,8 @@ Ce cas permet de tester :
       "PAUL"
     ],
     "anneeDateNaissance": 1984,
-    "moisDateNaissance": 12
+    "moisDateNaissance": 12,
+    "jourDateNaissance": 1
   }
   ```
 
@@ -117,7 +117,7 @@ Ce cas permet de tester :
 
   ```bash
   curl -H "Authorization: Bearer $token" \
-    -G -d 'recipient=13002526500013' -d 'codeCogInseeCommuneNaissance=08481' -d 'codeCogInseePaysNaissance=99127' -d 'sexeEtatCivil=M' -d 'nomNaissance=DUPONT' -d 'prenoms[]=PIERRE' -d 'prenoms[]=PAUL' -d 'anneeDateNaissance=1984' -d 'moisDateNaissance=12' \
+    -G -d 'recipient=13002526500013' -d 'codeCogInseePaysNaissance=99127' -d 'sexeEtatCivil=M' -d 'nomNaissance=DUPONT' -d 'prenoms[]=PIERRE' -d 'prenoms[]=PAUL' -d 'anneeDateNaissance=1984' -d 'moisDateNaissance=12' -d 'jourDateNaissance=1' \
     --url "https://staging.particulier.api.gouv.fr/v3/dss/complementaire_sante_solidaire/identite"
   ```
 

--- a/mocks/payloads/api_particulier_v3_cnav_complementaire_sante_solidaire_with_civility/summary.csv
+++ b/mocks/payloads/api_particulier_v3_cnav_complementaire_sante_solidaire_with_civility/summary.csv
@@ -20,7 +20,7 @@ Ce cas permet de tester :
 - [Param. appel] Pays de naissance autre que la France
 - [Param. appel] sexe masculin
 - [Param. appel] Deux prénoms
-- [Réponse] statut bénéficiaire de la complémentaire santé solidaire SANS participation financière","{""codeCogInseeCommuneNaissance"":""08481"",""codeCogInseePaysNaissance"":""99127"",""sexeEtatCivil"":""M"",""nomNaissance"":""DUPONT"",""prenoms"":[""PIERRE"",""PAUL""],""anneeDateNaissance"":1984,""moisDateNaissance"":12}",200,"{
+- [Réponse] statut bénéficiaire de la complémentaire santé solidaire SANS participation financière","{""codeCogInseePaysNaissance"":""99127"",""sexeEtatCivil"":""M"",""nomNaissance"":""DUPONT"",""prenoms"":[""PIERRE"",""PAUL""],""anneeDateNaissance"":1984,""moisDateNaissance"":12,""jourDateNaissance"":1}",200,"{
   ""data"": {
     ""est_beneficiaire"": true,
     ""avec_participation"": false,


### PR DESCRIPTION
Aligne les paramètres du mock avec ceux attendus par la recette : retire codeCogInseeCommuneNaissance (incohérent avec une naissance à l'étranger) et ajoute jourDateNaissance pour compléter la date de naissance.

Closes #20