### PR TITLE
Pin mjml to v4 in CI to fix mailer tests

### DIFF
--- a/.github/workflows/site-ci_cd.yml
+++ b/.github/workflows/site-ci_cd.yml
@@ -93,7 +93,7 @@ jobs:
         uses: actions/setup-node@v6
 
       - name: Install mjml dependency
-        run: npm install mjml
+        run: npm install mjml@4
 
       - name: Install postgres client
         run: sudo apt-get install libpq-dev


### PR DESCRIPTION
`npm install mjml` now installs v5 which dropped the MJML 4 binary format