### PR TITLE
Feat: ping for DataSubvention

### DIFF
--- a/siade/config/pings.yml
+++ b/siade/config/pings.yml
@@ -697,3 +697,14 @@ shared:
           siret: '19753471200017'
         key_to_dig: 'habilitations_france_competence'
         method_to_test_on_payload: 'any?'
+    data_subvention/subventions:
+      kind: 'retriever'
+      cache: <%= 5.minutes %>
+      provider: 'DataSubvention'
+      status_page:
+        name: "DataSubvention - Subventions"
+        alerts_wait: 5
+      driver_params:
+        retriever: 'DataSubvention::Subventions'
+        params:
+          siren_or_siret_or_rna: '780603734'


### PR DESCRIPTION
## Summary
- Ajoute la sonde de monitoring manquante pour l'API Data.Subvention (active en prod mais absente de `config/pings.yml`)
- `kind: retriever` — pattern identique à `infogreffe/rcs`, `inpi/rne`
- SIREN de test : `775672272` (Croix-Rouge Française) — association avec subventions récurrentes

## Test plan
- [x] Vérifier localement que `GET /v3/ping/api_entreprise/data_subvention/subventions` renvoie `200 OK`

API-4067