### PR TITLE
GIP-MDS: track 429 errors + add caching

### DIFF
--- a/siade/app/controllers/api_entreprise/v3_and_more/gip_mds/effectifs_annuels_entreprise_controller.rb
+++ b/siade/app/controllers/api_entreprise/v3_and_more/gip_mds/effectifs_annuels_entreprise_controller.rb
@@ -22,7 +22,15 @@ class APIEntreprise::V3AndMore::GIPMDS::EffectifsAnnuelsEntrepriseController < A
     ::APIEntreprise::GIPMDS::EffectifsAnnuelsEntrepriseSerializer
   end
 
+  def expires_in
+    (Time.zone.now.end_of_day - Time.zone.now).to_i
+  end
+
+  def cache_key
+    [request.path, params[:nature_effectif]].compact.join('/')
+  end
+
   def organizer
-    @organizer ||= retrieve_payload_data(::GIPMDS::EffectifsAnnuelsEntreprise)
+    @organizer ||= retrieve_payload_data(::GIPMDS::EffectifsAnnuelsEntreprise, cache: true, expires_in:)
   end
 end

--- a/siade/app/controllers/api_entreprise/v3_and_more/gip_mds/effectifs_mensuels_etablissement_controller.rb
+++ b/siade/app/controllers/api_entreprise/v3_and_more/gip_mds/effectifs_mensuels_etablissement_controller.rb
@@ -24,7 +24,15 @@ class APIEntreprise::V3AndMore::GIPMDS::EffectifsMensuelsEtablissementController
     ::APIEntreprise::GIPMDS::EffectifsMensuelsEtablissementSerializer
   end
 
+  def expires_in
+    (Time.zone.now.end_of_day - Time.zone.now).to_i
+  end
+
+  def cache_key
+    [request.path, params[:profondeur], params[:nature_effectif]].compact.join('/')
+  end
+
   def organizer
-    @organizer ||= retrieve_payload_data(::GIPMDS::EffectifsMensuelsEtablissement)
+    @organizer ||= retrieve_payload_data(::GIPMDS::EffectifsMensuelsEtablissement, cache: true, expires_in:)
   end
 end

--- a/siade/app/interactors/gip_mds/effectifs/validate_response.rb
+++ b/siade/app/interactors/gip_mds/effectifs/validate_response.rb
@@ -45,8 +45,15 @@ class GIPMDS::Effectifs::ValidateResponse < ValidateResponse
 
   def quota_error!
     retry_date_string = Rack::Utils.parse_nested_query(response.body)['nextAccessTime']
+    retry_date = DateTime.parse(retry_date_string)
 
-    context.errors << GIPMDSError.new(:quota_error, DateTime.parse(retry_date_string))
+    MonitoringService.instance.track_with_added_context(
+      'warning',
+      '[GIP-MDS] Quota exceeded',
+      { next_access_time: retry_date_string }
+    )
+
+    context.errors << GIPMDSError.new(:quota_error, retry_date)
     context.fail!
   end
 

--- a/siade/spec/interactors/gip_mds/effectifs/validate_response_spec.rb
+++ b/siade/spec/interactors/gip_mds/effectifs/validate_response_spec.rb
@@ -125,6 +125,18 @@ RSpec.describe GIPMDS::Effectifs::ValidateResponse, type: :validate_response do
     it 'sets a retry_in on the error' do
       expect(subject.errors.first.meta[:retry_in]).to eq(3.minutes.to_i + 2.hours.to_i)
     end
+
+    it 'tracks the quota error via MonitoringService' do
+      allow(MonitoringService.instance).to receive(:track_with_added_context)
+
+      subject
+
+      expect(MonitoringService.instance).to have_received(:track_with_added_context).with(
+        'warning',
+        '[GIP-MDS] Quota exceeded',
+        { next_access_time: '2023-Oct-12 20:43:00+0000 UTC' }
+      )
+    end
   end
 
   context 'with a 500 status' do


### PR DESCRIPTION
Try to mitigate ~20% errors on this data provider: more calls leads to more 429 errors, need to monitor it more closely.