### PR TITLE
Refactor: centraliser la résolution utilisateur dans un middleware Rack

### DIFF
--- a/siade/app/controllers/concerns/handle_tokens.rb
+++ b/siade/app/controllers/concerns/handle_tokens.rb
@@ -24,10 +24,6 @@ module HandleTokens
     matchs[1] if matchs
   end
 
-  def token
-    @token ||= retrieve_token
-  end
-
   protected
 
   def resource_name
@@ -43,46 +39,35 @@ module HandleTokens
   end
 
   def authenticate_user!
-    raise NotValidTokenError unless token
-
-    extract_user
+    @current_user = request.env[UserResolutionMiddleware::USER_ENV_KEY] || extract_user_from_token
 
     raise NotValidTokenError if current_user.blank? || current_user.invalid?
+
+    instrument_user_access
 
     current_user.not_expired!
 
     true
   end
 
-  def extract_user
-    @current_user = jwt_token_service.extract_user(token)
-  end
-
-  def retrieve_token
-    token_from_query_params || token_from_headers
-  end
-
-  def token_from_query_params
-    params[:token]
-  end
-
-  def token_from_headers
-    bearer_token_from_headers
-  end
-
-  def jwt_token_service
-    ::JwtTokenService.instance
+  def extract_user_from_token
+    token = params[:token] || bearer_token_from_headers
+    JwtTokenService.instance.extract_user(token) if token
   end
 
   def set_monitoring_context
     return if current_user.blank?
 
-    monitoring_service.set_user_context(
-      current_user.as_json.symbolize_keys!
-    )
+    monitoring_service.set_user_context(current_user.as_json.symbolize_keys!)
+    monitoring_service.set_controller_params(params.to_unsafe_h)
+  end
 
-    monitoring_service.set_controller_params(
-      params.to_unsafe_h
+  def instrument_user_access
+    ActiveSupport::Notifications.instrument(
+      'user_access',
+      user: current_user.logstash_id,
+      jti: current_user.token_id,
+      iat: current_user.iat
     )
   end
 

--- a/siade/app/lib/user_resolution_middleware.rb
+++ b/siade/app/lib/user_resolution_middleware.rb
@@ -1,0 +1,40 @@
+class UserResolutionMiddleware
+  USER_ENV_KEY = 'siade.current_user'.freeze
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    resolve_user(env)
+    @app.call(env)
+  end
+
+  private
+
+  def resolve_user(env)
+    token = extract_token(env)
+    return if token.blank?
+
+    user = JwtTokenService.instance.extract_user(token)
+    return if user.blank?
+
+    env[USER_ENV_KEY] = user
+  end
+
+  def extract_token(env)
+    extract_bearer_token(env) || env['HTTP_X_API_KEY'] || extract_query_param_token(env)
+  end
+
+  def extract_bearer_token(env)
+    auth = env['HTTP_AUTHORIZATION']
+    return unless auth
+
+    match = auth.match(/\ABearer (.+)\z/)
+    match[1] if match
+  end
+
+  def extract_query_param_token(env)
+    Rack::Utils.parse_query(env['QUERY_STRING'])['token']
+  end
+end

--- a/siade/app/services/jwt_token_service.rb
+++ b/siade/app/services/jwt_token_service.rb
@@ -5,11 +5,7 @@ class JwtTokenService
 
   def extract_user(jwt_token)
     cached_token = cached_user(jwt_token)
-
-    if cached_token.present?
-      add_user_access_to_logger(cached_token)
-      return cached_user(jwt_token)
-    end
+    return cached_token if cached_token.present?
 
     decoded_token = decode_token(jwt_token)
 
@@ -19,11 +15,7 @@ class JwtTokenService
 
     jwt_data = enhance_jwt_data(jwt_data, decoded_token)
 
-    jwt_user = build_and_cache_user!(jwt_token, jwt_data)
-
-    add_user_access_to_logger(jwt_user)
-
-    jwt_user
+    build_and_cache_user!(jwt_token, jwt_data)
   rescue JWT::DecodeError, ActiveRecord::RecordNotFound
     nil
   end
@@ -32,17 +24,6 @@ class JwtTokenService
 
   def cache
     EncryptedCache.instance
-  end
-
-  def add_user_access_to_logger(jwt_user)
-    return if jwt_user.blank?
-
-    ActiveSupport::Notifications.instrument(
-      'user_access',
-      user: jwt_user.logstash_id,
-      jti: jwt_user.token_id,
-      iat: jwt_user.iat
-    )
   end
 
   def enhance_jwt_data(jwt_data, decoded_token)

--- a/siade/app/services/rate_limiting_service.rb
+++ b/siade/app/services/rate_limiting_service.rb
@@ -2,10 +2,18 @@ class RateLimitingService
   include Rails.application.routes.url_helpers
 
   def discriminate_by_jwt_for_endpoints(req, endpoints_list)
-    jwt = extract_token_from_request(req)
     endpoint = extract_endpoint_from_url(req.url).slice(:controller, :action)
 
-    Digest::SHA256.hexdigest(jwt) if jwt && endpoints_list.include?(endpoint)
+    return nil unless endpoints_list.include?(endpoint)
+
+    user = resolved_user(req)
+
+    if user
+      Digest::SHA256.hexdigest(user.token_id)
+    else
+      token = extract_token_from_request(req)
+      Digest::SHA256.hexdigest(token) if token.present?
+    end
   end
 
   def whitelisted_access?(req)
@@ -15,14 +23,13 @@ class RateLimitingService
   end
 
   def blacklisted_access?(req)
-    jwt = extract_token_from_request(req)
+    user = resolved_user(req)
 
-    token_blacklisted_from_database?(jwt)
+    user.present? && user.blacklisted?
   end
 
   def ip_forbidden_access?(req)
-    jwt = extract_token_from_request(req)
-    user = user_from_jwt(jwt)
+    user = resolved_user(req)
 
     return false if user.blank?
     return false if user.allowed_ips.blank?
@@ -31,10 +38,7 @@ class RateLimitingService
   end
 
   def custom_rate_limit_for(req)
-    jwt = extract_token_from_request(req)
-    user = user_from_jwt(jwt)
-
-    user&.rate_limit_per_minute
+    resolved_user(req)&.rate_limit_per_minute
   end
 
   def custom_rate_limit?(req)
@@ -55,6 +59,10 @@ class RateLimitingService
   end
 
   private
+
+  def resolved_user(req)
+    req.env[UserResolutionMiddleware::USER_ENV_KEY]
+  end
 
   def compute_reset(data)
     now = data[:epoch_time]
@@ -87,17 +95,6 @@ class RateLimitingService
 
   def extract_token_from_query_params(request)
     request.params.fetch('token', nil)
-  end
-
-  def token_blacklisted_from_database?(jwt)
-    user = user_from_jwt(jwt)
-
-    user.present? &&
-      user.blacklisted?
-  end
-
-  def user_from_jwt(jwt)
-    JwtTokenService.instance.extract_user(jwt)
   end
 
   def whitelist

--- a/siade/config/initializers/rack_attack.rb
+++ b/siade/config/initializers/rack_attack.rb
@@ -3,7 +3,10 @@ require 'digest/sha2'
 
 require_relative '../../app/services/rate_limiting_service'
 require_relative '../../app/services/operation_id_resolver'
+require_relative '../../app/lib/user_resolution_middleware'
 require_relative '../../app/lib/rate_limit_headers_middleware'
+
+Rails.configuration.middleware.insert_before Rack::Attack, UserResolutionMiddleware
 require_relative '../../app/errors/application_error'
 require_relative '../../app/errors/forbidden_error'
 require_relative '../../app/errors/forbidden_ip_error'

--- a/siade/docs/development/chaine_de_resolution_utilisateur.md
+++ b/siade/docs/development/chaine_de_resolution_utilisateur.md
@@ -1,0 +1,86 @@
+# Chaîne de résolution utilisateur
+
+## Vue d'ensemble
+
+L'authentification et la résolution de l'utilisateur sont centralisées dans un middleware Rack (`UserResolutionMiddleware`) qui s'exécute **avant** Rack::Attack. Tous les consumers (rate limiting, IP check, controllers) lisent le résultat depuis `request.env`.
+
+```
+Requête HTTP
+  │
+  ▼
+UserResolutionMiddleware        ← résout le user complet (1 seule fois)
+  │
+  ▼
+Rack::Attack                    ← lit request.env (IP, rate limit, blacklist)
+  │
+  ▼
+RateLimitHeadersMiddleware      ← ajoute les headers RateLimit-*
+  │
+  ▼
+Controller (HandleTokens)       ← lit request.env, vérifie expiration, logge
+```
+
+## UserResolutionMiddleware
+
+Fichier : `app/lib/user_resolution_middleware.rb`
+
+1. Extrait le token (`Authorization: Bearer`, `X-Api-Key`, query param `token`)
+2. Décode via `JwtTokenService` (cache 1h)
+3. Stocke le user dans `env['siade.current_user']`
+
+### Tokens opaques (FranceConnect, X-Api-Key V2)
+
+Les tokens qui ne sont pas des JWT valides ne peuvent pas être décodés par `JwtTokenService` : `env['siade.current_user']` reste `nil`. Ces flows utilisent leur propre logique d'authentification au niveau controller (ex: `FranceConnectable`).
+
+## RateLimitingService
+
+Fichier : `app/services/rate_limiting_service.rb`
+
+Pur lecteur de `request.env` — ne fait aucune requête DB, ne décode aucun JWT.
+
+- `ip_forbidden_access?` → lit `user.allowed_ips`
+- `custom_rate_limit_for` → lit `user.rate_limit_per_minute`
+- `discriminate_by_jwt_for_endpoints` → lit `user.token_id`, fallback SHA256 pour tokens opaques
+- `whitelisted_access?` → comparaison directe du token brut (seul cas qui nécessite encore l'extraction)
+
+## HandleTokens (controller)
+
+Fichier : `app/controllers/concerns/handle_tokens.rb`
+
+```
+before_action :authenticate_user!       ← lit env, fallback JwtTokenService
+before_action :set_monitoring_context   ← logstash + Sentry
+before_action :authorize_access_to_resource!  ← vérifie les scopes
+```
+
+`authenticate_user!` prend le user depuis `request.env`. Si absent (controller specs, cas spéciaux), fallback sur `JwtTokenService.instance.extract_user(token)`.
+
+`set_monitoring_context` émet l'event `'user_access'` pour LogStasher avec le user complet.
+
+## JwtTokenService
+
+Fichier : `app/services/jwt_token_service.rb`
+
+Pur service de données : decode JWT, enrichit depuis la DB (Token, security settings), cache 1h. Aucun side-effect (pas de logging, pas de notification).
+
+## Cas spéciaux
+
+### INPIProxyController
+
+Override complet de `authenticate_user!`. Utilise un `token_id` chiffré dans l'URL du proxy pour re-résoudre le token depuis la DB. Ne passe pas par le middleware.
+
+### FranceConnectable
+
+Override de `authenticate_user!`. Utilise le Bearer token comme access token FC opaque pour appeler l'IdP FranceConnect. Le middleware renvoie `nil` (token non-JWT).
+
+### API Particulier V2
+
+Utilise `X-Api-Key` comme header d'auth. Le middleware le gère directement (extraction depuis `HTTP_X_API_KEY`).
+
+## Fichiers clés
+
+- `app/lib/user_resolution_middleware.rb` : middleware de résolution
+- `app/services/rate_limiting_service.rb` : rate limiting (lecteur pur)
+- `app/controllers/concerns/handle_tokens.rb` : auth controller + logging
+- `app/services/jwt_token_service.rb` : decode JWT + cache (pur data service)
+- `config/initializers/rack_attack.rb` : wiring middleware + règles Rack::Attack

--- a/siade/spec/services/rate_limiting_service_spec.rb
+++ b/siade/spec/services/rate_limiting_service_spec.rb
@@ -1,8 +1,9 @@
 RSpec.describe RateLimitingService do
   let(:req) { instance_double(Rack::Request) }
+  let(:env) { {} }
 
   before do
-    allow(req).to receive(:params).and_return({})
+    allow(req).to receive_messages(params: {}, env:)
   end
 
   describe '#discriminate_by_jwt_for_endpoints' do
@@ -30,43 +31,49 @@ RSpec.describe RateLimitingService do
     before do
       allow(req).to receive(:url).and_return("#{base_path}/random/path")
       allow(req).to receive(:get_header).with('HTTP_X_API_KEY').and_return(nil)
+      allow(req).to receive(:get_header).with('HTTP_AUTHORIZATION').and_return(nil)
     end
 
-    context 'when authorization header is not set' do
-      before { allow(req).to receive(:get_header).with('HTTP_AUTHORIZATION').and_return(nil) }
-
+    context 'when no user is resolved' do
       it { is_expected.to be_nil }
     end
 
-    context 'when authorization header is set' do
-      context 'when the Bearer format is not respected' do
-        before { allow(req).to receive(:get_header).with('HTTP_AUTHORIZATION').and_return('Beer hour') }
+    context 'when the token does not resolve to a user (opaque token)' do
+      let(:opaque_token) { 'random.opaque.token' }
 
-        it { is_expected.to be_nil }
+      before do
+        allow(req).to receive(:get_header).with('HTTP_AUTHORIZATION').and_return("Bearer #{opaque_token}")
+        allow(req).to receive(:url).and_return("#{base_path}/v3/insee/sirene/etablissements/0001")
       end
 
-      context 'when the Bearer is well formed' do
-        let(:token_value) { 'wow token' }
+      it 'falls back to the token hash' do
+        expect(subject).to eq(Digest::SHA256.hexdigest(opaque_token))
+      end
+    end
 
-        before { allow(req).to receive(:get_header).with('HTTP_AUTHORIZATION').and_return("Bearer #{token_value}") }
+    context 'with a resolved user' do
+      let(:user) do
+        JwtUser.new(uid: SecureRandom.uuid, jti: SecureRandom.uuid, scopes: [], iat: 1.day.ago.to_i)
+      end
 
-        context 'when the request path matches one of the endpoint\'s URL in the list' do
-          before { allow(req).to receive(:url).and_return("#{base_path}/v3/insee/sirene/etablissements/0001") }
+      before { env[UserResolutionMiddleware::USER_ENV_KEY] = user }
 
-          it { is_expected.to eq(Digest::SHA256.hexdigest(token_value)) }
-        end
+      context 'when the request path matches one of the endpoints in the list' do
+        before { allow(req).to receive(:url).and_return("#{base_path}/v3/insee/sirene/etablissements/0001") }
 
-        describe 'non-regression test: when the request path matches dgfip v3 attestations_fiscales' do
-          before { allow(req).to receive(:url).and_return("#{base_path}/v3/dgfip/unites_legales/301028346/liasses_fiscales/2017") }
+        it { is_expected.to eq(Digest::SHA256.hexdigest(user.token_id)) }
+      end
 
-          it { is_expected.to eq(Digest::SHA256.hexdigest(token_value)) }
-        end
+      describe 'non-regression: dgfip v3 attestations_fiscales' do
+        before { allow(req).to receive(:url).and_return("#{base_path}/v3/dgfip/unites_legales/301028346/liasses_fiscales/2017") }
 
-        context 'when the request path does not match any of the endpoints in the list' do
-          before { allow(req).to receive(:url).and_return("#{base_path}/not/in/the/list") }
+        it { is_expected.to eq(Digest::SHA256.hexdigest(user.token_id)) }
+      end
 
-          it { is_expected.to be_nil }
-        end
+      context 'when the request path does not match any of the endpoints in the list' do
+        before { allow(req).to receive(:url).and_return("#{base_path}/not/in/the/list") }
+
+        it { is_expected.to be_nil }
       end
     end
   end
@@ -112,86 +119,62 @@ RSpec.describe RateLimitingService do
   describe '#blacklisted_access?' do
     subject { described_class.new.blacklisted_access?(req) }
 
-    before do
-      allow(req).to receive(:get_header).with('HTTP_X_API_KEY').and_return(nil)
-    end
-
-    context 'when authorization header is not set' do
-      before { allow(req).to receive(:get_header).with('HTTP_AUTHORIZATION').and_return(nil) }
-
+    context 'when no user is resolved' do
       it { is_expected.to be(false) }
     end
 
-    context 'when authorization header is set' do
-      context 'when the Bearer format is not respected' do
-        before { allow(req).to receive(:get_header).with('HTTP_AUTHORIZATION').and_return('Beer hour') }
-
-        it { is_expected.to be(false) }
+    context 'when user is resolved and blacklisted' do
+      let(:user) do
+        JwtUser.new(uid: SecureRandom.uuid, jti: SecureRandom.uuid, scopes: [], iat: 1.day.ago.to_i, blacklisted: true)
       end
 
-      context 'when the Bearer is well formed' do
-        before { allow(req).to receive(:get_header).with('HTTP_AUTHORIZATION').and_return("Bearer #{token}") }
+      before { env[UserResolutionMiddleware::USER_ENV_KEY] = user }
 
-        context 'when the token is blacklisted' do
-          context 'when it is a token from the database' do
-            let(:token) { TokenFactory.new([]).valid(uid: Seeds.new.blacklisted_jwt_id) }
+      it { is_expected.to be(true) }
+    end
 
-            it { is_expected.to be(true) }
-          end
-        end
-
-        context 'when the token is not blacklisted' do
-          let(:token) { 'random token' }
-
-          it { is_expected.to be(false) }
-        end
+    context 'when user is resolved and not blacklisted' do
+      let(:user) do
+        JwtUser.new(uid: SecureRandom.uuid, jti: SecureRandom.uuid, scopes: [], iat: 1.day.ago.to_i)
       end
+
+      before { env[UserResolutionMiddleware::USER_ENV_KEY] = user }
+
+      it { is_expected.to be(false) }
     end
   end
 
   describe '#ip_forbidden_access?' do
     subject { described_class.new.ip_forbidden_access?(req) }
 
-    before do
-      allow(req).to receive(:get_header).with('HTTP_X_API_KEY').and_return(nil)
-      allow(req).to receive(:ip).and_return(request_ip)
-    end
+    before { allow(req).to receive(:ip).and_return(request_ip) }
 
     let(:request_ip) { '8.8.8.8' }
 
-    context 'when authorization header is not set' do
-      before { allow(req).to receive(:get_header).with('HTTP_AUTHORIZATION').and_return(nil) }
-
+    context 'when no user is resolved' do
       it { is_expected.to be(false) }
     end
 
-    context 'with a valid token' do
-      let(:authorization_request) { AuthorizationRequest.create!(siret: '12345678901234') }
-      let(:token_record) do
-        Token.create!(
-          iat: 1.day.ago.to_i,
-          exp: 1.year.from_now.to_i,
-          scopes: [],
-          authorization_request_model_id: authorization_request.id
-        )
-      end
-      let(:token) { TokenFactory.new([]).valid(uid: token_record.id) }
-
-      before do
-        allow(req).to receive(:get_header).with('HTTP_AUTHORIZATION').and_return("Bearer #{token}")
-      end
-
+    context 'with a resolved user' do
       context 'without IP whitelist configured' do
+        let(:user) do
+          JwtUser.new(uid: SecureRandom.uuid, jti: SecureRandom.uuid, scopes: [], iat: 1.day.ago.to_i)
+        end
+
+        before { env[UserResolutionMiddleware::USER_ENV_KEY] = user }
+
         it { is_expected.to be(false) }
       end
 
       context 'with IP whitelist configured' do
-        before do
-          AuthorizationRequestSecuritySettings.create!(
-            authorization_request:,
+        let(:user) do
+          JwtUser.new(
+            uid: SecureRandom.uuid, jti: SecureRandom.uuid, scopes: [], iat: 1.day.ago.to_i,
             allowed_ips: ['192.168.1.0/24']
           )
         end
+
+        before { env[UserResolutionMiddleware::USER_ENV_KEY] = user }
 
         context 'when request IP is allowed' do
           let(:request_ip) { '192.168.1.50' }
@@ -211,81 +194,50 @@ RSpec.describe RateLimitingService do
   describe '#custom_rate_limit_for' do
     subject { described_class.new.custom_rate_limit_for(req) }
 
-    before do
-      allow(req).to receive(:get_header).with('HTTP_X_API_KEY').and_return(nil)
+    context 'when no user is resolved' do
+      it { is_expected.to be_nil }
     end
 
-    context 'when authorization header is not set' do
-      before { allow(req).to receive(:get_header).with('HTTP_AUTHORIZATION').and_return(nil) }
+    context 'with a resolved user without custom rate limit' do
+      let(:user) do
+        JwtUser.new(uid: SecureRandom.uuid, jti: SecureRandom.uuid, scopes: [], iat: 1.day.ago.to_i)
+      end
+
+      before { env[UserResolutionMiddleware::USER_ENV_KEY] = user }
 
       it { is_expected.to be_nil }
     end
 
-    context 'with a valid token' do
-      let(:authorization_request) { AuthorizationRequest.create!(siret: '12345678901234') }
-      let(:token_record) do
-        Token.create!(
-          iat: 1.day.ago.to_i,
-          exp: 1.year.from_now.to_i,
-          scopes: [],
-          authorization_request_model_id: authorization_request.id
+    context 'with a resolved user with custom rate limit' do
+      let(:user) do
+        JwtUser.new(
+          uid: SecureRandom.uuid, jti: SecureRandom.uuid, scopes: [], iat: 1.day.ago.to_i,
+          rate_limit_per_minute: 100
         )
       end
-      let(:token) { TokenFactory.new([]).valid(uid: token_record.id) }
 
-      before do
-        allow(req).to receive(:get_header).with('HTTP_AUTHORIZATION').and_return("Bearer #{token}")
-      end
+      before { env[UserResolutionMiddleware::USER_ENV_KEY] = user }
 
-      context 'without custom rate limit configured' do
-        it { is_expected.to be_nil }
-      end
-
-      context 'with custom rate limit configured' do
-        before do
-          AuthorizationRequestSecuritySettings.create!(
-            authorization_request:,
-            rate_limit_per_minute: 100
-          )
-        end
-
-        it { is_expected.to eq(100) }
-      end
+      it { is_expected.to eq(100) }
     end
   end
 
   describe '#custom_rate_limit?' do
     subject { described_class.new.custom_rate_limit?(req) }
 
-    before do
-      allow(req).to receive(:get_header).with('HTTP_X_API_KEY').and_return(nil)
-    end
-
-    context 'when authorization header is not set' do
-      before { allow(req).to receive(:get_header).with('HTTP_AUTHORIZATION').and_return(nil) }
-
+    context 'when no user is resolved' do
       it { is_expected.to be(false) }
     end
 
-    context 'with a valid token with custom rate limit' do
-      let(:authorization_request) { AuthorizationRequest.create!(siret: '12345678901234') }
-      let(:token_record) do
-        Token.create!(
-          iat: 1.day.ago.to_i,
-          exp: 1.year.from_now.to_i,
-          scopes: [],
-          authorization_request_model_id: authorization_request.id
-        )
-      end
-      let(:token) { TokenFactory.new([]).valid(uid: token_record.id) }
-
-      before do
-        allow(req).to receive(:get_header).with('HTTP_AUTHORIZATION').and_return("Bearer #{token}")
-        AuthorizationRequestSecuritySettings.create!(
-          authorization_request:,
+    context 'with a resolved user with custom rate limit' do
+      let(:user) do
+        JwtUser.new(
+          uid: SecureRandom.uuid, jti: SecureRandom.uuid, scopes: [], iat: 1.day.ago.to_i,
           rate_limit_per_minute: 100
         )
       end
+
+      before { env[UserResolutionMiddleware::USER_ENV_KEY] = user }
 
       it { is_expected.to be(true) }
     end


### PR DESCRIPTION
## Contexte

Préparation pour #31 (jeton éditeur + délégations). En auditant la chaîne d'authentification, on a constaté que la résolution utilisateur était éclatée (au sol LOL) entre plusieurs couches :

### Avant

```
Rack::Attack (RateLimitingService)
  → extrait le token (headers/query)
  → decode le JWT via JwtTokenService
  → lit les infos user (IP, rate limit, blacklist)

Controller (HandleTokens)
  → extrait le token (headers/query) — logique dupliquée
  → decode le JWT via JwtTokenService — appel dupliqué (caché, mais couplage)
  → vérifie expiration, scopes

JwtTokenService
  → decode + enrichit depuis la DB
  → logge dans LogStasher (side-effect caché dans un service de données)
```

**Problèmes** :
- Extraction du token dupliquée (RateLimitingService vs HandleTokens)
- Résolution user dupliquée (même si le cache JwtTokenService amortit)
- JwtTokenService mélange data et observabilité
- Ajouter une étape de résolution (ex: délégation éditeur) nécessite de modifier **deux** couches indépendantes

### Après

```
UserResolutionMiddleware (avant Rack::Attack)
  → extrait le token
  → decode via JwtTokenService (pure data, sans side-effect)
  → stocke le user dans request.env['siade.current_user']

Rack::Attack (RateLimitingService)
  → lit request.env — pur lecteur, 0 query DB

Controller (HandleTokens)
  → lit request.env
  → vérifie expiration, scopes
  → logge dans LogStasher (seul point de logging)
```

**Résultat** :
- 1 seul point de résolution (middleware)
- RateLimitingService passe de ~100 à ~60 lignes, ne connaît plus JwtTokenService
- HandleTokens perd retrieve_token/token_from_*/jwt_token_service
- JwtTokenService devient un pur service de données (decode, enrich, cache)
- Le logging est au bon endroit (controller, user complet)

## Commits

1. **Introduce UserResolutionMiddleware** — middleware Rack avant Rack::Attack
2. **Simplify RateLimitingService** — lecteur pur de request.env
3. **Simplify HandleTokens** — lit request.env, fallback pour controller specs
4. **Remove logging side-effect from JwtTokenService** — logging déplacé dans HandleTokens
5. **Docs** — architecture de la chaîne de résolution