### PR TITLE
Align GIP-MDS effectifs cache TTL with end-of-month update cycle

### DIFF
--- a/commons/endpoints/api_entreprise/gip_mds_effectifs.yml
+++ b/commons/endpoints/api_entreprise/gip_mds_effectifs.yml
@@ -25,8 +25,10 @@ fiche:
         - ✅ France métropolitaine
         - ✅ DROM-COM
       updating_rules_description: |+
-        L'effectif de l'année N d'une unité légale est mis à disposition **fin janvier de l'année N+1**.
-        L'effectif d'une même année **peut évoluer au cours du temps**, car les régularisations _a posteriori_ sont possibles.
+        L'effectif de l'année N d'une unité légale est valorisé pour sa très grande majorité **fin janvier de l'année N+1**, à travers deux vagues principales successives liées aux échéances DSN.
+        Les mises à jour ultérieures sont effectuées **à la fin de chaque mois**, car les régularisations _a posteriori_ sont possibles.
+
+        La réponse est mise en cache jusqu'à la fin du mois courant, en phase avec le cycle de mise à jour des données.
       entities:
         - entreprises
         - associations
@@ -181,9 +183,11 @@ fiche:
         - ✅ France métropolitaine
         - ✅ DROM-COM
       updating_rules_description: |+
-        L'effectif du mois M d'un établissement est mis à disposition **à la fin du mois M+1** ; par exemple, l'effectif du mois de février est disponible fin mars. Il n'est donc pas possible d'obtenir l'effectif du mois courant.
+        L'effectif du mois M d'un établissement est collecté et mis à disposition **à la fin du mois M+1** ; par exemple, l'effectif du mois de février est disponible fin mars. Il n'est donc pas possible d'obtenir l'effectif du mois courant.
 
         L'effectif d'un même mois **peut évoluer au cours du temps**, car les régularisations _a posteriori_ sont possibles.
+
+        La réponse est mise en cache jusqu'à la fin du mois courant, en phase avec le cycle de mise à jour des données.
       entities:
         - entreprises
         - associations

--- a/siade/app/controllers/api_entreprise/v3_and_more/gip_mds/effectifs_annuels_entreprise_controller.rb
+++ b/siade/app/controllers/api_entreprise/v3_and_more/gip_mds/effectifs_annuels_entreprise_controller.rb
@@ -23,7 +23,7 @@ class APIEntreprise::V3AndMore::GIPMDS::EffectifsAnnuelsEntrepriseController < A
   end
 
   def expires_in
-    (Time.zone.now.end_of_day - Time.zone.now).to_i
+    (Time.zone.now.end_of_month - Time.zone.now).to_i
   end
 
   def cache_key

--- a/siade/app/controllers/api_entreprise/v3_and_more/gip_mds/effectifs_mensuels_etablissement_controller.rb
+++ b/siade/app/controllers/api_entreprise/v3_and_more/gip_mds/effectifs_mensuels_etablissement_controller.rb
@@ -25,7 +25,7 @@ class APIEntreprise::V3AndMore::GIPMDS::EffectifsMensuelsEtablissementController
   end
 
   def expires_in
-    (Time.zone.now.end_of_day - Time.zone.now).to_i
+    (Time.zone.now.end_of_month - Time.zone.now).to_i
   end
 
   def cache_key


### PR DESCRIPTION
Le GIP-MDS a confirme que les effectifs (annuels comme mensuels) ne sont rafraichis qu'en fin de mois :
- Effectifs annuels : valorises pour l'essentiel fin janvier via 2 vagues DSN successives, puis corriges en fin de chaque mois (regularisations).
- Effectifs mensuels : collectes en fin de mois M+1.

Le cache actuel (fin de journee) provoquait des appels redondants au fournisseur alors que la donnee ne bouge pas avant la fin du mois. On aligne donc le TTL sur end_of_month pour coller au cycle reel de mise a jour, reduire la charge chez le GIP-MDS (contexte du sujet en cours sur le rate limiting avec leurs equipes infra / TMA RCD) et servir une donnee stable.

La fiche metier est mise a jour pour refleter la nouvelle regle de mise a jour et documenter le comportement du cache cote consommateur.