### PR TITLE
Expose `campaignYear` parameter on CNOUS student scholarship API

### DIFF
--- a/commons/endpoints/_swagger_shared/cnous.yml
+++ b/commons/endpoints/_swagger_shared/cnous.yml
@@ -152,7 +152,7 @@ cnous:
 
   etudiant_boursier:
     parameters:
-      ine: 
+      ine:
         title: INE
         description: Identifiant National Étudiant (INE). Cet identifiant est unique
           à chaque étudiant sur le territoire français. Il est composé de 11 caractères,
@@ -161,8 +161,20 @@ cnous:
           et leur certificat de scolarité.
         pattern: "^[0-9a-zA-Z]{11}$"
         example: 1234567890G
+      campaignYear:
+        title: Année de campagne
+        description: |+
+          **Année de référence de la campagne scolaire** (paramètre optionnel).
 
-  v2: 
+          Année de début de la campagne scolaire recherchée. Par exemple, l'année scolaire 2025-2026 est représentée par `2025`.
+
+          Les données sont disponibles à partir de la campagne 2021-2022. La fiabilité des données augmente avec les années, notamment car les imports régionaux étaient moins fréquents lors des premières campagnes.
+
+          En l'absence de ce paramètre, l'API recherche une bourse valide pour l'étudiant ; si plusieurs résultats existent, elle renvoie la bourse la plus récente en priorité.
+        minimum: 2021
+        example: 2024
+
+  v2:
     commons:
       title: Status étudiant boursier
       description: Statut et échelon boursier d'un étudiant, délivrés par le Cnous

--- a/commons/endpoints/api_particulier/cnous_student_scholarship.yml
+++ b/commons/endpoints/api_particulier/cnous_student_scholarship.yml
@@ -47,6 +47,12 @@ fiche:
         <span class="fr-text--xs">
         <sup>\*</sup>Tous les champs sont facultatifs.
         </span>
+
+        **Paramètre additionnel optionnel** :
+        `campaignYear` permet de cibler une année scolaire précise lors de la recherche du dossier étudiant.
+        La valeur correspond à l'**année de début de la campagne scolaire** (exemple : `campaignYear=2025` pour l'année scolaire 2025-2026).
+        Les données sont disponibles à partir de la campagne 2021-2022.
+        En l'absence de ce paramètre, l'API renvoie la bourse valide la plus récente.
     data: &cnous_data
       description: |+
         Cette API **indique si un étudiant est boursier et permet de connaître le montant de la bourse** perçue grâce à l'échelon et la durée de versement.
@@ -82,7 +88,20 @@ fiche:
     position: 401
     ping_url: *cnous_ping_url
     perimeter: *cnous_perimeter
-    parameters_details: *cnous_parameters_details
+    parameters_details:
+      description: |+
+        Cette API propose trois modalités d'appel :
+        <p class="fr-badge fr-badge--blue-ecume">![Cette API est FranceConnectée](<%= image_path('api_particulier/cas_usages/pictos/modalite_appel_france_connect.svg') %>){:width="20px"} FranceConnect</p>
+        **Avec la [modalité d'appel FranceConnect](<%= cas_usage_path('modalite_appel_france_connect') %>)**.
+
+        <p class="fr-badge fr-badge--purple-glycine">Identifiant</p>
+        **Avec l'Identifiant National Étudiant (INE)** : Cet identifiant unique figure notamment sur la carte étudiant.
+
+        <p class="fr-badge fr-badge--brown-cafe-creme">Identité pivot</p>
+        **Avec les données d'identité** : Nom, prénom, sexe, date de naissance et lieu de naissance de l'étudiant (exemple : Angers)<sup>\*</sup>.
+        <span class="fr-text--xs">
+        <sup>\*</sup>Tous les champs sont facultatifs.
+        </span>
     data: *cnous_data
     provider_uids: *cnous_provider_uids
     keywords: *cnous_keywords

--- a/commons/swagger/openapi-particulier.yaml
+++ b/commons/swagger/openapi-particulier.yaml
@@ -9375,6 +9375,21 @@ paths:
           et permet de retrouver le code COG avec le paramètre 'anneeDateNaissance'.\n\nNe
           pas remplir si la personne est née à l'étranger."
         required: false
+      - name: campaignYear
+        in: query
+        description: |
+          **Année de référence de la campagne scolaire** (paramètre optionnel).
+
+          Année de début de la campagne scolaire recherchée. Par exemple, l'année scolaire 2025-2026 est représentée par `2025`.
+
+          Les données sont disponibles à partir de la campagne 2021-2022. La fiabilité des données augmente avec les années, notamment car les imports régionaux étaient moins fréquents lors des premières campagnes.
+
+          En l'absence de ce paramètre, l'API recherche une bourse valide pour l'étudiant ; si plusieurs résultats existent, elle renvoie la bourse la plus récente en priorité.
+        example: 2024
+        schema:
+          type: integer
+          minimum: 2021
+        required: false
       security:
       - jwt_bearer_token: []
       description: Statut et échelon boursier d'un étudiant, délivrés par le Cnous.
@@ -9706,6 +9721,21 @@ paths:
         required: true
         schema:
           type: string
+      - name: campaignYear
+        in: query
+        description: |
+          **Année de référence de la campagne scolaire** (paramètre optionnel).
+
+          Année de début de la campagne scolaire recherchée. Par exemple, l'année scolaire 2025-2026 est représentée par `2025`.
+
+          Les données sont disponibles à partir de la campagne 2021-2022. La fiabilité des données augmente avec les années, notamment car les imports régionaux étaient moins fréquents lors des premières campagnes.
+
+          En l'absence de ce paramètre, l'API recherche une bourse valide pour l'étudiant ; si plusieurs résultats existent, elle renvoie la bourse la plus récente en priorité.
+        example: 2024
+        schema:
+          type: integer
+          minimum: 2021
+        required: false
       security:
       - jwt_bearer_token: []
       description: Statut et échelon boursier d'un étudiant, délivrés par le Cnous.
@@ -9996,6 +10026,21 @@ paths:
           type: string
           pattern: "^[0-9a-zA-Z]{11}$"
         required: true
+      - name: campaignYear
+        in: query
+        description: |
+          **Année de référence de la campagne scolaire** (paramètre optionnel).
+
+          Année de début de la campagne scolaire recherchée. Par exemple, l'année scolaire 2025-2026 est représentée par `2025`.
+
+          Les données sont disponibles à partir de la campagne 2021-2022. La fiabilité des données augmente avec les années, notamment car les imports régionaux étaient moins fréquents lors des premières campagnes.
+
+          En l'absence de ce paramètre, l'API recherche une bourse valide pour l'étudiant ; si plusieurs résultats existent, elle renvoie la bourse la plus récente en priorité.
+        example: 2024
+        schema:
+          type: integer
+          minimum: 2021
+        required: false
       security:
       - jwt_bearer_token: []
       description: Statut et échelon boursier d'un étudiant, délivrés par le Cnous.

--- a/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_civility/200_boursier_campagne_anterieure.yaml
+++ b/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_civility/200_boursier_campagne_anterieure.yaml
@@ -1,0 +1,47 @@
+---
+description: 'Boursier sur une campagne antérieure ciblée via campaignYear'
+params:
+  nomNaissance: 'Pagnol'
+  prenoms:
+    - 'Marcel'
+  anneeDateNaissance: 1998
+  moisDateNaissance: 7
+  jourDateNaissance: 12
+  codeCogInseeCommuneNaissance: '75000'
+  sexeEtatCivil: 'M'
+  campaignYear: 2022
+status: 200
+payload: |-
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": true,
+        "est_radie": false,
+        "date_radiation": null
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "2022-09-01",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Evry",
+        "nom_etablissement": "ENSIIE"
+      },
+      "echelon_bourse": {
+        "echelon": "4",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "marcel@pagnol.fr",
+      "identite": {
+        "nom": "PAGNOL",
+        "prenoms": [
+          "MARCEL"
+        ],
+        "date_naissance": "1998-07-12",
+        "nom_commune_naissance": "Paris",
+        "sexe": "M"
+      }
+    },
+    "links": {},
+    "meta": {}
+  }

--- a/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_civility/README.md
+++ b/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_civility/README.md
@@ -78,6 +78,86 @@
 
   </p>
   </details>
+* [200_boursier_campagne_anterieure.yaml](200_boursier_campagne_anterieure.yaml)
+
+  Status `200`
+
+  Boursier sur une campagne antérieure ciblée via campaignYear
+
+  <details><summary>Paramètres</summary>
+  <p>
+
+  ```json
+  {
+    "nomNaissance": "Pagnol",
+    "prenoms": [
+      "Marcel"
+    ],
+    "anneeDateNaissance": 1998,
+    "moisDateNaissance": 7,
+    "jourDateNaissance": 12,
+    "codeCogInseeCommuneNaissance": "75000",
+    "sexeEtatCivil": "M",
+    "campaignYear": 2022
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Réponse API</summary>
+  <p>
+
+  ```json
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": true,
+        "est_radie": false,
+        "date_radiation": null
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "2022-09-01",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Evry",
+        "nom_etablissement": "ENSIIE"
+      },
+      "echelon_bourse": {
+        "echelon": "4",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "marcel@pagnol.fr",
+      "identite": {
+        "nom": "PAGNOL",
+        "prenoms": [
+          "MARCEL"
+        ],
+        "date_naissance": "1998-07-12",
+        "nom_commune_naissance": "Paris",
+        "sexe": "M"
+      }
+    },
+    "links": {},
+    "meta": {}
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Commande cURL</summary>
+  <p>
+
+  ```bash
+  curl -H "Authorization: Bearer $token" \
+    -G -d 'recipient=13002526500013' -d 'nomNaissance=Pagnol' -d 'prenoms[]=Marcel' -d 'anneeDateNaissance=1998' -d 'moisDateNaissance=7' -d 'jourDateNaissance=12' -d 'codeCogInseeCommuneNaissance=75000' -d 'sexeEtatCivil=M' -d 'campaignYear=2022' \
+    --url "https://staging.particulier.api.gouv.fr/v4/cnous/etudiant_boursier/identite"
+  ```
+
+  </p>
+  </details>
 * [200_non_boursier.yaml](200_non_boursier.yaml)
 
   Status `200`

--- a/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_civility/summary.csv
+++ b/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_civility/summary.csv
@@ -32,6 +32,39 @@ Titre,Description,Paramètres,Status,Réponse
   ""links"": {},
   ""meta"": {}
 }"
+,Boursier sur une campagne antérieure ciblée via campaignYear,"{""nomNaissance"":""Pagnol"",""prenoms"":[""Marcel""],""anneeDateNaissance"":1998,""moisDateNaissance"":7,""jourDateNaissance"":12,""codeCogInseeCommuneNaissance"":""75000"",""sexeEtatCivil"":""M"",""campaignYear"":2022}",200,"{
+  ""data"": {
+    ""statut_boursier"": {
+      ""est_boursier"": true,
+      ""est_radie"": false,
+      ""date_radiation"": null
+    },
+    ""periode_versement_bourse"": {
+      ""date_rentree"": ""2022-09-01"",
+      ""duree"": 12
+    },
+    ""etablissement_etudes"": {
+      ""nom_commune"": ""Evry"",
+      ""nom_etablissement"": ""ENSIIE""
+    },
+    ""echelon_bourse"": {
+      ""echelon"": ""4"",
+      ""echelon_bourse_regionale_provisoire"": false
+    },
+    ""email"": ""marcel@pagnol.fr"",
+    ""identite"": {
+      ""nom"": ""PAGNOL"",
+      ""prenoms"": [
+        ""MARCEL""
+      ],
+      ""date_naissance"": ""1998-07-12"",
+      ""nom_commune_naissance"": ""Paris"",
+      ""sexe"": ""M""
+    }
+  },
+  ""links"": {},
+  ""meta"": {}
+}"
 ,Non boursier,"{""nomNaissance"":""Durand"",""prenoms"":[""Sophie""],""anneeDateNaissance"":2000,""moisDateNaissance"":3,""jourDateNaissance"":25,""codeCogInseeCommuneNaissance"":""69123"",""sexeEtatCivil"":""F""}",200,"{
   ""data"": {
     ""statut_boursier"": {

--- a/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_france_connect/200_boursier_campagne_anterieure.yaml
+++ b/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_france_connect/200_boursier_campagne_anterieure.yaml
@@ -1,0 +1,42 @@
+---
+description: |-
+  Cas de test avec jeton FranceConnect - Boursier sur une campagne antérieure ciblée via campaignYear
+params:
+  prenoms:
+  - 'Angela'
+  - 'Claire'
+  - 'Louise'
+  nomNaissance: "DUBOIS"
+  anneeDateNaissance: 1962
+  moisDateNaissance: 8
+  jourDateNaissance: 24
+  sexeEtatCivil: "F"
+  codeInseeLieuDeNaissance: "75107"
+  codePaysLieuDeNaissance: "99100"
+  campaignYear: 2022
+status: 200
+payload: |-
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": true,
+        "est_radie": false,
+        "date_radiation": null
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "2022-09-01",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Paris",
+        "nom_etablissement": "Sorbonne Université"
+      },
+      "echelon_bourse": {
+        "echelon": "4",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "angela.dubois@sorbonne.fr"
+    },
+    "links": {},
+    "meta": {}
+  }

--- a/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_france_connect/README.md
+++ b/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_france_connect/README.md
@@ -1,4 +1,76 @@
 # [FranceConnect] Statut étudiant boursier
+* [200_boursier_campagne_anterieure.yaml](200_boursier_campagne_anterieure.yaml)
+
+  Status `200`
+
+  Cas de test avec jeton FranceConnect - Boursier sur une campagne antérieure ciblée via campaignYear
+
+  <details><summary>Paramètres</summary>
+  <p>
+
+  ```json
+  {
+    "prenoms": [
+      "Angela",
+      "Claire",
+      "Louise"
+    ],
+    "nomNaissance": "DUBOIS",
+    "anneeDateNaissance": 1962,
+    "moisDateNaissance": 8,
+    "jourDateNaissance": 24,
+    "sexeEtatCivil": "F",
+    "codeInseeLieuDeNaissance": "75107",
+    "codePaysLieuDeNaissance": "99100",
+    "campaignYear": 2022
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Réponse API</summary>
+  <p>
+
+  ```json
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": true,
+        "est_radie": false,
+        "date_radiation": null
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "2022-09-01",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Paris",
+        "nom_etablissement": "Sorbonne Université"
+      },
+      "echelon_bourse": {
+        "echelon": "4",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "angela.dubois@sorbonne.fr"
+    },
+    "links": {},
+    "meta": {}
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Commande cURL</summary>
+  <p>
+
+  ```bash
+  curl -H "Authorization: Bearer $token_france_connect" --url "https://staging.particulier.api.gouv.fr/v4/cnous/etudiant_boursier/france_connect?recipient=13002526500013"
+  ```
+
+  </p>
+  </details>
 * [fake_france_connect.yaml](fake_france_connect.yaml)
 
   Status `200`

--- a/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_france_connect/summary.csv
+++ b/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_france_connect/summary.csv
@@ -1,4 +1,28 @@
 Titre,Description,Paramètres,Status,Réponse
+,Cas de test avec jeton FranceConnect - Boursier sur une campagne antérieure ciblée via campaignYear,"{""prenoms"":[""Angela"",""Claire"",""Louise""],""nomNaissance"":""DUBOIS"",""anneeDateNaissance"":1962,""moisDateNaissance"":8,""jourDateNaissance"":24,""sexeEtatCivil"":""F"",""codeInseeLieuDeNaissance"":""75107"",""codePaysLieuDeNaissance"":""99100"",""campaignYear"":2022}",200,"{
+  ""data"": {
+    ""statut_boursier"": {
+      ""est_boursier"": true,
+      ""est_radie"": false,
+      ""date_radiation"": null
+    },
+    ""periode_versement_bourse"": {
+      ""date_rentree"": ""2022-09-01"",
+      ""duree"": 12
+    },
+    ""etablissement_etudes"": {
+      ""nom_commune"": ""Paris"",
+      ""nom_etablissement"": ""Sorbonne Université""
+    },
+    ""echelon_bourse"": {
+      ""echelon"": ""4"",
+      ""echelon_bourse_regionale_provisoire"": false
+    },
+    ""email"": ""angela.dubois@sorbonne.fr""
+  },
+  ""links"": {},
+  ""meta"": {}
+}"
 ,Cas de test avec jeton FranceConnect de test - Non boursier,"{""prenoms"":[""Georges""],""nomNaissance"":""CNAF"",""nomUsage"":""MARTIN"",""anneeDateNaissance"":2002,""moisDateNaissance"":1,""jourDateNaissance"":1,""sexeEtatCivil"":""M"",""codeCogInseeCommuneNaissance"":""75002"",""codeCogInseePaysNaissance"":""99100""}",200,"{
   ""data"": {
     ""statut_boursier"": {

--- a/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/200_boursier_campagne_anterieure.yaml
+++ b/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/200_boursier_campagne_anterieure.yaml
@@ -1,0 +1,40 @@
+---
+description: 'Boursier sur une campagne antérieure ciblée via campaignYear'
+params:
+  ine: '1234567890A'
+  campaignYear: 2022
+status: 200
+payload: |-
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": true,
+        "est_radie": false,
+        "date_radiation": null
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "2022-09-01",
+        "duree": 10
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Toulouse",
+        "nom_etablissement": "Université Toulouse III - Paul Sabatier"
+      },
+      "echelon_bourse": {
+        "echelon": "3",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "etudiant@univ-tlse3.fr",
+      "identite": {
+        "nom": "LEROY",
+        "prenoms": [
+          "THOMAS"
+        ],
+        "date_naissance": "2001-05-18",
+        "nom_commune_naissance": "Toulouse",
+        "sexe": "M"
+      }
+    },
+    "links": {},
+    "meta": {}
+  }

--- a/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/README.md
+++ b/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/README.md
@@ -70,6 +70,78 @@
 
   </p>
   </details>
+* [200_boursier_campagne_anterieure.yaml](200_boursier_campagne_anterieure.yaml)
+
+  Status `200`
+
+  Boursier sur une campagne antérieure ciblée via campaignYear
+
+  <details><summary>Paramètres</summary>
+  <p>
+
+  ```json
+  {
+    "ine": "1234567890A",
+    "campaignYear": 2022
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Réponse API</summary>
+  <p>
+
+  ```json
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": true,
+        "est_radie": false,
+        "date_radiation": null
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "2022-09-01",
+        "duree": 10
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Toulouse",
+        "nom_etablissement": "Université Toulouse III - Paul Sabatier"
+      },
+      "echelon_bourse": {
+        "echelon": "3",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "etudiant@univ-tlse3.fr",
+      "identite": {
+        "nom": "LEROY",
+        "prenoms": [
+          "THOMAS"
+        ],
+        "date_naissance": "2001-05-18",
+        "nom_commune_naissance": "Toulouse",
+        "sexe": "M"
+      }
+    },
+    "links": {},
+    "meta": {}
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Commande cURL</summary>
+  <p>
+
+  ```bash
+  curl -H "Authorization: Bearer $token" \
+    -G -d 'recipient=13002526500013' -d 'ine=1234567890A' -d 'campaignYear=2022' \
+    --url "https://staging.particulier.api.gouv.fr/v4/cnous/etudiant_boursier/ine"
+  ```
+
+  </p>
+  </details>
 * [200_radie.yaml](200_radie.yaml)
 
   Status `200`

--- a/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/summary.csv
+++ b/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/summary.csv
@@ -32,6 +32,39 @@ Titre,Description,Paramètres,Status,Réponse
   ""links"": {},
   ""meta"": {}
 }"
+,Boursier sur une campagne antérieure ciblée via campaignYear,"{""ine"":""1234567890A"",""campaignYear"":2022}",200,"{
+  ""data"": {
+    ""statut_boursier"": {
+      ""est_boursier"": true,
+      ""est_radie"": false,
+      ""date_radiation"": null
+    },
+    ""periode_versement_bourse"": {
+      ""date_rentree"": ""2022-09-01"",
+      ""duree"": 10
+    },
+    ""etablissement_etudes"": {
+      ""nom_commune"": ""Toulouse"",
+      ""nom_etablissement"": ""Université Toulouse III - Paul Sabatier""
+    },
+    ""echelon_bourse"": {
+      ""echelon"": ""3"",
+      ""echelon_bourse_regionale_provisoire"": false
+    },
+    ""email"": ""etudiant@univ-tlse3.fr"",
+    ""identite"": {
+      ""nom"": ""LEROY"",
+      ""prenoms"": [
+        ""THOMAS""
+      ],
+      ""date_naissance"": ""2001-05-18"",
+      ""nom_commune_naissance"": ""Toulouse"",
+      ""sexe"": ""M""
+    }
+  },
+  ""links"": {},
+  ""meta"": {}
+}"
 ,Boursier radié,"{""ine"":""0987654321B""}",200,"{
   ""data"": {
     ""statut_boursier"": {

--- a/siade/app/controllers/api_particulier/v3_and_more/cnous/etudiant_boursier_with_civility_controller.rb
+++ b/siade/app/controllers/api_particulier/v3_and_more/cnous/etudiant_boursier_with_civility_controller.rb
@@ -19,7 +19,7 @@ class APIParticulier::V3AndMore::CNOUS::EtudiantBoursierWithCivilityController <
   private
 
   def organizer_params
-    civility_parameters
+    civility_parameters.merge(campaign_year: params[:campaignYear])
   end
 
   def serializer_module

--- a/siade/app/controllers/api_particulier/v3_and_more/cnous/etudiant_boursier_with_france_connect_controller.rb
+++ b/siade/app/controllers/api_particulier/v3_and_more/cnous/etudiant_boursier_with_france_connect_controller.rb
@@ -13,7 +13,10 @@ class APIParticulier::V3AndMore::CNOUS::EtudiantBoursierWithFranceConnectControl
   private
 
   def organizer_params
-    civility_parameters_from_france_connect.merge({ token_id: current_user.token_id })
+    civility_parameters_from_france_connect.merge(
+      token_id: current_user.token_id,
+      campaign_year: params[:campaignYear]
+    )
   end
 
   def serializer_module

--- a/siade/app/controllers/api_particulier/v3_and_more/cnous/etudiant_boursier_with_ine_controller.rb
+++ b/siade/app/controllers/api_particulier/v3_and_more/cnous/etudiant_boursier_with_ine_controller.rb
@@ -12,7 +12,8 @@ class APIParticulier::V3AndMore::CNOUS::EtudiantBoursierWithINEController < APIP
 
   def organizer_params
     {
-      ine: params[:ine]
+      ine: params[:ine],
+      campaign_year: params[:campaignYear]
     }
   end
 

--- a/siade/app/errors/unprocessable_entity_error.rb
+++ b/siade/app/errors/unprocessable_entity_error.rb
@@ -50,6 +50,7 @@ class UnprocessableEntityError < ApplicationError
       gender: '00364',
       birth_place: '00365',
       civility: '00366',
+      campaign_year: '00368',
       # DGFIP usager
       tax_number: '00370',
       tax_notice_number: '00371',

--- a/siade/app/interactors/cnous/student_scholarship_with_civility/make_request.rb
+++ b/siade/app/interactors/cnous/student_scholarship_with_civility/make_request.rb
@@ -9,7 +9,8 @@ class CNOUS::StudentScholarshipWithCivility::MakeRequest < MakeRequest::Post
       firstNames: prenoms,
       birthDate: date_naissance,
       birthPlace: code_cog_insee_commune_naissance,
-      civility: gender
+      civility: gender,
+      campaignYear: campaign_year
     }.compact
   end
 
@@ -21,7 +22,8 @@ class CNOUS::StudentScholarshipWithCivility::MakeRequest < MakeRequest::Post
       moisDateNaissance: month,
       jourDateNaissance: day,
       sexeEtatCivil: gender,
-      codeCogInseeCommuneNaissance: code_cog_insee_commune_naissance
+      codeCogInseeCommuneNaissance: code_cog_insee_commune_naissance,
+      campaignYear: campaign_year
     }.compact
   end
 
@@ -33,6 +35,10 @@ class CNOUS::StudentScholarshipWithCivility::MakeRequest < MakeRequest::Post
 
   def nom_naissance
     context.params[:nom_naissance]
+  end
+
+  def campaign_year
+    context.params[:campaign_year].presence&.to_i
   end
 
   def prenoms

--- a/siade/app/interactors/cnous/student_scholarship_with_france_connect/make_request.rb
+++ b/siade/app/interactors/cnous/student_scholarship_with_france_connect/make_request.rb
@@ -9,8 +9,9 @@ class CNOUS::StudentScholarshipWithFranceConnect::MakeRequest < MakeRequest::Get
       family_name: nom_naissance,
       birthdate: date_naissance,
       gender:,
-      birthplace: code_cog_insee_commune_naissance
-    }.to_json
+      birthplace: code_cog_insee_commune_naissance,
+      campaignYear: campaign_year
+    }.compact.to_json
   end
 
   def mocking_params
@@ -21,7 +22,8 @@ class CNOUS::StudentScholarshipWithFranceConnect::MakeRequest < MakeRequest::Get
       moisDateNaissance: month,
       jourDateNaissance: day,
       sexeEtatCivil: gender,
-      codeCogInseeCommuneNaissance: code_cog_insee_commune_naissance
+      codeCogInseeCommuneNaissance: code_cog_insee_commune_naissance,
+      campaignYear: campaign_year
     }.compact
   end
 
@@ -31,8 +33,9 @@ class CNOUS::StudentScholarshipWithFranceConnect::MakeRequest < MakeRequest::Get
       family_name: nom_naissance,
       birthdate: date_naissance,
       gender:,
-      birthplace: code_cog_insee_commune_naissance
-    }
+      birthplace: code_cog_insee_commune_naissance,
+      campaignYear: campaign_year
+    }.compact
   end
 
   def request_params
@@ -47,6 +50,10 @@ class CNOUS::StudentScholarshipWithFranceConnect::MakeRequest < MakeRequest::Get
 
   def nom_naissance
     context.params[:nom_naissance]
+  end
+
+  def campaign_year
+    context.params[:campaign_year].presence&.to_i
   end
 
   def prenoms

--- a/siade/app/interactors/cnous/student_scholarship_with_ine/make_request.rb
+++ b/siade/app/interactors/cnous/student_scholarship_with_ine/make_request.rb
@@ -4,13 +4,14 @@ class CNOUS::StudentScholarshipWithINE::MakeRequest < MakeRequest::Get
   protected
 
   def request_params
-    {}
+    { campaignYear: campaign_year }.compact
   end
 
   def mocking_params
     {
-      ine: ine_number
-    }
+      ine: ine_number,
+      campaignYear: campaign_year
+    }.compact
   end
 
   def request_uri
@@ -21,5 +22,9 @@ class CNOUS::StudentScholarshipWithINE::MakeRequest < MakeRequest::Get
 
   def ine_number
     context.params[:ine]
+  end
+
+  def campaign_year
+    context.params[:campaign_year].presence&.to_i
   end
 end

--- a/siade/app/interactors/cnous/validate_campaign_year.rb
+++ b/siade/app/interactors/cnous/validate_campaign_year.rb
@@ -1,0 +1,23 @@
+class CNOUS::ValidateCampaignYear < ValidateParamInteractor
+  MIN_CAMPAIGN_YEAR = 2021
+
+  def call
+    return if context.params[:campaign_year].blank?
+
+    invalid_param!(:campaign_year) unless valid_campaign_year?
+  end
+
+  private
+
+  def valid_campaign_year?
+    raw = context.params[:campaign_year].to_s
+
+    return false unless /\A\d{4}\z/.match?(raw)
+
+    raw.to_i.between?(MIN_CAMPAIGN_YEAR, max_campaign_year)
+  end
+
+  def max_campaign_year
+    Date.current.year - 1
+  end
+end

--- a/siade/app/organizers/cnous/student_scholarship_with_civility.rb
+++ b/siade/app/organizers/cnous/student_scholarship_with_civility.rb
@@ -1,5 +1,6 @@
 class CNOUS::StudentScholarshipWithCivility < RetrieverOrganizer
   organize CNOUS::StudentScholarshipWithCivility::ValidateParams,
+    CNOUS::ValidateCampaignYear,
     CNOUS::Authenticate,
     CNOUS::StudentScholarshipWithCivility::MakeRequest,
     CNOUS::ValidateResponse,

--- a/siade/app/organizers/cnous/student_scholarship_with_france_connect.rb
+++ b/siade/app/organizers/cnous/student_scholarship_with_france_connect.rb
@@ -1,5 +1,6 @@
 class CNOUS::StudentScholarshipWithFranceConnect < RetrieverOrganizer
-  organize CNOUS::Authenticate,
+  organize CNOUS::ValidateCampaignYear,
+    CNOUS::Authenticate,
     CNOUS::StudentScholarshipWithFranceConnect::MakeRequest,
     CNOUS::ValidateResponse,
     CNOUS::BuildResource

--- a/siade/app/organizers/cnous/student_scholarship_with_ine.rb
+++ b/siade/app/organizers/cnous/student_scholarship_with_ine.rb
@@ -1,5 +1,6 @@
 class CNOUS::StudentScholarshipWithINE < RetrieverOrganizer
   organize ServiceUser::ValidateINE,
+    CNOUS::ValidateCampaignYear,
     CNOUS::Authenticate,
     CNOUS::StudentScholarshipWithINE::MakeRequest,
     CNOUS::ValidateResponse,

--- a/siade/config/errors.yml
+++ b/siade/config/errors.yml
@@ -260,6 +260,10 @@
   title: 'Entité non traitable'
   detail: "Le ou les prénoms sont manquants."
 
+- code: '00368'
+  title: 'Entité non traitable'
+  detail: "L'année de campagne (campaignYear) n'est pas correctement formatée: doit être comprise entre 2021 et l'année courante - 1"
+
 - code: '00370'
   title: 'Entité non traitable'
   detail: "Le numéro fiscal n'est pas correctement formaté"

--- a/siade/spec/interactors/cnous/validate_campaign_year_spec.rb
+++ b/siade/spec/interactors/cnous/validate_campaign_year_spec.rb
@@ -1,0 +1,63 @@
+RSpec.describe CNOUS::ValidateCampaignYear, type: :validate_param_interactor do
+  subject { described_class.call(params:) }
+
+  around do |example|
+    Timecop.freeze(Date.new(2026, 4, 27)) { example.run }
+  end
+
+  let(:params) { { campaign_year: } }
+
+  context 'when campaign_year is missing' do
+    let(:campaign_year) { nil }
+
+    it { is_expected.to be_a_success }
+  end
+
+  context 'when campaign_year is blank' do
+    let(:campaign_year) { '' }
+
+    it { is_expected.to be_a_success }
+  end
+
+  context 'when campaign_year is below the minimum' do
+    let(:campaign_year) { '2020' }
+
+    it { is_expected.to be_a_failure }
+
+    its(:errors) { is_expected.to include(instance_of(UnprocessableEntityError)) }
+  end
+
+  context 'when campaign_year equals the minimum (2021)' do
+    let(:campaign_year) { '2021' }
+
+    it { is_expected.to be_a_success }
+  end
+
+  context 'when campaign_year equals current year - 1' do
+    let(:campaign_year) { '2025' }
+
+    it { is_expected.to be_a_success }
+  end
+
+  context 'when campaign_year equals current year' do
+    let(:campaign_year) { '2026' }
+
+    it { is_expected.to be_a_failure }
+
+    its(:errors) { is_expected.to include(instance_of(UnprocessableEntityError)) }
+  end
+
+  context 'when campaign_year is not a 4-digit string' do
+    let(:campaign_year) { '20a4' }
+
+    it { is_expected.to be_a_failure }
+
+    its(:errors) { is_expected.to include(instance_of(UnprocessableEntityError)) }
+  end
+
+  context 'when campaign_year is an integer in range' do
+    let(:campaign_year) { 2024 }
+
+    it { is_expected.to be_a_success }
+  end
+end

--- a/siade/spec/requests/api_particulier/v3_and_more/cnous/v4/etudiant_boursier_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnous/v4/etudiant_boursier_with_civility_spec.rb
@@ -28,6 +28,16 @@ RSpec.describe 'API Particulier: CNOUS: Etudiant Boursier with Civility v4', api
         ]
       )
 
+      parameter name: :campaignYear,
+        in: :query,
+        description: SwaggerData.get('cnous.etudiant_boursier.parameters.campaignYear.description'),
+        example: SwaggerData.get('cnous.etudiant_boursier.parameters.campaignYear.example'),
+        schema: {
+          type: :integer,
+          minimum: SwaggerData.get('cnous.etudiant_boursier.parameters.campaignYear.minimum')
+        },
+        required: false
+
       let(:nomNaissance) { 'Dupont' }
       let(:'prenoms[]') { %w[Jean Charlie] }
       let(:anneeDateNaissance) { 2000 }

--- a/siade/spec/requests/api_particulier/v3_and_more/cnous/v4/etudiant_boursier_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnous/v4/etudiant_boursier_with_france_connect_spec.rb
@@ -7,6 +7,16 @@ RSpec.describe 'API Particulier: CNOUS: Statut Etudiant with FranceConnect v4', 
 
       common_action_attributes
 
+      parameter name: :campaignYear,
+        in: :query,
+        description: SwaggerData.get('cnous.etudiant_boursier.parameters.campaignYear.description'),
+        example: SwaggerData.get('cnous.etudiant_boursier.parameters.campaignYear.example'),
+        schema: {
+          type: :integer,
+          minimum: SwaggerData.get('cnous.etudiant_boursier.parameters.campaignYear.minimum')
+        },
+        required: false
+
       let(:recipient) { valid_siret(:recipient) }
       let(:Authorization) { 'Bearer super_valid_token' }
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnous/v4/etudiant_boursier_with_ine_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnous/v4/etudiant_boursier_with_ine_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe 'API Particulier: CNOUS: Statut Etudiant with INE v4', api: :part
         },
         required: true
 
+      parameter name: :campaignYear,
+        in: :query,
+        description: SwaggerData.get('cnous.etudiant_boursier.parameters.campaignYear.description'),
+        example: SwaggerData.get('cnous.etudiant_boursier.parameters.campaignYear.example'),
+        schema: {
+          type: :integer,
+          minimum: SwaggerData.get('cnous.etudiant_boursier.parameters.campaignYear.minimum')
+        },
+        required: false
+
       let(:scopes) { %i[cnous_identite cnous_email cnous_statut_boursier cnous_echelon_bourse cnous_statut_bourse cnous_periode_versement cnous_ville_etudes] }
 
       let(:ine) { '1234567890A' }


### PR DESCRIPTION
The upstream CNOUS API has exposed a `campaignYear` parameter since October 2024, allowing callers to target a specific academic year when looking up a student record. Without it, the upstream defaults to the most recent valid scholarship, which prevents partner administrations from processing files that rely on a previous year (appeals, retroactive corrections, after-the- fact controls, etc.).

The parameter is forwarded as-is and stays optional: no scope change, no version bump (backward-compatible). A lower bound of 2021 is enforced since no earlier data exists upstream, and an upper bound of `current_year - 1` prevents calls on the ongoing campaign whose data is not yet consolidated (the dataset is only considered complete by late November).

Only the v4 fiche (latest version) is documented; the already-deprecated v3 is intentionally left untouched to avoid encouraging its use.

Closes https://linear.app/pole-api/issue/API-6580