### PR TITLE
Add agent-vm sandbox setup for site/, siade/ and mocks/

### DIFF
--- a/.agent-vm.runtime.sh
+++ b/.agent-vm.runtime.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env zsh
+# Runs inside the agent-vm Lima VM each time it starts (and on `agent-vm shell`).
+# Bootstraps everything required to run site/, siade/ and mocks/.
+#
+# IMPORTANT: agent-vm pipes this file into `zsh -l` (the shebang is ignored).
+# Keep it zsh-compatible — no BASH_SOURCE, no bash-isms.
+#
+# The agent-vm base image already provides: git, curl, build-essential,
+# Node.js 24, mise, Docker, headless Chromium, ripgrep, gh.
+# We only add what the three Ruby apps need on top.
+#
+# Each step is idempotent and gated so re-runs are fast. Force a full re-run
+# by deleting the relevant marker in $STATE_DIR (or all of $STATE_DIR).
+
+set -eo pipefail
+
+REPO_ROOT="$PWD"
+STATE_DIR="$HOME/.cache/apistration-agent-vm"
+mkdir -p "$STATE_DIR"
+
+log()  { printf '\n\033[1;34m==> %s\033[0m\n' "$*"; }
+skip() { printf '    \033[2m· %s (already done)\033[0m\n' "$*"; }
+done_marker() { touch "$STATE_DIR/$1"; }
+has_marker()  { [ -f "$STATE_DIR/$1" ]; }
+
+# -- 1. system packages -------------------------------------------------------
+if has_marker apt.done; then
+  skip "system packages"
+else
+  log "Installing system packages (postgres, redis, gpgme, libpq, …)"
+  sudo DEBIAN_FRONTEND=noninteractive apt-get update -y
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    postgresql postgresql-contrib \
+    redis-server \
+    libpq-dev \
+    libgpgme-dev libgpgme11t64 \
+    gnupg2 \
+    libyaml-dev libffi-dev libreadline-dev zlib1g-dev libssl-dev \
+    libxml2-dev libxslt1-dev \
+    pkg-config
+  done_marker apt.done
+fi
+
+# -- 2. services --------------------------------------------------------------
+log "Ensuring postgres + redis are running"
+sudo service postgresql status >/dev/null 2>&1 || sudo service postgresql start
+sudo service redis-server status >/dev/null 2>&1 || sudo service redis-server start
+
+# -- 3. pg_hba auth -----------------------------------------------------------
+if has_marker pg-hba.done; then
+  skip "pg_hba (already trust)"
+else
+  log "Relaxing local pg_hba auth (dev VM only)"
+  PG_HBA="$(sudo -u postgres psql -tAc 'SHOW hba_file;')"
+  sudo sed -i \
+    -e 's/^\(local\s\+all\s\+all\s\+\).*/\1trust/' \
+    -e 's/^\(host\s\+all\s\+all\s\+127\.0\.0\.1\/32\s\+\).*/\1trust/' \
+    -e 's/^\(host\s\+all\s\+all\s\+::1\/128\s\+\).*/\1trust/' \
+    "$PG_HBA"
+  sudo service postgresql restart
+  done_marker pg-hba.done
+fi
+
+# -- 4. DB roles + databases --------------------------------------------------
+if sudo -u postgres psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='siade'" 2>/dev/null | grep -q 1 \
+   && sudo -u postgres psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='admin_apientreprise'" 2>/dev/null | grep -q 1; then
+  skip "Postgres roles + databases"
+else
+  log "Creating Postgres roles and databases"
+  sudo -u postgres psql -v ON_ERROR_STOP=0 -f "$REPO_ROOT/site/postgresql_setup.txt"     || true
+  sudo -u postgres psql -v ON_ERROR_STOP=0 -f "$REPO_ROOT/siade/db/postgresql_setup.txt" || true
+fi
+
+# -- 5. mjml ------------------------------------------------------------------
+# mjml-rails (in site/) requires mjml v4 and looks for it in the project's
+# node_modules, not on $PATH. Pin to v4 explicitly — `mjml` (latest) ships v5+
+# which the gem rejects with "Couldn't find the MJML 4. binary".
+if [ -x "$REPO_ROOT/site/node_modules/.bin/mjml" ] \
+   && "$REPO_ROOT/site/node_modules/.bin/mjml" --version 2>/dev/null | grep -q '^mjml-core: 4\.'; then
+  skip "mjml v4 (site/node_modules)"
+else
+  log "Installing mjml@4 locally in site/"
+  ( cd "$REPO_ROOT/site" && npm install --no-save 'mjml@^4' )
+fi
+
+# -- 6. Ruby + bundle per app -------------------------------------------------
+# mise ignores .ruby-version unless idiomatic_version_file is enabled for ruby.
+# Without this, `mise install` finds nothing and `mise exec -- bundle` fails.
+if ! mise settings get idiomatic_version_file_enable_tools 2>/dev/null | grep -q ruby; then
+  log "Enabling .ruby-version support in mise"
+  mise settings add idiomatic_version_file_enable_tools ruby
+fi
+
+log "Ensuring Ruby and gems for site/ siade/ mocks/"
+for app in site siade mocks; do
+  ( cd "$REPO_ROOT/$app"
+    mise install
+    if ! mise exec -- which bundle >/dev/null 2>&1; then
+      log "  → installing bundler ($app)"
+      mise exec -- gem install --no-document --conservative bundler
+    fi
+    if mise exec -- bundle check >/dev/null 2>&1; then
+      skip "$app gems"
+    else
+      log "  → bundle install ($app)"
+      mise exec -- bundle install
+    fi
+  )
+done
+
+# -- 7. siade GPG keys + schema ----------------------------------------------
+# Skip siade/bin/install.sh: it re-tries to install gpgme via brew/apt (noise +
+# permission errors) and runs psql without -U postgres. Reproduce only the
+# parts that aren't covered elsewhere.
+if has_marker siade-bootstrap.done; then
+  skip "siade GPG + schema"
+else
+  log "Bootstrapping siade GPG keys + schema"
+  ( cd "$REPO_ROOT/siade"
+    find config/gpg_public_keys_for_data_encryption -type f -name '*.asc' -print0 \
+      | xargs -0 -r gpg2 --import 2>&1 | grep -v '^gpg: key .* not changed$' || true
+
+    signer_email=$(mise exec -- ruby -ryaml -e 'print YAML.load_file("config/encrypt_data_signer_data.yml")["shared"]["signer_email"]')
+    signer_pass=$(mise exec -- ruby -ryaml -e 'print YAML.load_file("config/encrypt_data_signer_data.yml")["shared"]["signer_passphrase"]')
+
+    if ! gpg2 --list-keys 2>/dev/null | grep -q "$signer_email"; then
+      mkdir -p ~/.gnupg
+      grep -q use-agent              ~/.gnupg/gpg.conf       2>/dev/null || echo use-agent              >> ~/.gnupg/gpg.conf
+      grep -q "pinentry-mode loopback" ~/.gnupg/gpg.conf     2>/dev/null || echo pinentry-mode loopback >> ~/.gnupg/gpg.conf
+      grep -q allow-loopback-pinentry ~/.gnupg/gpg-agent.conf 2>/dev/null || echo allow-loopback-pinentry >> ~/.gnupg/gpg-agent.conf
+      echo RELOADAGENT | gpg-connect-agent
+      printf 'Key-Type: DSA\nKey-Length: 1024\nSubkey-Type: ELG-E\nSubkey-Length: 1024\nName-Real: Test User\nName-Email: %s\nExpire-Date: 0\nPassphrase: %s\n%%commit\n' \
+        "$signer_email" "$signer_pass" | gpg2 --batch --gen-key
+    fi
+
+    mise exec -- bin/rails db:schema:load RAILS_ENV=test
+    mise exec -- bin/rails db:schema:load RAILS_ENV=development
+  ) && done_marker siade-bootstrap.done \
+    || echo "siade bootstrap returned non-zero (delete $STATE_DIR/siade-bootstrap.done to retry)"
+fi
+
+# -- 8. site schema + seeds ---------------------------------------------------
+if has_marker site-bootstrap.done; then
+  skip "site schema + seeds"
+else
+  log "Loading site/ schema (test + development) and seeds"
+  ( cd "$REPO_ROOT/site"
+    mise exec -- bin/rails db:schema:load RAILS_ENV=test
+    mise exec -- bin/rails db:schema:load RAILS_ENV=development
+    mise exec -- bin/rails db:seed:replant
+  ) && done_marker site-bootstrap.done \
+    || echo "site bootstrap returned non-zero (delete $STATE_DIR/site-bootstrap.done to retry)"
+fi
+
+log "Ready. Servers:"
+cat <<'EOF'
+  site   : cd site   && bin/local.sh           (http://entreprise.api.localtest.me:5000)
+  siade  : cd siade  && bin/rails s -p 3000
+  mocks  : cd mocks  && bundle exec rspec      (data-only repo, no server)
+
+  Force a full re-bootstrap: rm -rf ~/.cache/apistration-agent-vm
+EOF

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ tmp/
 siade/.env.local
 site/.env.local
 .env.local
+site/node_modules/

--- a/README.md
+++ b/README.md
@@ -20,6 +20,38 @@ Built and maintained by [DINUM](https://www.numerique.gouv.fr/) (Direction Inter
 
 - [`bin/setup_worktree.sh`](bin/setup_worktree.sh) `<path> [branch]` — crée un git worktree et génère des `.env.local` dans `site/` et `siade/` pour isoler les bases Postgres (dev/test) par worktree (via `dotenv-rails`).
 
+## Sandbox via [agent-vm](https://github.com/sylvinus/agent-vm)
+
+Run AI coding agents (Claude Code, OpenCode, Codex) inside an isolated Lima VM. The agent gets full autonomy inside the VM while the host stays clean — no Node, Docker, Postgres or Ruby toolchain to install locally. The repository ships the configuration:
+
+- [`.agent-vm.runtime.sh`](.agent-vm.runtime.sh) — *per-project* script, replayed by agent-vm on every VM start (including each `agent-vm shell`). Installs `postgresql`, `redis-server`, `libgpgme-dev`, `libpq-dev`, `mjml@4` (locally in `site/`), Ruby via `mise` (with `.ruby-version` support enabled), then runs `bundle install`, generates the `siade` GPG signing key, and loads schemas + seeds for `site/` and `siade/`. **Idempotent**: every step is gated either by a marker file in `~/.cache/apistration-agent-vm/` or by a state check (apt packages already installed, services up, Postgres roles existing, gems resolved, etc.). Subsequent runs collapse to a few seconds of no-op checks. Force a full re-bootstrap with `rm -rf ~/.cache/apistration-agent-vm` inside the VM, or `agent-vm rm` from the host to start over with a fresh VM.
+- [`runtime.example.sh`](runtime.example.sh) — *per-user* template to copy into `~/.agent-vm/runtime.sh` for your SSH key, git identity (with `format.signOff = true`, required by [`CONTRIBUTING.md`](CONTRIBUTING.md)), `gh auth`, MCP servers, etc. Keep your real copy out of any repository — it may contain secrets.
+
+Host-side setup (once):
+
+```sh
+git clone https://github.com/sylvinus/agent-vm.git ~/src/agent-vm
+echo "source ~/src/agent-vm/agent-vm.sh" >> ~/.zshrc   # or ~/.bashrc
+exec $SHELL
+agent-vm setup --disk 30 --memory 8 --cpus 4
+
+cp runtime.example.sh ~/.agent-vm/runtime.sh
+chmod +x ~/.agent-vm/runtime.sh
+$EDITOR ~/.agent-vm/runtime.sh                          # fill in SSH key, identity, gh token
+```
+
+Usage from the repository root:
+
+```sh
+agent-vm claude        # Claude Code
+agent-vm opencode      # OpenCode
+agent-vm codex         # Codex CLI
+agent-vm shell         # zsh shell inside the VM
+agent-vm --offline claude   # Block outbound internet (code review, audit…)
+```
+
+Lima auto-forwards ports: `http://entreprise.api.localtest.me:5000` is reachable from the host browser. The VM persists across sessions; see the [agent-vm README](https://github.com/sylvinus/agent-vm#vm-lifecycle) for `stop` / `rm` / `--rm`.
+
 ## Contributing
 
 External contributions are welcome. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for ground rules, workflow, and requirements (signed-off commits, tests, green CI, RGAA accessibility).

--- a/mocks/Gemfile.lock
+++ b/mocks/Gemfile.lock
@@ -55,6 +55,7 @@ GEM
       concurrent-ruby (~> 1.0)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-22
   arm64-darwin-24
   arm64-darwin-25

--- a/runtime.example.sh
+++ b/runtime.example.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+# =============================================================================
+# runtime.example.sh — Template for ~/.agent-vm/runtime.sh
+# =============================================================================
+#
+# This file runs inside every agent-vm on each start, BEFORE the per-project
+# .agent-vm.runtime.sh script. It is the right place for things tied to *you*
+# (SSH keys, git identity, GitHub auth, Claude config) rather than to the
+# project (those go in the repo's .agent-vm.runtime.sh).
+#
+# Setup:
+#   cp runtime.example.sh ~/.agent-vm/runtime.sh
+#   chmod +x ~/.agent-vm/runtime.sh
+#   # Edit with your own values, then uncomment the sections you need.
+#
+# This file is a TEMPLATE: it must stay free of secrets. Keep your real
+# ~/.agent-vm/runtime.sh out of any repository.
+
+
+# =============================================================================
+# 1. SSH authentication for GitHub
+# =============================================================================
+#
+# Embed your SSH private key (base64-encoded) so the VM can push, pull and
+# clone over SSH. Without this the VM has no way to talk to GitHub privately.
+#
+#   To encode your key on the host:
+#     cat ~/.ssh/id_ed25519 | base64
+#
+# Paste the output below.
+
+# SSH_KEY_B64="<your-base64-encoded-private-key>"
+# mkdir -p ~/.ssh && chmod 700 ~/.ssh
+# echo "$SSH_KEY_B64" | base64 -d > ~/.ssh/id_ed25519
+# chmod 600 ~/.ssh/id_ed25519
+# ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+
+
+# =============================================================================
+# 2. Git identity (required by APIstration's DCO policy)
+# =============================================================================
+#
+# CONTRIBUTING.md requires every commit to carry a `Signed-off-by` trailer
+# (Developer Certificate of Origin). `format.signOff = true` makes `git commit`
+# add it automatically — no need to remember `-s`.
+#
+# Recommendation: do NOT run `git commit` from inside the VM if you sign your
+# commits with a GPG/SSH key that lives only on the host. Commit from the host
+# instead. The VM can still stage, diff, push and review.
+
+# git config --global user.name  "Your Name"
+# git config --global user.email "you@example.com"
+# git config --global format.signOff true
+
+# Force SSH for all GitHub remotes (avoids HTTPS credential prompts):
+# git config --global url."git@github.com:".insteadOf "https://github.com/"
+
+
+# =============================================================================
+# 3. GitHub CLI authentication
+# =============================================================================
+#
+# Required for `gh pr create`, `gh issue comment`, `gh run watch`, etc. from
+# inside the VM. The agent will use it heavily.
+#
+#   Create a fine-grained token: https://github.com/settings/tokens
+#   Scopes needed: repo, read:org, workflow
+#
+# Tip: store the token in `security` (macOS Keychain) on the host and inject
+# it via an env var when launching the VM, instead of hard-coding it here.
+
+# echo "<your-github-pat>" | gh auth login --with-token
+
+
+# =============================================================================
+# 4. Claude Code skills shared across all your VMs
+# =============================================================================
+#
+# Skills cloned here are available in every project the VM mounts.
+# APIstration ships project-specific skills under .claude/skills/ in the repo
+# itself (e.g. edit-endpoint, bump-version, siade-sync-openapi-payloads); those
+# are picked up automatically — do NOT duplicate them here.
+
+# mkdir -p ~/.claude/skills
+# git clone git@github.com:your-org/claude-skills.git ~/.claude/skills/your-org-skills
+
+
+# =============================================================================
+# 5. MCP servers (user scope)
+# =============================================================================
+#
+# The agent-vm base image already pre-configures Chrome DevTools MCP. Add
+# servers you want available in every project. Examples below — uncomment the
+# ones you actually use.
+
+# Linear (issue tracker):
+# claude mcp add --scope user linear-server npx -y @linear/mcp-server@latest
+
+# Sentry (production errors — siade has bin/sentry/ helpers):
+# claude mcp add --scope user sentry npx -y @sentry/mcp-server@latest
+
+
+# =============================================================================
+# 6. APIstration-specific niceties
+# =============================================================================
+
+# 6a. Pre-warm bundler caches across VMs. Bundling Ruby 4.0.1 + Rails for
+# site/, siade/ and mocks/ takes a while on a fresh VM; mounting a shared
+# bundle cache speeds it up significantly. Lima must mount ~/.bundle as RW
+# for this to help; see https://lima-vm.io/docs/config/mounts/.
+#
+# bundle config --global path "$HOME/.bundle/cache"
+
+# 6b. Worktree helper. The repo ships bin/setup_worktree.sh which generates
+# isolated .env.local files per worktree (Postgres DBs are namespaced by
+# worktree slug). If you create worktrees from inside the VM, alias it:
+#
+# alias awk-worktree='bash bin/setup_worktree.sh'
+
+# 6c. Default RAILS_ENV. The VM is intentionally non-production; keep it that
+# way to avoid hitting production credentials by accident.
+#
+# export RAILS_ENV=development
+
+
+# =============================================================================
+# 7. Claude Code status line (optional)
+# =============================================================================
+#
+# Show the current git branch at the bottom of the Claude Code UI. Useful when
+# you juggle several worktrees inside a single VM.
+
+# cat > /tmp/statusline-patch.json << 'PATCH'
+# {"statusLine": {"command": "git branch --show-current 2>/dev/null || echo ''"}}
+# PATCH
+#
+# if [ -f ~/.claude/settings.json ]; then
+#   jq -s '.[0] * .[1]' ~/.claude/settings.json /tmp/statusline-patch.json > /tmp/settings-merged.json
+#   mv /tmp/settings-merged.json ~/.claude/settings.json
+# else
+#   mkdir -p ~/.claude
+#   cp /tmp/statusline-patch.json ~/.claude/settings.json
+# fi
+# rm -f /tmp/statusline-patch.json


### PR DESCRIPTION
agent-vm (https://github.com/sylvinus/agent-vm) runs AI coding agents inside an isolated Lima VM. The host stays clean — no Node, Postgres, Docker or Ruby toolchain leaks onto the dev machine — while the agent gets full autonomy inside the VM.

Bring-up of the three sub-projects requires non-trivial bootstrap (postgres + redis services, GPG keys for siade encryption, mjml v4 for site mailers, etc.). Doing it by hand on every fresh VM is error-prone, so the per-project hook .agent-vm.runtime.sh wires it up end-to-end:

  * apt: postgresql, redis-server, libpq-dev, libgpgme-dev and the libs Ruby native gems need
  * pg_hba relaxed to trust on the loopback (dev VM only — VMs are throw-away and isolated by Lima)
  * postgres roles + databases for site and siade
  * mjml@4 installed locally in site/node_modules (mjml-rails rejects v5+ with "Couldn't find the MJML 4 binary" and looks in Rails.root/node_modules first)
  * Ruby via mise; .ruby-version support enabled explicitly (idiomatic_version_file_enable_tools = ruby) since mise ignores it by default
  * bundle install for site/, siade/, mocks/, with bundler ensured per install
  * siade GPG signer key generation (inlined instead of calling siade/bin/install.sh, which retries brew/apt without sudo and connects psql as $USER)
  * db:schema:load (test + development) and db:seed:replant for site and siade

Every section is idempotent: marker files in
~/.cache/apistration-agent-vm/ for one-shot operations, state checks (dpkg, command -v, pg_roles, bundle check, mjml --version) for the rest. Re-running `agent-vm shell` is a few seconds of no-ops once the VM is bootstrapped.

runtime.example.sh is the user-scoped counterpart, adapted from the upstream template. It documents how to inject SSH keys, configure git identity (with format.signOff = true to honour the DCO requirement from CONTRIBUTING.md), authenticate gh, register MCP servers, etc. Users copy it to ~/.agent-vm/runtime.sh — never committed to any repo.

Side-effects pulled in:
  * .gitignore ignores site/node_modules/ (created by mjml local install)
  * mocks/Gemfile.lock gains the aarch64-linux platform so `bundle install` works on the ARM Linux VM without lockfile churn