### PR TITLE
Add budget-reporting skill

### DIFF
--- a/.claude/skills/budget-reporting/SKILL.md
+++ b/.claude/skills/budget-reporting/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: budget-reporting
+description: Génère le reporting d'activité périodique (mensuel, trimestriel) de l'équipe API Entreprise / API Particulier sur le repo `datagouv/apistration` à partir des commits, PRs GitHub et issues Linear. Produit 4 livrables dans `sandbox/` à 4 niveaux de détail. Use when user asks for "reporting budgétaire", "summary du mois", "bilan mensuel", "reporting d'activité", "budget summary", "executive summary mensuel", ou tout reporting périodique d'activité sur apistration.
+---
+
+# Budget Reporting
+
+Génère un reporting d'activité périodique pour `datagouv/apistration` à 4 niveaux de détail.
+
+**Prérequis** : le MCP `linear-server` doit être branché (les sujets non-tech — recherche utilisateur, partenariats, COPIL, événements — sont uniquement dans Linear). Si le MCP n'est pas disponible, le signaler à l'utilisateur avant de démarrer ; ne pas tenter de contourner.
+
+## Étape 1 — Recueillir les paramètres
+
+Avant toute exploration, poser deux questions à l'utilisateur (en un seul message, format compact) :
+
+1. **Période** : dates de début et fin (ex. `2026-04-01 → 2026-04-30`). Déduire le suffixe de fichier (ex. `avril`, `2026-q2`).
+2. **Évolutions notables hors Linear/GitHub** : événements structurants invisibles dans les commits/PRs/issues — partenariat signé, COPIL, événement externe, décision d'org, lancement d'un programme transverse, etc.
+
+Ne pas démarrer l'exploration tant que la réponse n'est pas reçue.
+
+## Étape 2 — Exploration
+
+Collecter dans cet ordre, en parallèle quand c'est possible :
+
+1. **Commits sur `develop`** dans la période :
+   ```bash
+   git log --since=YYYY-MM-DD --until=YYYY-MM-DD --pretty=format:'%h %ad %s' --date=short develop
+   ```
+2. **PRs GitHub** sur `datagouv/apistration` (mergées + ouvertes + fermées dans la période) :
+   ```bash
+   gh pr list --repo datagouv/apistration --state all --limit 200 \
+     --search "merged:YYYY-MM-DD..YYYY-MM-DD" \
+     --json number,title,author,mergedAt,labels
+   gh pr list --repo datagouv/apistration --state all --limit 200 \
+     --search "created:YYYY-MM-DD..YYYY-MM-DD" \
+     --json number,title,author,state,createdAt
+   ```
+   Lire le body des PRs significatives via `gh pr view <num> --repo datagouv/apistration`.
+3. **Issues GitHub** ouvertes ou fermées dans la période :
+   ```bash
+   gh issue list --repo datagouv/apistration --state all \
+     --search "created:YYYY-MM-DD..YYYY-MM-DD" --json number,title,author,state
+   ```
+5. **Linear** : `mcp__linear-server__list_issues` pour les issues mises à jour dans la période. Filtrer par équipe API Entreprise / API Particulier. Pour les sujets non-tech (recherche utilisateur, partenariats, événements, COPIL), Linear est souvent la seule source.
+6. **Évolutions hors Linear/GitHub** fournies par l'utilisateur à l'étape 1.
+
+## Étape 3 — Production des livrables
+
+Produire **4 fichiers** dans `sandbox/` (créer le dossier s'il n'existe pas), avec un suffixe dérivé de la période (ex. `avril`, `2026-04`, `2026-q2`) :
+
+| Fichier | Audience | Style | Template |
+|---|---|---|---|
+| `sandbox/budget-summary-<suffixe>.exploration.md` | trace interne | brut, exhaustif | `references/exploration.md` |
+| `sandbox/budget-summary-<suffixe>.md` | tech / responsables produit | détaillé, structuré, avec PR# | `references/tech-summary.md` |
+| `sandbox/budget-executive-summary-<suffixe>.md` | direction / business | synthèse non technique | `references/executive-summary.md` |
+| `sandbox/budget-flash-<suffixe>.md` | livrable comm | ultra-court, 3 sections | `references/flash.md` |
+
+Lire le template correspondant avant d'écrire chaque fichier.
+
+## Règles transversales
+
+- Tout en français.
+- Pas d'emojis.
+- Numéros de PR (`PR #N`) inclus dans `exploration` et `tech-summary` ; retirés dans `executive` et `flash`.
+- Distinguer **API Particulier** (CNOUS, CAF/CNAV QF, MEN bourses, Pôle Emploi, DGFiP particulier…) et **API Entreprise** (Data Subvention, GIP-MDS effectifs, INSEE, DGFiP entreprise, Acoss/Urssaf, MICAF…) lorsque le contexte le permet.
+- Le fichier `exploration` doit permettre de régénérer les 3 autres : y consigner toutes les sources brutes (PRs, commits, issues Linear par identifiant, événements externes).
+- Le fichier `flash` doit tenir en ~15 bullets sur 3 sections : Évolutions notables / API Particulier / API Entreprise.
+- Ne jamais inventer de chiffres : toute volumétrie citée doit provenir de l'exploration.
+
+## Étape 4 — Restitution
+
+Annoncer les 4 chemins créés en une phrase. Ne pas recopier le contenu.

--- a/.claude/skills/budget-reporting/references/executive-summary.md
+++ b/.claude/skills/budget-reporting/references/executive-summary.md
@@ -1,0 +1,50 @@
+# Template — executive summary
+
+But : synthèse non technique pour la direction et les partenaires.
+
+## Style
+
+- Vulgariser : pas de noms de PR, pas de jargon technique, pas d'identifiants Linear.
+- Phrases courtes, parler en termes de valeur utilisateur et d'impact.
+- Une à deux pages max.
+- Garder un ton sobre, factuel.
+
+## Structure recommandée
+
+```markdown
+# Synthèse exécutive — <période lisible>
+
+## Le mois en une phrase
+<phrase qui capture l'essentiel : le fait marquant ou la dynamique générale>
+
+## Faits marquants
+### <Événement 1>
+2-4 phrases. Pourquoi c'est important, ce que ça permet.
+
+### <Événement 2>
+...
+
+## Améliorations livrées aux utilisateurs
+- **<Sujet>** : description en termes utilisateurs.
+
+## Qualité de service
+- Stabilisation, optimisations, fiabilité.
+
+## Communication
+- Annonces, maintenances, bandeaux.
+
+## Travail produit et partenariats
+- Entretiens utilisateurs, webinaires, ateliers, rendez-vous partenaires, accompagnement éditeurs.
+
+## Activité
+- Volumétrie haut niveau (« une soixantaine d'évolutions », « N issues utilisateurs traitées »).
+
+## À suivre
+- Prochains jalons sur la période suivante.
+```
+
+## Règles
+
+- Traduire les sujets techniques : « refactor user-management » devient « pose les fondations de la délégation éditeur ».
+- Citer les contributions externes par leur valeur (« deux premières contributions extérieures reçues ») sans handle GitHub.
+- Pas de PR# ni de SHA.

--- a/.claude/skills/budget-reporting/references/exploration.md
+++ b/.claude/skills/budget-reporting/references/exploration.md
@@ -1,0 +1,62 @@
+# Template — exploration
+
+But : trace brute permettant de régénérer les 3 autres livrables sans relancer l'exploration.
+
+## Style
+
+- Exhaustif, pas de filtre éditorial.
+- Listes plates ou tableaux.
+- Inclure tous les identifiants (PR#, commit SHA court, identifiants Linear, issues GitHub).
+- Conserver les liens vers anciens dépôts si pertinents.
+
+## Structure recommandée
+
+```markdown
+# Exploration — <période>
+
+## Périmètre
+- Repo : datagouv/apistration (+ anciens dépôts si applicable)
+- Période : YYYY-MM-DD → YYYY-MM-DD
+- Sources : commits develop, PRs GitHub, issues GitHub, Linear, évolutions hors-tracker
+
+## Évolutions hors Linear/GitHub
+<bullets fournis par l'utilisateur, verbatim>
+
+## PRs mergées
+| # | Titre | Auteur | Date merge | Thème |
+|---|---|---|---|---|
+| ... | ... | ... | ... | ... |
+
+## PRs ouvertes / non mergées en fin de période
+| # | Titre | État | Auteur | Notes |
+
+## PRs sur anciens dépôts
+<si applicable>
+
+## Issues GitHub
+| # | Titre | État | Auteur |
+
+## Issues Linear
+Regrouper par projet / thème. Inclure l'identifiant Linear (ex. `APE-123`).
+
+### Délégation éditeur
+- APE-XXX : ...
+
+### <autre projet>
+- ...
+
+## Commits notables (hors merges et hors PRs déjà listées)
+<sha court + message>
+
+## Volumétrie
+- Nombre de PRs mergées : N
+- Nombre de commits sur develop : N (hors merges)
+- Issues GitHub externes : N
+- Contributions externes : N (lister)
+```
+
+## Règles
+
+- Ne pas synthétiser : c'est la matière première.
+- Si une PR n'a pas pu être lue, le noter explicitement.
+- Lister les contributions externes nominativement (handle GitHub).

--- a/.claude/skills/budget-reporting/references/flash.md
+++ b/.claude/skills/budget-reporting/references/flash.md
@@ -1,0 +1,41 @@
+# Template — flash
+
+But : livrable de communication ultra-court, lisible en 30 secondes.
+
+## Style
+
+- ~15 bullets au total, répartis sur 3 sections.
+- Une phrase par bullet, sans subordonnées en cascade.
+- Pas de PR#, pas de jargon.
+- Toujours les mêmes 3 sections, dans l'ordre suivant.
+
+## Structure obligatoire
+
+```markdown
+# Flash <période>
+
+## Évolutions notables
+
+- <fait marquant 1, transverse ou non-tech>
+- <fait marquant 2>
+- <chantier en préparation>
+
+## API Particulier
+
+- <livraison utilisateur 1>
+- <livraison utilisateur 2>
+- <correctif ou amélioration>
+
+## API Entreprise
+
+- <livraison utilisateur 1>
+- <livraison utilisateur 2>
+- <correctif, transparence, ou indicateur>
+```
+
+## Règles
+
+- Maximum 5 bullets par section, idéalement 3.
+- Si une évolution touche les deux APIs (ex. transparence des limites d'usage), la mettre dans la section où elle est la plus pertinente, pas dans les deux.
+- Si la période n'a pas de fait marquant transverse, mettre dans « Évolutions notables » les chantiers structurants en cours (préparation d'un projet, refonte, partenariat).
+- Ne jamais dépasser une page.

--- a/.claude/skills/budget-reporting/references/tech-summary.md
+++ b/.claude/skills/budget-reporting/references/tech-summary.md
@@ -1,0 +1,60 @@
+# Template — tech summary
+
+But : reporting détaillé pour responsables produit / tech, basé sur l'exploration.
+
+## Style
+
+- Détaillé mais éditorialisé : grouper par thème, pas par PR.
+- Inclure les numéros de PR entre parenthèses (ex. `PR #69`).
+- Distinguer livré / en cours / non livré.
+- Mentionner les contributions externes.
+
+## Structure recommandée
+
+```markdown
+# Reporting <type> — <période lisible>
+
+Période : YYYY-MM-DD → YYYY-MM-DD. Périmètre : `datagouv/apistration` (+ anciens dépôts si applicable).
+
+## Fait marquant
+<événement structurant de la période, hors-tracker ou non>
+
+## Évolutions fonctionnelles d'API
+- **<Fournisseur / Produit>** : description (PR #N, PR #M).
+- ...
+
+Regrouper par fournisseur (MEN, CNOUS, CNAV, CNAF, INSEE, GIP-MDS, DataSubvention, …).
+
+## Fiabilité et performance
+- ...
+
+## Communication produit
+- ...
+
+## Sécurité, secrets, CI/CD
+- ...
+
+## Outillage développeur / agentique
+- ...
+
+## Contributions externes
+- **<handle>** (PR #N) : description.
+
+## En cours / non livré
+- **<chantier>** : état, PR ouverte, identifiants Linear.
+
+## Sujets non techniques (Linear)
+Recherche utilisateur, webinaires, ateliers, partenariats, COPIL, accompagnement éditeurs, statistiques.
+
+## Volumétrie
+- ~N PRs créées, dont ~M mergées.
+- ~N commits sur develop.
+- N issues GitHub externes traitées.
+- N PRs sur anciens dépôts (si applicable).
+```
+
+## Règles
+
+- Pas de tableau exhaustif des PRs — c'est le rôle de l'exploration.
+- Privilégier la phrase explicative au copier-coller du titre de PR.
+- Citer les chiffres tels que comptés dans l'exploration.


### PR DESCRIPTION
Skill projet pour générer le reporting d'activité périodique de l'équipe (API Entreprise / API Particulier) à partir des commits, PRs GitHub et issues Linear, et produire 4 livrables dans sandbox/ à 4 niveaux de détail : exploration brute, summary tech, executive summary business, flash ultra-court.

Le SKILL.md gouverne le workflow (questions sur la période et les évolutions hors-tracker, exploration, écriture des 4 fichiers) et délègue la mise en forme à 4 templates dans references/.

Prérequis explicitement signalé : le MCP linear-server doit être branché (les sujets non-tech ne sont que dans Linear).