### PR TITLE
Enhance errors management to make it public on our site (scoped to URSSAF only)

### DIFF
--- a/commons/swagger/openapi-entreprise.yaml
+++ b/commons/swagger/openapi-entreprise.yaml
@@ -472,7 +472,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_04999:
                   value:
                     errors:
                     - code: '04999'
@@ -487,6 +487,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_04000:
+                  value:
+                    errors:
+                    - code: '04000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: ACOSS
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_04008:
+                  value:
+                    errors:
+                    - code: '04008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: ACOSS
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_04011:
+                  value:
+                    errors:
+                    - code: '04011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: ACOSS
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_04009:
+                  value:
+                    errors:
+                    - code: '04009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: ACOSS
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
                 fichier_renvoye_par_le_fournisseur_de_donnees_non_valide_04051:
                   value:
                     errors:
@@ -601,6 +655,19 @@ paths:
                   description: Il n'est pas possible de renvoyer l'attestation. Cela
                     peut être dû au fait qu'un des établissements d'une entreprise
                     n'a pas retourné les informations.
+                erreur_reseau_du_service_d_hebergement_de_donnees_00502:
+                  value:
+                    errors:
+                    - code: '00502'
+                      title: Erreur réseau du service d'hébergement de données
+                      detail: Problème de connexion au serveur d'hébergement de données.
+                        L'erreur peut venir soit du fournisseur, soit de API Entreprise
+                      source:
+                      meta:
+                        retry_in: 10
+                  summary: Erreur réseau du service d'hébergement de données
+                  description: Problème de connexion au serveur d'hébergement de données.
+                    L'erreur peut venir soit du fournisseur, soit de API Entreprise
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -1190,7 +1257,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_19999:
                   value:
                     errors:
                     - code: '19999'
@@ -1205,6 +1272,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_19000:
+                  value:
+                    errors:
+                    - code: '19000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: ADEME
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_19008:
+                  value:
+                    errors:
+                    - code: '19008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: ADEME
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_19011:
+                  value:
+                    errors:
+                    - code: '19011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: ADEME
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_19009:
+                  value:
+                    errors:
+                    - code: '19009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: ADEME
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -1873,7 +1994,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_17999:
                   value:
                     errors:
                     - code: '17999'
@@ -1888,6 +2009,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_17000:
+                  value:
+                    errors:
+                    - code: '17000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: Banque de France
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_17008:
+                  value:
+                    errors:
+                    - code: '17008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: Banque de France
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_17011:
+                  value:
+                    errors:
+                    - code: '17011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: Banque de France
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_17009:
+                  value:
+                    errors:
+                    - code: '17009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: Banque de France
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -2526,7 +2701,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_33999:
                   value:
                     errors:
                     - code: '33999'
@@ -2541,6 +2716,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_33000:
+                  value:
+                    errors:
+                    - code: '33000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: CARIF-OREF
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_33008:
+                  value:
+                    errors:
+                    - code: '33008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: CARIF-OREF
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_33011:
+                  value:
+                    errors:
+                    - code: '33011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: CARIF-OREF
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_33009:
+                  value:
+                    errors:
+                    - code: '33009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: CARIF-OREF
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -2873,7 +3102,7 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_38999:
                   value:
                     errors:
                     - code: '38999'
@@ -2888,6 +3117,83 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_38000:
+                  value:
+                    errors:
+                    - code: '38000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: CIBTP
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_38008:
+                  value:
+                    errors:
+                    - code: '38008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: CIBTP
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_38011:
+                  value:
+                    errors:
+                    - code: '38011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: CIBTP
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_38009:
+                  value:
+                    errors:
+                    - code: '38009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: CIBTP
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
+                fichier_renvoye_par_le_fournisseur_de_donnees_non_valide_38055:
+                  value:
+                    errors:
+                    - code: '38055'
+                      title: Fichier renvoyé par le fournisseur de données non valide
+                      detail: Le fichier n'est pas au format attendu
+                      source:
+                      meta: {}
+                  summary: Fichier renvoyé par le fournisseur de données non valide
+                  description: Le fichier n'est pas au format attendu
+                erreur_reseau_du_service_d_hebergement_de_donnees_00502:
+                  value:
+                    errors:
+                    - code: '00502'
+                      title: Erreur réseau du service d'hébergement de données
+                      detail: Problème de connexion au serveur d'hébergement de données.
+                        L'erreur peut venir soit du fournisseur, soit de API Entreprise
+                      source:
+                      meta:
+                        retry_in: 10
+                  summary: Erreur réseau du service d'hébergement de données
+                  description: Problème de connexion au serveur d'hébergement de données.
+                    L'erreur peut venir soit du fournisseur, soit de API Entreprise
         '404':
           description: Non trouvée
           content:
@@ -3247,7 +3553,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_08999:
                   value:
                     errors:
                     - code: '08999'
@@ -3262,6 +3568,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_08000:
+                  value:
+                    errors:
+                    - code: '08000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: CNETP
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_08008:
+                  value:
+                    errors:
+                    - code: '08008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: CNETP
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_08011:
+                  value:
+                    errors:
+                    - code: '08011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: CNETP
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_08009:
+                  value:
+                    errors:
+                    - code: '08009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: CNETP
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
                 fichier_renvoye_par_le_fournisseur_de_donnees_non_valide_08051:
                   value:
                     errors:
@@ -3328,6 +3688,19 @@ paths:
                   summary: Fichier renvoyé par le fournisseur de données non valide
                   description: Le fichier renvoyé par le fournisseur de données est
                     vide
+                erreur_reseau_du_service_d_hebergement_de_donnees_00502:
+                  value:
+                    errors:
+                    - code: '00502'
+                      title: Erreur réseau du service d'hébergement de données
+                      detail: Problème de connexion au serveur d'hébergement de données.
+                        L'erreur peut venir soit du fournisseur, soit de API Entreprise
+                      source:
+                      meta:
+                        retry_in: 10
+                  summary: Erreur réseau du service d'hébergement de données
+                  description: Problème de connexion au serveur d'hébergement de données.
+                    L'erreur peut venir soit du fournisseur, soit de API Entreprise
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -3999,7 +4372,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_52999:
                   value:
                     errors:
                     - code: '52999'
@@ -4014,6 +4387,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_52000:
+                  value:
+                    errors:
+                    - code: '52000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: DataSubvention
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_52008:
+                  value:
+                    errors:
+                    - code: '52008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: DataSubvention
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_52011:
+                  value:
+                    errors:
+                    - code: '52011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: DataSubvention
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_52009:
+                  value:
+                    errors:
+                    - code: '52009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: DataSubvention
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -4403,7 +4830,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_16999:
                   value:
                     errors:
                     - code: '16999'
@@ -4418,6 +4845,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_16000:
+                  value:
+                    errors:
+                    - code: '16000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: DGDDI
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_16008:
+                  value:
+                    errors:
+                    - code: '16008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: DGDDI
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_16011:
+                  value:
+                    errors:
+                    - code: '16011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: DGDDI
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_16009:
+                  value:
+                    errors:
+                    - code: '16009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: DGDDI
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -4836,7 +5317,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_03999:
                   value:
                     errors:
                     - code: '03999'
@@ -4851,6 +5332,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_03000:
+                  value:
+                    errors:
+                    - code: '03000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: DGFIP - Adélie
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_03008:
+                  value:
+                    errors:
+                    - code: '03008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: DGFIP - Adélie
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_03011:
+                  value:
+                    errors:
+                    - code: '03011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: DGFIP - Adélie
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_03009:
+                  value:
+                    errors:
+                    - code: '03009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: DGFIP - Adélie
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
                 fichier_renvoye_par_le_fournisseur_de_donnees_non_valide_03051:
                   value:
                     errors:
@@ -4917,6 +5452,19 @@ paths:
                   summary: Fichier renvoyé par le fournisseur de données non valide
                   description: Le fichier renvoyé par le fournisseur de données est
                     vide
+                erreur_reseau_du_service_d_hebergement_de_donnees_00502:
+                  value:
+                    errors:
+                    - code: '00502'
+                      title: Erreur réseau du service d'hébergement de données
+                      detail: Problème de connexion au serveur d'hébergement de données.
+                        L'erreur peut venir soit du fournisseur, soit de API Entreprise
+                      source:
+                      meta:
+                        retry_in: 10
+                  summary: Erreur réseau du service d'hébergement de données
+                  description: Problème de connexion au serveur d'hébergement de données.
+                    L'erreur peut venir soit du fournisseur, soit de API Entreprise
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -5338,7 +5886,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_03999:
                   value:
                     errors:
                     - code: '03999'
@@ -5353,6 +5901,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_03000:
+                  value:
+                    errors:
+                    - code: '03000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: DGFIP - Adélie
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_03008:
+                  value:
+                    errors:
+                    - code: '03008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: DGFIP - Adélie
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_03011:
+                  value:
+                    errors:
+                    - code: '03011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: DGFIP - Adélie
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_03009:
+                  value:
+                    errors:
+                    - code: '03009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: DGFIP - Adélie
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
                 fichier_renvoye_par_le_fournisseur_de_donnees_non_valide_03051:
                   value:
                     errors:
@@ -5419,6 +6021,19 @@ paths:
                   summary: Fichier renvoyé par le fournisseur de données non valide
                   description: Le fichier renvoyé par le fournisseur de données est
                     vide
+                erreur_reseau_du_service_d_hebergement_de_donnees_00502:
+                  value:
+                    errors:
+                    - code: '00502'
+                      title: Erreur réseau du service d'hébergement de données
+                      detail: Problème de connexion au serveur d'hébergement de données.
+                        L'erreur peut venir soit du fournisseur, soit de API Entreprise
+                      source:
+                      meta:
+                        retry_in: 10
+                  summary: Erreur réseau du service d'hébergement de données
+                  description: Problème de connexion au serveur d'hébergement de données.
+                    L'erreur peut venir soit du fournisseur, soit de API Entreprise
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -5825,7 +6440,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_03999:
                   value:
                     errors:
                     - code: '03999'
@@ -5840,6 +6455,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_03000:
+                  value:
+                    errors:
+                    - code: '03000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: DGFIP - Adélie
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_03008:
+                  value:
+                    errors:
+                    - code: '03008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: DGFIP - Adélie
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_03011:
+                  value:
+                    errors:
+                    - code: '03011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: DGFIP - Adélie
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_03009:
+                  value:
+                    errors:
+                    - code: '03009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: DGFIP - Adélie
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -6463,7 +7132,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_03999:
                   value:
                     errors:
                     - code: '03999'
@@ -6478,6 +7147,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_03000:
+                  value:
+                    errors:
+                    - code: '03000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: DGFIP - Adélie
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_03008:
+                  value:
+                    errors:
+                    - code: '03008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: DGFIP - Adélie
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_03011:
+                  value:
+                    errors:
+                    - code: '03011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: DGFIP - Adélie
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_03009:
+                  value:
+                    errors:
+                    - code: '03009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: DGFIP - Adélie
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
                 potentielle_ressource_non_trouvee_03501:
                   value:
                     errors:
@@ -7268,7 +7991,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_03999:
                   value:
                     errors:
                     - code: '03999'
@@ -7283,6 +8006,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_03000:
+                  value:
+                    errors:
+                    - code: '03000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: DGFIP - Adélie
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_03008:
+                  value:
+                    errors:
+                    - code: '03008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: DGFIP - Adélie
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_03011:
+                  value:
+                    errors:
+                    - code: '03011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: DGFIP - Adélie
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_03009:
+                  value:
+                    errors:
+                    - code: '03009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: DGFIP - Adélie
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -9160,7 +9937,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_29999:
                   value:
                     errors:
                     - code: '29999'
@@ -9175,6 +9952,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_29000:
+                  value:
+                    errors:
+                    - code: '29000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: DJEPVA
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_29008:
+                  value:
+                    errors:
+                    - code: '29008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: DJEPVA
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_29011:
+                  value:
+                    errors:
+                    - code: '29011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: DJEPVA
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_29009:
+                  value:
+                    errors:
+                    - code: '29009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: DJEPVA
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '409':
@@ -10592,7 +11423,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_29999:
                   value:
                     errors:
                     - code: '29999'
@@ -10607,6 +11438,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_29000:
+                  value:
+                    errors:
+                    - code: '29000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: DJEPVA
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_29008:
+                  value:
+                    errors:
+                    - code: '29008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: DJEPVA
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_29011:
+                  value:
+                    errors:
+                    - code: '29011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: DJEPVA
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_29009:
+                  value:
+                    errors:
+                    - code: '29009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: DJEPVA
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '409':
@@ -10872,7 +11757,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_28999:
                   value:
                     errors:
                     - code: '28999'
@@ -10887,6 +11772,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_28000:
+                  value:
+                    errors:
+                    - code: '28000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: Commission Européenne
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_28008:
+                  value:
+                    errors:
+                    - code: '28008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: Commission Européenne
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_28011:
+                  value:
+                    errors:
+                    - code: '28011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: Commission Européenne
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_28009:
+                  value:
+                    errors:
+                    - code: '28009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: Commission Européenne
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -11347,7 +12286,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_14999:
                   value:
                     errors:
                     - code: '14999'
@@ -11362,6 +12301,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_14000:
+                  value:
+                    errors:
+                    - code: '14000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: Fabrique numérique des Ministères Sociaux
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_14008:
+                  value:
+                    errors:
+                    - code: '14008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: Fabrique numérique des Ministères Sociaux
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_14011:
+                  value:
+                    errors:
+                    - code: '14011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: Fabrique numérique des Ministères Sociaux
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_14009:
+                  value:
+                    errors:
+                    - code: '14009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: Fabrique numérique des Ministères Sociaux
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -11687,7 +12680,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_12999:
                   value:
                     errors:
                     - code: '12999'
@@ -11702,6 +12695,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_12000:
+                  value:
+                    errors:
+                    - code: '12000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: FNTP
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_12008:
+                  value:
+                    errors:
+                    - code: '12008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: FNTP
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_12011:
+                  value:
+                    errors:
+                    - code: '12011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: FNTP
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_12009:
+                  value:
+                    errors:
+                    - code: '12009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: FNTP
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
                 fichier_renvoye_par_le_fournisseur_de_donnees_non_valide_12051:
                   value:
                     errors:
@@ -11768,6 +12815,19 @@ paths:
                   summary: Fichier renvoyé par le fournisseur de données non valide
                   description: Le fichier renvoyé par le fournisseur de données est
                     vide
+                erreur_reseau_du_service_d_hebergement_de_donnees_00502:
+                  value:
+                    errors:
+                    - code: '00502'
+                      title: Erreur réseau du service d'hébergement de données
+                      detail: Problème de connexion au serveur d'hébergement de données.
+                        L'erreur peut venir soit du fournisseur, soit de API Entreprise
+                      source:
+                      meta:
+                        retry_in: 10
+                  summary: Erreur réseau du service d'hébergement de données
+                  description: Problème de connexion au serveur d'hébergement de données.
+                    L'erreur peut venir soit du fournisseur, soit de API Entreprise
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -12281,7 +13341,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_31999:
                   value:
                     errors:
                     - code: '31999'
@@ -12296,6 +13356,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_31000:
+                  value:
+                    errors:
+                    - code: '31000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: GIP-MDS
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_31008:
+                  value:
+                    errors:
+                    - code: '31008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: GIP-MDS
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_31011:
+                  value:
+                    errors:
+                    - code: '31011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: GIP-MDS
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_31009:
+                  value:
+                    errors:
+                    - code: '31009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: GIP-MDS
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -12847,7 +13961,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_31999:
                   value:
                     errors:
                     - code: '31999'
@@ -12862,6 +13976,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_31000:
+                  value:
+                    errors:
+                    - code: '31000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: GIP-MDS
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_31008:
+                  value:
+                    errors:
+                    - code: '31008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: GIP-MDS
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_31011:
+                  value:
+                    errors:
+                    - code: '31011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: GIP-MDS
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_31009:
+                  value:
+                    errors:
+                    - code: '31009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: GIP-MDS
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -13676,7 +14844,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_02999:
                   value:
                     errors:
                     - code: '02999'
@@ -13691,6 +14859,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_02000:
+                  value:
+                    errors:
+                    - code: '02000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: Infogreffe
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_02008:
+                  value:
+                    errors:
+                    - code: '02008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: Infogreffe
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_02011:
+                  value:
+                    errors:
+                    - code: '02011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: Infogreffe
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_02009:
+                  value:
+                    errors:
+                    - code: '02009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: Infogreffe
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -14229,7 +15451,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_02999:
                   value:
                     errors:
                     - code: '02999'
@@ -14244,6 +15466,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_02000:
+                  value:
+                    errors:
+                    - code: '02000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: Infogreffe
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_02008:
+                  value:
+                    errors:
+                    - code: '02008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: Infogreffe
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_02011:
+                  value:
+                    errors:
+                    - code: '02011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: Infogreffe
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_02009:
+                  value:
+                    errors:
+                    - code: '02009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: Infogreffe
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -14714,7 +15990,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_34999:
                   value:
                     errors:
                     - code: '34999'
@@ -14729,6 +16005,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_34000:
+                  value:
+                    errors:
+                    - code: '34000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: INPI - RNE
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_34008:
+                  value:
+                    errors:
+                    - code: '34008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: INPI - RNE
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_34011:
+                  value:
+                    errors:
+                    - code: '34011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: INPI - RNE
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_34009:
+                  value:
+                    errors:
+                    - code: '34009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: INPI - RNE
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -15815,7 +17145,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_34999:
                   value:
                     errors:
                     - code: '34999'
@@ -15830,6 +17160,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_34000:
+                  value:
+                    errors:
+                    - code: '34000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: INPI - RNE
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_34008:
+                  value:
+                    errors:
+                    - code: '34008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: INPI - RNE
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_34011:
+                  value:
+                    errors:
+                    - code: '34011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: INPI - RNE
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_34009:
+                  value:
+                    errors:
+                    - code: '34009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: INPI - RNE
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -16668,7 +18052,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_34999:
                   value:
                     errors:
                     - code: '34999'
@@ -16683,6 +18067,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_34000:
+                  value:
+                    errors:
+                    - code: '34000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: INPI - RNE
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_34008:
+                  value:
+                    errors:
+                    - code: '34008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: INPI - RNE
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_34011:
+                  value:
+                    errors:
+                    - code: '34011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: INPI - RNE
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_34009:
+                  value:
+                    errors:
+                    - code: '34009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: INPI - RNE
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -17303,7 +18741,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_01999:
                   value:
                     errors:
                     - code: '01999'
@@ -17318,6 +18756,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_01000:
+                  value:
+                    errors:
+                    - code: '01000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_01008:
+                  value:
+                    errors:
+                    - code: '01008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_01011:
+                  value:
+                    errors:
+                    - code: '01011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_01009:
+                  value:
+                    errors:
+                    - code: '01009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -17968,7 +19460,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_01999:
                   value:
                     errors:
                     - code: '01999'
@@ -17983,6 +19475,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_01000:
+                  value:
+                    errors:
+                    - code: '01000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_01008:
+                  value:
+                    errors:
+                    - code: '01008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_01011:
+                  value:
+                    errors:
+                    - code: '01011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_01009:
+                  value:
+                    errors:
+                    - code: '01009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -19344,7 +20890,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_01999:
                   value:
                     errors:
                     - code: '01999'
@@ -19359,6 +20905,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_01000:
+                  value:
+                    errors:
+                    - code: '01000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_01008:
+                  value:
+                    errors:
+                    - code: '01008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_01011:
+                  value:
+                    errors:
+                    - code: '01011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_01009:
+                  value:
+                    errors:
+                    - code: '01009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -20777,7 +22377,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_01999:
                   value:
                     errors:
                     - code: '01999'
@@ -20792,6 +22392,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_01000:
+                  value:
+                    errors:
+                    - code: '01000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_01008:
+                  value:
+                    errors:
+                    - code: '01008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_01011:
+                  value:
+                    errors:
+                    - code: '01011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_01009:
+                  value:
+                    errors:
+                    - code: '01009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -22195,7 +23849,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_01999:
                   value:
                     errors:
                     - code: '01999'
@@ -22210,6 +23864,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_01000:
+                  value:
+                    errors:
+                    - code: '01000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_01008:
+                  value:
+                    errors:
+                    - code: '01008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_01011:
+                  value:
+                    errors:
+                    - code: '01011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_01009:
+                  value:
+                    errors:
+                    - code: '01009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -23670,7 +25378,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_01999:
                   value:
                     errors:
                     - code: '01999'
@@ -23685,6 +25393,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_01000:
+                  value:
+                    errors:
+                    - code: '01000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_01008:
+                  value:
+                    errors:
+                    - code: '01008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_01011:
+                  value:
+                    errors:
+                    - code: '01011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_01009:
+                  value:
+                    errors:
+                    - code: '01009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -25086,7 +26848,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_01999:
                   value:
                     errors:
                     - code: '01999'
@@ -25101,6 +26863,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_01000:
+                  value:
+                    errors:
+                    - code: '01000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_01008:
+                  value:
+                    errors:
+                    - code: '01008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_01011:
+                  value:
+                    errors:
+                    - code: '01011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_01009:
+                  value:
+                    errors:
+                    - code: '01009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -26559,7 +28375,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_01999:
                   value:
                     errors:
                     - code: '01999'
@@ -26574,6 +28390,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_01000:
+                  value:
+                    errors:
+                    - code: '01000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_01008:
+                  value:
+                    errors:
+                    - code: '01008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_01011:
+                  value:
+                    errors:
+                    - code: '01011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_01009:
+                  value:
+                    errors:
+                    - code: '01009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -27928,7 +29798,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_01999:
                   value:
                     errors:
                     - code: '01999'
@@ -27943,6 +29813,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_01000:
+                  value:
+                    errors:
+                    - code: '01000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_01008:
+                  value:
+                    errors:
+                    - code: '01008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_01011:
+                  value:
+                    errors:
+                    - code: '01011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_01009:
+                  value:
+                    errors:
+                    - code: '01009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -29354,7 +31278,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_01999:
                   value:
                     errors:
                     - code: '01999'
@@ -29369,6 +31293,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_01000:
+                  value:
+                    errors:
+                    - code: '01000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_01008:
+                  value:
+                    errors:
+                    - code: '01008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_01011:
+                  value:
+                    errors:
+                    - code: '01011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_01009:
+                  value:
+                    errors:
+                    - code: '01009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -29798,7 +31776,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_01999:
                   value:
                     errors:
                     - code: '01999'
@@ -29813,6 +31791,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_01000:
+                  value:
+                    errors:
+                    - code: '01000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_01008:
+                  value:
+                    errors:
+                    - code: '01008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_01011:
+                  value:
+                    errors:
+                    - code: '01011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_01009:
+                  value:
+                    errors:
+                    - code: '01009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -30655,7 +32687,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_01999:
                   value:
                     errors:
                     - code: '01999'
@@ -30670,6 +32702,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_01000:
+                  value:
+                    errors:
+                    - code: '01000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_01008:
+                  value:
+                    errors:
+                    - code: '01008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_01011:
+                  value:
+                    errors:
+                    - code: '01011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_01009:
+                  value:
+                    errors:
+                    - code: '01009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -31546,7 +33632,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_01999:
                   value:
                     errors:
                     - code: '01999'
@@ -31561,6 +33647,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_01000:
+                  value:
+                    errors:
+                    - code: '01000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_01008:
+                  value:
+                    errors:
+                    - code: '01008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_01011:
+                  value:
+                    errors:
+                    - code: '01011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_01009:
+                  value:
+                    errors:
+                    - code: '01009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -32427,7 +34567,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_01999:
                   value:
                     errors:
                     - code: '01999'
@@ -32442,6 +34582,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_01000:
+                  value:
+                    errors:
+                    - code: '01000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_01008:
+                  value:
+                    errors:
+                    - code: '01008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_01011:
+                  value:
+                    errors:
+                    - code: '01011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_01009:
+                  value:
+                    errors:
+                    - code: '01009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -33336,7 +35530,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_01999:
                   value:
                     errors:
                     - code: '01999'
@@ -33351,6 +35545,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_01000:
+                  value:
+                    errors:
+                    - code: '01000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_01008:
+                  value:
+                    errors:
+                    - code: '01008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_01011:
+                  value:
+                    errors:
+                    - code: '01011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_01009:
+                  value:
+                    errors:
+                    - code: '01009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: INSEE
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -33758,7 +36006,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_21999:
                   value:
                     errors:
                     - code: '21999'
@@ -33773,6 +36021,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_21000:
+                  value:
+                    errors:
+                    - code: '21000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: MI
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_21008:
+                  value:
+                    errors:
+                    - code: '21008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: MI
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_21011:
+                  value:
+                    errors:
+                    - code: '21011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: MI
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_21009:
+                  value:
+                    errors:
+                    - code: '21009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: MI
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
                 fichier_renvoye_par_le_fournisseur_de_donnees_non_valide_21051:
                   value:
                     errors:
@@ -34416,7 +36718,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_21999:
                   value:
                     errors:
                     - code: '21999'
@@ -34431,6 +36733,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_21000:
+                  value:
+                    errors:
+                    - code: '21000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: MI
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_21008:
+                  value:
+                    errors:
+                    - code: '21008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: MI
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_21011:
+                  value:
+                    errors:
+                    - code: '21011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: MI
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_21009:
+                  value:
+                    errors:
+                    - code: '21009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: MI
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '409':
@@ -34749,7 +37105,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_10999:
                   value:
                     errors:
                     - code: '10999'
@@ -34764,6 +37120,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_10000:
+                  value:
+                    errors:
+                    - code: '10000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: MSA
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_10008:
+                  value:
+                    errors:
+                    - code: '10008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: MSA
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_10011:
+                  value:
+                    errors:
+                    - code: '10011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: MSA
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_10009:
+                  value:
+                    errors:
+                    - code: '10009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: MSA
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -35219,7 +37629,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_11999:
                   value:
                     errors:
                     - code: '11999'
@@ -35234,6 +37644,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_11000:
+                  value:
+                    errors:
+                    - code: '11000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: OPQIBI
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_11008:
+                  value:
+                    errors:
+                    - code: '11008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: OPQIBI
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_11011:
+                  value:
+                    errors:
+                    - code: '11011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: OPQIBI
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_11009:
+                  value:
+                    errors:
+                    - code: '11009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: OPQIBI
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -35587,7 +38051,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_09999:
                   value:
                     errors:
                     - code: '09999'
@@ -35602,6 +38066,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_09000:
+                  value:
+                    errors:
+                    - code: '09000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: ProBTP
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_09008:
+                  value:
+                    errors:
+                    - code: '09008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: ProBTP
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_09011:
+                  value:
+                    errors:
+                    - code: '09011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: ProBTP
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_09009:
+                  value:
+                    errors:
+                    - code: '09009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: ProBTP
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
                 fichier_renvoye_par_le_fournisseur_de_donnees_non_valide_09051:
                   value:
                     errors:
@@ -35668,6 +38186,19 @@ paths:
                   summary: Fichier renvoyé par le fournisseur de données non valide
                   description: Le fichier renvoyé par le fournisseur de données est
                     vide
+                erreur_reseau_du_service_d_hebergement_de_donnees_00502:
+                  value:
+                    errors:
+                    - code: '00502'
+                      title: Erreur réseau du service d'hébergement de données
+                      detail: Problème de connexion au serveur d'hébergement de données.
+                        L'erreur peut venir soit du fournisseur, soit de API Entreprise
+                      source:
+                      meta:
+                        retry_in: 10
+                  summary: Erreur réseau du service d'hébergement de données
+                  description: Problème de connexion au serveur d'hébergement de données.
+                    L'erreur peut venir soit du fournisseur, soit de API Entreprise
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -36036,7 +38567,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_09999:
                   value:
                     errors:
                     - code: '09999'
@@ -36051,6 +38582,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_09000:
+                  value:
+                    errors:
+                    - code: '09000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: ProBTP
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_09008:
+                  value:
+                    errors:
+                    - code: '09008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: ProBTP
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_09011:
+                  value:
+                    errors:
+                    - code: '09011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: ProBTP
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_09009:
+                  value:
+                    errors:
+                    - code: '09009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: ProBTP
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -36405,7 +38990,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_06999:
                   value:
                     errors:
                     - code: '06999'
@@ -36420,6 +39005,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_06000:
+                  value:
+                    errors:
+                    - code: '06000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: Qualibat
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_06008:
+                  value:
+                    errors:
+                    - code: '06008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: Qualibat
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_06011:
+                  value:
+                    errors:
+                    - code: '06011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: Qualibat
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_06009:
+                  value:
+                    errors:
+                    - code: '06009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: Qualibat
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
                 fichier_renvoye_par_le_fournisseur_de_donnees_non_valide_06051:
                   value:
                     errors:
@@ -36486,6 +39125,19 @@ paths:
                   summary: Fichier renvoyé par le fournisseur de données non valide
                   description: Le fichier renvoyé par le fournisseur de données est
                     vide
+                erreur_reseau_du_service_d_hebergement_de_donnees_00502:
+                  value:
+                    errors:
+                    - code: '00502'
+                      title: Erreur réseau du service d'hébergement de données
+                      detail: Problème de connexion au serveur d'hébergement de données.
+                        L'erreur peut venir soit du fournisseur, soit de API Entreprise
+                      source:
+                      meta:
+                        retry_in: 10
+                  summary: Erreur réseau du service d'hébergement de données
+                  description: Problème de connexion au serveur d'hébergement de données.
+                    L'erreur peut venir soit du fournisseur, soit de API Entreprise
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -36988,7 +39640,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_06999:
                   value:
                     errors:
                     - code: '06999'
@@ -37003,6 +39655,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_06000:
+                  value:
+                    errors:
+                    - code: '06000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: Qualibat
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_06008:
+                  value:
+                    errors:
+                    - code: '06008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: Qualibat
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_06011:
+                  value:
+                    errors:
+                    - code: '06011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: Qualibat
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_06009:
+                  value:
+                    errors:
+                    - code: '06009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: Qualibat
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
                 fichier_renvoye_par_le_fournisseur_de_donnees_non_valide_06051:
                   value:
                     errors:
@@ -37069,6 +39775,19 @@ paths:
                   summary: Fichier renvoyé par le fournisseur de données non valide
                   description: Le fichier renvoyé par le fournisseur de données est
                     vide
+                erreur_reseau_du_service_d_hebergement_de_donnees_00502:
+                  value:
+                    errors:
+                    - code: '00502'
+                      title: Erreur réseau du service d'hébergement de données
+                      detail: Problème de connexion au serveur d'hébergement de données.
+                        L'erreur peut venir soit du fournisseur, soit de API Entreprise
+                      source:
+                      meta:
+                        retry_in: 10
+                  summary: Erreur réseau du service d'hébergement de données
+                  description: Problème de connexion au serveur d'hébergement de données.
+                    L'erreur peut venir soit du fournisseur, soit de API Entreprise
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -37707,7 +40426,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_32999:
                   value:
                     errors:
                     - code: '32999'
@@ -37722,6 +40441,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_32000:
+                  value:
+                    errors:
+                    - code: '32000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: Qualifelec
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_32008:
+                  value:
+                    errors:
+                    - code: '32008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: Qualifelec
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_32011:
+                  value:
+                    errors:
+                    - code: '32011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: Qualifelec
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_32009:
+                  value:
+                    errors:
+                    - code: '32009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: Qualifelec
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -38109,7 +40882,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_22999:
                   value:
                     errors:
                     - code: '22999'
@@ -38124,6 +40897,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_22000:
+                  value:
+                    errors:
+                    - code: '22000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: RNM
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_22008:
+                  value:
+                    errors:
+                    - code: '22008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: RNM
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_22011:
+                  value:
+                    errors:
+                    - code: '22011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: RNM
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_22009:
+                  value:
+                    errors:
+                    - code: '22009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: RNM
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -38571,7 +41398,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_04999:
                   value:
                     errors:
                     - code: '04999'
@@ -38586,85 +41413,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
-                fichier_renvoye_par_le_fournisseur_de_donnees_non_valide_04051:
+                erreur_interne_du_fournisseur_de_donnees_04000:
                   value:
                     errors:
-                    - code: '04051'
-                      title: Fichier renvoyé par le fournisseur de données non valide
-                      detail: 'Erreur lors du décodage : la chaîne de caractères en
-                        base64 est invalide'
-                      source:
-                      meta: {}
-                  summary: Fichier renvoyé par le fournisseur de données non valide
-                  description: 'Erreur lors du décodage : la chaîne de caractères
-                    en base64 est invalide'
-                fichier_renvoye_par_le_fournisseur_de_donnees_non_valide_04052:
-                  value:
-                    errors:
-                    - code: '04052'
-                      title: Fichier renvoyé par le fournisseur de données non valide
-                      detail: Temps d'attente de téléchargement du document écoulé
-                      source:
-                      meta: {}
-                  summary: Fichier renvoyé par le fournisseur de données non valide
-                  description: Temps d'attente de téléchargement du document écoulé
-                fichier_renvoye_par_le_fournisseur_de_donnees_non_valide_04053:
-                  value:
-                    errors:
-                    - code: '04053'
-                      title: Fichier renvoyé par le fournisseur de données non valide
-                      detail: Erreur de connexion sur le server distant
-                      source:
-                      meta: {}
-                  summary: Fichier renvoyé par le fournisseur de données non valide
-                  description: Erreur de connexion sur le server distant
-                fichier_renvoye_par_le_fournisseur_de_donnees_non_valide_04054:
-                  value:
-                    errors:
-                    - code: '04054'
-                      title: Fichier renvoyé par le fournisseur de données non valide
-                      detail: L'URL vers le document renvoyée par le fournisseur de
-                        données est invalide
-                      source:
-                      meta: {}
-                  summary: Fichier renvoyé par le fournisseur de données non valide
-                  description: L'URL vers le document renvoyée par le fournisseur
-                    de données est invalide
-                fichier_renvoye_par_le_fournisseur_de_donnees_non_valide_04055:
-                  value:
-                    errors:
-                    - code: '04055'
-                      title: Fichier renvoyé par le fournisseur de données non valide
-                      detail: Le fichier n'est pas au format attendu
-                      source:
-                      meta: {}
-                  summary: Fichier renvoyé par le fournisseur de données non valide
-                  description: Le fichier n'est pas au format attendu
-                fichier_renvoye_par_le_fournisseur_de_donnees_non_valide_04056:
-                  value:
-                    errors:
-                    - code: '04056'
-                      title: Fichier renvoyé par le fournisseur de données non valide
-                      detail: Le fichier renvoyé par le fournisseur de données est
-                        vide
-                      source:
-                      meta: {}
-                  summary: Fichier renvoyé par le fournisseur de données non valide
-                  description: Le fichier renvoyé par le fournisseur de données est
-                    vide
-                demande_de_traitement_logiciel_en_cours_04502:
-                  value:
-                    errors:
-                    - code: '04502'
-                      title: Demande de traitement logiciel en cours
-                      detail: Une erreur informatique a eu lieu, une demande de traitement
-                        par le logiciel est en cours.
+                    - code: '04000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
                       source:
                       meta:
                         provider: ACOSS
-                  summary: Demande de traitement logiciel en cours
-                  description: Une erreur informatique a eu lieu, une demande de traitement
-                    par le logiciel est en cours.
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_04008:
+                  value:
+                    errors:
+                    - code: '04008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: ACOSS
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_04011:
+                  value:
+                    errors:
+                    - code: '04011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: ACOSS
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_04009:
+                  value:
+                    errors:
+                    - code: '04009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: ACOSS
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
                 analyse_manuelle_de_la_situation_du_compte_en_cours_04501:
                   value:
                     errors:
@@ -38683,6 +41485,54 @@ paths:
                     Le temps de traitement est très variable selon de la complexité
                     de situation, la demande de pièces justificatives complémentaires
                     ou la charge de travail des agents.
+                demande_de_traitement_logiciel_en_cours_04502:
+                  value:
+                    errors:
+                    - code: '04502'
+                      title: Demande de traitement logiciel en cours
+                      detail: Une erreur informatique a eu lieu, une demande de traitement
+                        par le logiciel est en cours.
+                      source:
+                      meta:
+                        provider: ACOSS
+                  summary: Demande de traitement logiciel en cours
+                  description: Une erreur informatique a eu lieu, une demande de traitement
+                    par le logiciel est en cours.
+                fichier_renvoye_par_le_fournisseur_de_donnees_non_valide_04051:
+                  value:
+                    errors:
+                    - code: '04051'
+                      title: Fichier renvoyé par le fournisseur de données non valide
+                      detail: 'Erreur lors du décodage : la chaîne de caractères en
+                        base64 est invalide'
+                      source:
+                      meta: {}
+                  summary: Fichier renvoyé par le fournisseur de données non valide
+                  description: 'Erreur lors du décodage : la chaîne de caractères
+                    en base64 est invalide'
+                fichier_renvoye_par_le_fournisseur_de_donnees_non_valide_04055:
+                  value:
+                    errors:
+                    - code: '04055'
+                      title: Fichier renvoyé par le fournisseur de données non valide
+                      detail: Le fichier n'est pas au format attendu
+                      source:
+                      meta: {}
+                  summary: Fichier renvoyé par le fournisseur de données non valide
+                  description: Le fichier n'est pas au format attendu
+                erreur_reseau_du_service_d_hebergement_de_donnees_00502:
+                  value:
+                    errors:
+                    - code: '00502'
+                      title: Erreur réseau du service d'hébergement de données
+                      detail: Problème de connexion au serveur d'hébergement de données.
+                        L'erreur peut venir soit du fournisseur, soit de API Entreprise
+                      source:
+                      meta:
+                        retry_in: 10
+                  summary: Erreur réseau du service d'hébergement de données
+                  description: Problème de connexion au serveur d'hébergement de données.
+                    L'erreur peut venir soit du fournisseur, soit de API Entreprise
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':

--- a/commons/swagger/openapi-particulier.yaml
+++ b/commons/swagger/openapi-particulier.yaml
@@ -1133,7 +1133,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_37999:
                   value:
                     errors:
                     - code: '37999'
@@ -1148,6 +1148,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_37000:
+                  value:
+                    errors:
+                    - code: '37000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_37008:
+                  value:
+                    errors:
+                    - code: '37008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_37011:
+                  value:
+                    errors:
+                    - code: '37011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_37009:
+                  value:
+                    errors:
+                    - code: '37009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -1937,7 +1991,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_37999:
                   value:
                     errors:
                     - code: '37999'
@@ -1952,6 +2006,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_37000:
+                  value:
+                    errors:
+                    - code: '37000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_37008:
+                  value:
+                    errors:
+                    - code: '37008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_37011:
+                  value:
+                    errors:
+                    - code: '37011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_37009:
+                  value:
+                    errors:
+                    - code: '37009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -2744,7 +2852,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_37999:
                   value:
                     errors:
                     - code: '37999'
@@ -2759,6 +2867,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_37000:
+                  value:
+                    errors:
+                    - code: '37000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_37008:
+                  value:
+                    errors:
+                    - code: '37008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_37011:
+                  value:
+                    errors:
+                    - code: '37011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_37009:
+                  value:
+                    errors:
+                    - code: '37009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -3545,7 +3707,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_37999:
                   value:
                     errors:
                     - code: '37999'
@@ -3560,6 +3722,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_37000:
+                  value:
+                    errors:
+                    - code: '37000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_37008:
+                  value:
+                    errors:
+                    - code: '37008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_37011:
+                  value:
+                    errors:
+                    - code: '37011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_37009:
+                  value:
+                    errors:
+                    - code: '37009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -4479,7 +4695,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_37999:
                   value:
                     errors:
                     - code: '37999'
@@ -4494,6 +4710,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_37000:
+                  value:
+                    errors:
+                    - code: '37000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_37008:
+                  value:
+                    errors:
+                    - code: '37008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_37011:
+                  value:
+                    errors:
+                    - code: '37011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_37009:
+                  value:
+                    errors:
+                    - code: '37009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -5431,7 +5701,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_37999:
                   value:
                     errors:
                     - code: '37999'
@@ -5446,6 +5716,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_37000:
+                  value:
+                    errors:
+                    - code: '37000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_37008:
+                  value:
+                    errors:
+                    - code: '37008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_37011:
+                  value:
+                    errors:
+                    - code: '37011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_37009:
+                  value:
+                    errors:
+                    - code: '37009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -5749,7 +6073,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_37999:
                   value:
                     errors:
                     - code: '37999'
@@ -5764,6 +6088,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_37000:
+                  value:
+                    errors:
+                    - code: '37000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_37008:
+                  value:
+                    errors:
+                    - code: '37008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_37011:
+                  value:
+                    errors:
+                    - code: '37011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_37009:
+                  value:
+                    errors:
+                    - code: '37009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -6562,7 +6940,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_37999:
                   value:
                     errors:
                     - code: '37999'
@@ -6577,6 +6955,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_37000:
+                  value:
+                    errors:
+                    - code: '37000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_37008:
+                  value:
+                    errors:
+                    - code: '37008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_37011:
+                  value:
+                    errors:
+                    - code: '37011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_37009:
+                  value:
+                    errors:
+                    - code: '37009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -7599,7 +8031,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_37999:
                   value:
                     errors:
                     - code: '37999'
@@ -7614,6 +8046,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_37000:
+                  value:
+                    errors:
+                    - code: '37000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_37008:
+                  value:
+                    errors:
+                    - code: '37008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_37011:
+                  value:
+                    errors:
+                    - code: '37011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_37009:
+                  value:
+                    errors:
+                    - code: '37009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -8431,7 +8917,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_26999:
                   value:
                     errors:
                     - code: '26999'
@@ -8446,6 +8932,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_26000:
+                  value:
+                    errors:
+                    - code: '26000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: CNOUS
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_26008:
+                  value:
+                    errors:
+                    - code: '26008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: CNOUS
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_26011:
+                  value:
+                    errors:
+                    - code: '26011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: CNOUS
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_26009:
+                  value:
+                    errors:
+                    - code: '26009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: CNOUS
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -9149,7 +9689,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_26999:
                   value:
                     errors:
                     - code: '26999'
@@ -9164,6 +9704,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_26000:
+                  value:
+                    errors:
+                    - code: '26000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: CNOUS
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_26008:
+                  value:
+                    errors:
+                    - code: '26008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: CNOUS
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_26011:
+                  value:
+                    errors:
+                    - code: '26011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: CNOUS
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_26009:
+                  value:
+                    errors:
+                    - code: '26009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: CNOUS
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -10675,7 +11269,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_39999:
                   value:
                     errors:
                     - code: '39999'
@@ -10690,6 +11284,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_39000:
+                  value:
+                    errors:
+                    - code: '39000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: DSNJ
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_39008:
+                  value:
+                    errors:
+                    - code: '39008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: DSNJ
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_39011:
+                  value:
+                    errors:
+                    - code: '39011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: DSNJ
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_39009:
+                  value:
+                    errors:
+                    - code: '39009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: DSNJ
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -11222,7 +11870,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_24999:
                   value:
                     errors:
                     - code: '24999'
@@ -11237,6 +11885,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_24000:
+                  value:
+                    errors:
+                    - code: '24000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: France Travail
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_24008:
+                  value:
+                    errors:
+                    - code: '24008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: France Travail
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_24011:
+                  value:
+                    errors:
+                    - code: '24011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: France Travail
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_24009:
+                  value:
+                    errors:
+                    - code: '24009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: France Travail
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -11735,7 +12437,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_24999:
                   value:
                     errors:
                     - code: '24999'
@@ -11750,6 +12452,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_24000:
+                  value:
+                    errors:
+                    - code: '24000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: France Travail
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_24008:
+                  value:
+                    errors:
+                    - code: '24008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: France Travail
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_24011:
+                  value:
+                    errors:
+                    - code: '24011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: France Travail
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_24009:
+                  value:
+                    errors:
+                    - code: '24009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: France Travail
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -12233,7 +12989,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_31999:
                   value:
                     errors:
                     - code: '31999'
@@ -12248,6 +13004,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_31000:
+                  value:
+                    errors:
+                    - code: '31000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: GIP-MDS
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_31008:
+                  value:
+                    errors:
+                    - code: '31008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: GIP-MDS
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_31011:
+                  value:
+                    errors:
+                    - code: '31011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: GIP-MDS
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_31009:
+                  value:
+                    errors:
+                    - code: '31009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: GIP-MDS
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -13204,7 +14014,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_30999:
                   value:
                     errors:
                     - code: '30999'
@@ -13219,6 +14029,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_30000:
+                  value:
+                    errors:
+                    - code: '30000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: MEN
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_30008:
+                  value:
+                    errors:
+                    - code: '30008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: MEN
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_30011:
+                  value:
+                    errors:
+                    - code: '30011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: MEN
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_30009:
+                  value:
+                    errors:
+                    - code: '30009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: MEN
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -13762,7 +14626,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_30999:
                   value:
                     errors:
                     - code: '30999'
@@ -13777,6 +14641,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_30000:
+                  value:
+                    errors:
+                    - code: '30000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: MEN
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_30008:
+                  value:
+                    errors:
+                    - code: '30008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: MEN
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_30011:
+                  value:
+                    errors:
+                    - code: '30011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: MEN
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_30009:
+                  value:
+                    errors:
+                    - code: '30009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: MEN
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -14358,7 +15276,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_30999:
                   value:
                     errors:
                     - code: '30999'
@@ -14373,6 +15291,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_30000:
+                  value:
+                    errors:
+                    - code: '30000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: MEN
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_30008:
+                  value:
+                    errors:
+                    - code: '30008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: MEN
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_30011:
+                  value:
+                    errors:
+                    - code: '30011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: MEN
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_30009:
+                  value:
+                    errors:
+                    - code: '30009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: MEN
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -14870,7 +15842,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_25999:
                   value:
                     errors:
                     - code: '25999'
@@ -14885,6 +15857,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_25000:
+                  value:
+                    errors:
+                    - code: '25000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: MESRI
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_25008:
+                  value:
+                    errors:
+                    - code: '25008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: MESRI
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_25011:
+                  value:
+                    errors:
+                    - code: '25011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: MESRI
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_25009:
+                  value:
+                    errors:
+                    - code: '25009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: MESRI
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -15601,7 +16627,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_25999:
                   value:
                     errors:
                     - code: '25999'
@@ -15616,6 +16642,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_25000:
+                  value:
+                    errors:
+                    - code: '25000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: MESRI
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_25008:
+                  value:
+                    errors:
+                    - code: '25008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: MESRI
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_25011:
+                  value:
+                    errors:
+                    - code: '25011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: MESRI
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_25009:
+                  value:
+                    errors:
+                    - code: '25009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: MESRI
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':
@@ -16215,7 +17295,7 @@ paths:
           content:
             application/json:
               examples:
-                provider_unknown_error:
+                erreur_inconnue_du_fournisseur_de_donnees_41999:
                   value:
                     errors:
                     - code: '41999'
@@ -16230,6 +17310,60 @@ paths:
                   description: La réponse retournée par le fournisseur de données
                     est invalide et inconnue de notre service. L'équipe technique
                     a été notifiée de cette erreur pour investigation.
+                erreur_interne_du_fournisseur_de_donnees_41000:
+                  value:
+                    errors:
+                    - code: '41000'
+                      title: Erreur interne du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et a été identifié comme étant une erreur interne.
+                        Si le problème persiste, consultez la page de status ou contactez
+                        nous sur le support.
+                      source:
+                      meta:
+                        provider: SDH
+                  summary: Erreur interne du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et a été identifié comme étant une erreur interne.
+                    Si le problème persiste, consultez la page de status ou contactez
+                    nous sur le support.
+                erreur_aupres_du_fournisseur_de_donnees_trop_de_requetes_41008:
+                  value:
+                    errors:
+                    - code: '41008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: SDH
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+                erreur_temporaire_du_fournisseur_de_donnees_41011:
+                  value:
+                    errors:
+                    - code: '41011'
+                      title: Erreur temporaire du fournisseur de données
+                      detail: Merci de réessayer dans quelques instants
+                      source:
+                      meta:
+                        provider: SDH
+                  summary: Erreur temporaire du fournisseur de données
+                  description: Merci de réessayer dans quelques instants
+                erreur_de_certificat_ssl_du_fournisseur_de_donnees_41009:
+                  value:
+                    errors:
+                    - code: '41009'
+                      title: Erreur de certificat SSL du fournisseur de données
+                      detail: Le certificat SSL du fournisseur de données est invalide
+                        ou expiré.
+                      source:
+                      meta:
+                        provider: SDH
+                  summary: Erreur de certificat SSL du fournisseur de données
+                  description: Le certificat SSL du fournisseur de données est invalide
+                    ou expiré.
               schema:
                 "$ref": "#/components/schemas/Error"
         '504':

--- a/siade/app/controllers/concerns/organizers_methods_helpers.rb
+++ b/siade/app/controllers/concerns/organizers_methods_helpers.rb
@@ -1,33 +1,12 @@
 module OrganizersMethodsHelpers
-  # rubocop:disable Metrics
   def extract_http_code(retriever)
     return retriever.mocked_data[:status] if retriever.mocked_data
+    return :ok if retriever.errors.blank?
 
-    if retriever.errors.blank?
-      :ok
-    elsif at_least_one_error_kind_of?(:wrong_parameter, retriever)
-      :unprocessable_content
-    elsif at_least_one_error_kind_of?(%i[network_error provider_error provider_unknown_error], retriever)
-      :bad_gateway
-    elsif at_least_one_error_kind_of?(:timeout_error, retriever)
-      :gateway_timeout
-    elsif at_least_one_error_kind_of?(:unavailable_for_legal_reason, retriever)
-      :unavailable_for_legal_reasons
-    elsif at_least_one_error_kind_of?(:unauthorized, retriever)
-      :unauthorized
-    elsif at_least_one_error_kind_of?(:not_found, retriever)
-      :not_found
-    elsif at_least_one_error_kind_of?(:conflict, retriever)
-      :conflict
-    elsif at_least_one_error_kind_of?(:internal_error, retriever)
-      :internal_error
-    elsif at_least_one_error_kind_of?(:too_many_requests, retriever)
-      :too_many_requests
-    elsif at_least_one_error_kind_of?(:maintenance, retriever)
-      :service_unavailable
-    else
-      raise 'No valid HTTP status'
+    Errors::HTTPStatusForKind::KIND_TO_STATUS.each do |kind, status|
+      return status if at_least_one_error_kind_of?(kind, retriever)
     end
+
+    raise 'No valid HTTP status'
   end
-  # rubocop:enable Metrics
 end

--- a/siade/app/errors/abstract_generic_provider_error.rb
+++ b/siade/app/errors/abstract_generic_provider_error.rb
@@ -1,6 +1,10 @@
 class AbstractGenericProviderError < ApplicationError
   class UnknownProviderCode < StandardError; end
 
+  def self.build_example(provider_name:, **)
+    new(provider_name)
+  end
+
   attr_reader :provider_name
 
   def initialize(provider_name, message = nil)

--- a/siade/app/errors/abstract_specific_provider_error.rb
+++ b/siade/app/errors/abstract_specific_provider_error.rb
@@ -1,4 +1,8 @@
 class AbstractSpecificProviderError < ApplicationError
+  def self.build_example(kind:, **)
+    new(kind)
+  end
+
   def initialize(kind)
     @kind = kind.to_sym
   end

--- a/siade/app/errors/application_error.rb
+++ b/siade/app/errors/application_error.rb
@@ -1,4 +1,8 @@
 class ApplicationError
+  def self.build_example(**)
+    new
+  end
+
   def code
     raise 'It should be override in inherited classes'
   end

--- a/siade/app/errors/bad_file_from_provider_error.rb
+++ b/siade/app/errors/bad_file_from_provider_error.rb
@@ -1,4 +1,8 @@
 class BadFileFromProviderError < ApplicationError
+  def self.build_example(provider_name:, kind:, **)
+    new(provider_name, kind)
+  end
+
   KIND_TO_SUBCODE = {
     invalid_base64: {
       subcode: '051',

--- a/siade/app/interactors/acoss/attestations_sociales/validate_response.rb
+++ b/siade/app/interactors/acoss/attestations_sociales/validate_response.rb
@@ -1,4 +1,6 @@
 class ACOSS::AttestationsSociales::ValidateResponse < URSSAF::AttestationsSociales::ValidateResponse::RawBody
+  raises ACOSSError, kind: :cannot_deliver_document
+
   def handle_errors
     if cannot_deliver_document?
       fail_with_error!(ACOSSError.new(:cannot_deliver_document))

--- a/siade/app/interactors/application_interactor.rb
+++ b/siade/app/interactors/application_interactor.rb
@@ -1,4 +1,8 @@
 class ApplicationInteractor
   include Interactor
   include MockedDataHelper
+
+  def self.raises(error_class, **)
+    ErrorRegistry.register(self, error_class, **)
+  end
 end

--- a/siade/app/interactors/documents/base64_decode.rb
+++ b/siade/app/interactors/documents/base64_decode.rb
@@ -1,4 +1,6 @@
 class Documents::Base64Decode < ApplicationInteractor
+  raises BadFileFromProviderError, kind: :invalid_base64
+
   before do
     context.errors ||= []
   end

--- a/siade/app/interactors/documents/upload.rb
+++ b/siade/app/interactors/documents/upload.rb
@@ -1,4 +1,6 @@
 class Documents::Upload < ApplicationInteractor
+  raises HostingServiceError
+
   before do
     context.errors ||= []
   end

--- a/siade/app/interactors/documents/validate_format.rb
+++ b/siade/app/interactors/documents/validate_format.rb
@@ -1,4 +1,6 @@
 class Documents::ValidateFormat < ApplicationInteractor
+  raises BadFileFromProviderError, kind: :invalid_extension
+
   before do
     context.errors ||= []
   end

--- a/siade/app/interactors/urssaf/attestations_sociales/validate_response/raw_body.rb
+++ b/siade/app/interactors/urssaf/attestations_sociales/validate_response/raw_body.rb
@@ -1,4 +1,7 @@
 class URSSAF::AttestationsSociales::ValidateResponse::RawBody < ValidateResponse
+  raises ACOSSError, kind: :manual_verification_asked
+  raises ACOSSError, kind: :ongoing_manual_verification
+
   def call
     if body.blank?
       internal_server_error!('Le corps de la réponse est vide, il s\'agit d\'une erreur interne du fournisseur')

--- a/siade/app/services/error_registry.rb
+++ b/siade/app/services/error_registry.rb
@@ -1,0 +1,52 @@
+class ErrorRegistry
+  Declaration = Data.define(:error_class, :options)
+
+  class << self
+    def register(validator_class, error_class, **options)
+      decl = Declaration.new(error_class:, options: options.freeze)
+      bucket = declarations[validator_class] ||= []
+      bucket << decl unless bucket.include?(decl)
+      decl
+    end
+
+    def declarations_for(validator_class)
+      validator_class.ancestors.flat_map { |klass| declarations.fetch(klass, []) }.uniq
+    end
+
+    def declarations_for_organizer(organizer_class)
+      flatten_chain(organizer_class).flat_map { |klass| declarations_for(klass) }.uniq
+    end
+
+    def examples_for_status(organizer_class, http_status, provider_name:)
+      target = http_status.to_i
+
+      declarations_for_organizer(organizer_class).filter_map do |decl|
+        example = decl.error_class.build_example(provider_name:, kind: decl.options[:kind])
+        next unless status_code(example) == target
+
+        example
+      end
+    end
+
+    def reset!
+      @declarations = {}
+    end
+
+    private
+
+    def declarations
+      @declarations ||= {}
+    end
+
+    def flatten_chain(klass)
+      return [klass] unless klass.respond_to?(:organized) && klass.organized.any?
+
+      klass.organized.flat_map { |inner| flatten_chain(inner) }
+    end
+
+    def status_code(error)
+      symbol = Errors::HTTPStatusForKind.call(error.kind)
+      Rack::Utils.status_code(symbol) if symbol
+    end
+  end
+end

--- a/siade/app/services/errors/http_status_for_kind.rb
+++ b/siade/app/services/errors/http_status_for_kind.rb
@@ -1,0 +1,20 @@
+class Errors::HTTPStatusForKind
+  KIND_TO_STATUS = {
+    wrong_parameter: :unprocessable_content,
+    network_error: :bad_gateway,
+    provider_error: :bad_gateway,
+    provider_unknown_error: :bad_gateway,
+    timeout_error: :gateway_timeout,
+    unavailable_for_legal_reason: :unavailable_for_legal_reasons,
+    unauthorized: :unauthorized,
+    not_found: :not_found,
+    conflict: :conflict,
+    internal_error: :internal_error,
+    too_many_requests: :too_many_requests,
+    maintenance: :service_unavailable
+  }.freeze
+
+  def self.call(kind)
+    KIND_TO_STATUS[kind]
+  end
+end

--- a/siade/spec/requests/api_entreprise/v3_and_more/urssaf/attestations_sociales/v4_spec.rb
+++ b/siade/spec/requests/api_entreprise/v3_and_more/urssaf/attestations_sociales/v4_spec.rb
@@ -43,15 +43,7 @@ RSpec.describe 'URSSAF: Attestation de vigilance', api: :entreprise, type: %i[re
 
           unprocessable_content_error_request(:siren)
 
-          common_provider_errors_request(
-            'ACOSS',
-            URSSAF::AttestationsSociales,
-            documents_errors('ACOSS')
-            .push(
-              ACOSSError.new(:ongoing_manual_verification),
-              ACOSSError.new(:manual_verification_asked)
-            )
-          )
+          common_provider_errors_request('ACOSS', URSSAF::AttestationsSociales)
 
           response '404', 'Entreprise non trouvée', vcr: { cassette_name: 'acoss/with_non_existent_siren', match_requests_on: strict_match_vcr_requests_on_attributes.excluding(:body_sanitized) } do
             let(:siren) { not_found_siren }

--- a/siade/spec/services/error_registry_spec.rb
+++ b/siade/spec/services/error_registry_spec.rb
@@ -1,0 +1,135 @@
+require 'rails_helper'
+
+RSpec.describe ErrorRegistry do
+  around do |example|
+    snapshot = described_class.send(:declarations).deep_dup
+    described_class.reset!
+    example.run
+  ensure
+    described_class.instance_variable_set(:@declarations, snapshot)
+  end
+
+  let(:validator_class) do
+    Class.new do
+      def self.name
+        'AnonymousValidator'
+      end
+    end
+  end
+
+  describe '.register' do
+    it 'stores a declaration for a validator class' do
+      decl = described_class.register(validator_class, NotFoundError)
+
+      expect(decl.error_class).to eq(NotFoundError)
+      expect(decl.options).to eq({})
+      expect(described_class.declarations_for(validator_class)).to include(decl)
+    end
+
+    it 'is idempotent' do
+      described_class.register(validator_class, NotFoundError)
+      described_class.register(validator_class, NotFoundError)
+
+      expect(described_class.declarations_for(validator_class).size).to eq(1)
+    end
+
+    it 'distinguishes declarations by options' do
+      described_class.register(validator_class, ACOSSError, kind: :manual_verification_asked)
+      described_class.register(validator_class, ACOSSError, kind: :ongoing_manual_verification)
+
+      expect(described_class.declarations_for(validator_class).size).to eq(2)
+    end
+  end
+
+  describe '.declarations_for' do
+    it 'walks ancestors' do
+      parent = Class.new do
+        def self.name
+          'ParentValidator'
+        end
+      end
+      child = Class.new(parent) do
+        def self.name
+          'ChildValidator'
+        end
+      end
+
+      described_class.register(parent, ProviderUnknownError)
+      described_class.register(child, NotFoundError)
+
+      classes = described_class.declarations_for(child).map(&:error_class)
+      expect(classes).to contain_exactly(ProviderUnknownError, NotFoundError)
+    end
+  end
+
+  describe '.declarations_for_organizer' do
+    it 'recursively walks the organize chain' do
+      inner_validator = Class.new do
+        def self.name
+          'InnerValidator'
+        end
+      end
+      sub_organizer = Class.new do
+        class << self
+          attr_reader :organized
+        end
+      end
+      sub_organizer.instance_variable_set(:@organized, [inner_validator])
+
+      organizer = Class.new do
+        class << self
+          attr_reader :organized
+        end
+      end
+      organizer.instance_variable_set(:@organized, [sub_organizer])
+
+      described_class.register(inner_validator, NotFoundError)
+
+      classes = described_class.declarations_for_organizer(organizer).map(&:error_class)
+      expect(classes).to eq([NotFoundError])
+    end
+  end
+
+  describe '.examples_for_status' do
+    it 'instantiates errors matching the status' do
+      validator = Class.new do
+        def self.name
+          'Validator'
+        end
+      end
+      organizer = Class.new do
+        define_singleton_method(:organized) { [validator] }
+      end
+
+      described_class.register(validator, NotFoundError)
+      described_class.register(validator, ProviderUnknownError)
+      described_class.register(validator, ACOSSError, kind: :manual_verification_asked)
+
+      errors_502 = described_class.examples_for_status(organizer, 502, provider_name: 'ACOSS')
+
+      expect(errors_502.map(&:class)).to contain_exactly(ProviderUnknownError, ACOSSError)
+      expect(errors_502.find { |e| e.is_a?(ACOSSError) }.code).to eq('04501')
+
+      errors_404 = described_class.examples_for_status(organizer, 404, provider_name: 'ACOSS')
+      expect(errors_404.map(&:class)).to eq([NotFoundError])
+    end
+
+    it 'instantiates BadFileFromProviderError with provider and kind' do
+      validator = Class.new do
+        def self.name
+          'Validator'
+        end
+      end
+      organizer = Class.new do
+        define_singleton_method(:organized) { [validator] }
+      end
+
+      described_class.register(validator, BadFileFromProviderError, kind: :invalid_base64)
+
+      errors = described_class.examples_for_status(organizer, 502, provider_name: 'ACOSS')
+
+      expect(errors.size).to eq(1)
+      expect(errors.first.code).to eq('04051')
+    end
+  end
+end

--- a/siade/spec/support/rswag_common_errors.rb
+++ b/siade/spec/support/rswag_common_errors.rb
@@ -1,5 +1,20 @@
 # rubocop:disable Metrics/ModuleLength
 module RSwagCommonErrors
+  BASELINE_PROVIDER_ERROR_CLASSES = [
+    ProviderUnknownError,
+    ProviderInternalServerError,
+    ProviderRateLimitingError,
+    ProviderTemporaryError,
+    SSLCertificateError
+  ].freeze
+
+  BASELINE_NETWORK_ERROR_CLASSES = [
+    ProviderTimeoutError,
+    ProviderUnavailable,
+    NetworkError,
+    DnsResolutionError
+  ].freeze
+
   def unauthorized_request(&block)
     describe 'with valid mandatory params but invalid token' do
       include_context 'Valid mandatory params and no token'
@@ -73,20 +88,17 @@ module RSwagCommonErrors
     end
   end
 
-  def common_provider_errors_request(provider_name, organizer_klass, extra_errors = [], &block)
+  def common_provider_errors_request(provider_name, organizer_klass, extra_errors = nil, &block)
     response '502', 'Erreur du fournisseur' do
-      provider_unknown_error = ProviderUnknownError.new(provider_name)
+      baseline_errors = BASELINE_PROVIDER_ERROR_CLASSES.map { |klass| klass.new(provider_name) }
 
-      stubbed_organizer_error(
-        organizer_klass,
-        provider_unknown_error
-      )
+      stubbed_organizer_error(organizer_klass, baseline_errors.first)
 
       schema '$ref' => '#/components/schemas/Error'
 
-      build_rswag_example(provider_unknown_error, :provider_unknown_error)
+      registry_errors = ErrorRegistry.examples_for_status(organizer_klass, 502, provider_name:)
 
-      Array(extra_errors).each do |error|
+      (baseline_errors + Array(extra_errors) + registry_errors).uniq(&:code).each do |error|
         build_rswag_example(error)
       end
 

--- a/siade/spec/support/validate_response_emission_guard.rb
+++ b/siade/spec/support/validate_response_emission_guard.rb
@@ -1,0 +1,55 @@
+module ValidateResponseEmissionGuard
+  EMISSIONS = Hash.new { |h, k| h[k] = Set.new }
+  INSTRUMENTED = Set.new
+
+  UNIVERSAL_ERRORS = (
+    RSwagCommonErrors::BASELINE_PROVIDER_ERROR_CLASSES +
+    RSwagCommonErrors::BASELINE_NETWORK_ERROR_CLASSES +
+    [NotFoundError]
+  ).freeze
+
+  def self.instrument(validator_class)
+    return if INSTRUMENTED.include?(validator_class)
+
+    INSTRUMENTED << validator_class
+
+    validator_class.prepend(
+      Module.new do
+        define_method(:fail_with_error!) do |error|
+          kind = (error.instance_variable_get(:@kind) if error.instance_variables.include?(:@kind))
+          ValidateResponseEmissionGuard::EMISSIONS[self.class] << [error.class, kind]
+          super(error)
+        end
+      end
+    )
+  end
+
+  def self.verify!(validator_class) # rubocop:disable Metrics/AbcSize
+    declared = ErrorRegistry
+      .declarations_for(validator_class)
+      .to_set { |decl| [decl.error_class, decl.options[:kind]] }
+
+    return if declared.empty?
+
+    emitted = EMISSIONS[validator_class]
+
+    not_emitted = declared - emitted
+    undeclared = emitted.reject { |klass, _kind| UNIVERSAL_ERRORS.include?(klass) }.to_set - declared # rubocop:disable Style/HashExcept
+
+    failures = []
+    failures << "[#{validator_class}] declared via raises but never emitted in spec: #{not_emitted.to_a.inspect}" if not_emitted.any?
+    failures << "[#{validator_class}] emitted but not declared via raises (and not part of the universal baseline): #{undeclared.to_a.inspect}" if undeclared.any?
+
+    raise failures.join("\n") if failures.any?
+  end
+end
+
+RSpec.configure do |config|
+  config.before(:context, type: :validate_response) do |group|
+    ValidateResponseEmissionGuard.instrument(group.class.metadata[:described_class])
+  end
+
+  config.after(:context, type: :validate_response) do |group|
+    ValidateResponseEmissionGuard.verify!(group.class.metadata[:described_class])
+  end
+end

--- a/siade/spec/support/validate_response_emission_guard.rb
+++ b/siade/spec/support/validate_response_emission_guard.rb
@@ -8,39 +8,42 @@ module ValidateResponseEmissionGuard
     [NotFoundError]
   ).freeze
 
-  def self.instrument(validator_class)
-    return if INSTRUMENTED.include?(validator_class)
-
-    INSTRUMENTED << validator_class
-
-    validator_class.prepend(
-      Module.new do
-        define_method(:fail_with_error!) do |error|
-          kind = (error.instance_variable_get(:@kind) if error.instance_variables.include?(:@kind))
-          ValidateResponseEmissionGuard::EMISSIONS[self.class] << [error.class, kind]
-          super(error)
-        end
-      end
-    )
+  Tracker = Module.new do
+    def fail_with_error!(error)
+      kind = error.instance_variable_get(:@kind) if error.instance_variable_defined?(:@kind)
+      EMISSIONS[self.class] << [error.class, kind]
+      super
+    end
   end
 
-  def self.verify!(validator_class) # rubocop:disable Metrics/AbcSize
-    declared = ErrorRegistry
-      .declarations_for(validator_class)
-      .to_set { |decl| [decl.error_class, decl.options[:kind]] }
+  def self.instrument(validator_class)
+    validator_class.prepend(Tracker) if INSTRUMENTED.add?(validator_class)
+  end
 
+  def self.verify!(validator_class)
+    declared = declared_set(validator_class)
     return if declared.empty?
 
     emitted = EMISSIONS[validator_class]
-
-    not_emitted = declared - emitted
-    undeclared = emitted.reject { |klass, _kind| UNIVERSAL_ERRORS.include?(klass) }.to_set - declared # rubocop:disable Style/HashExcept
-
-    failures = []
-    failures << "[#{validator_class}] declared via raises but never emitted in spec: #{not_emitted.to_a.inspect}" if not_emitted.any?
-    failures << "[#{validator_class}] emitted but not declared via raises (and not part of the universal baseline): #{undeclared.to_a.inspect}" if undeclared.any?
-
+    failures = format_failures(validator_class, declared - emitted, undeclared_extras(emitted, declared))
     raise failures.join("\n") if failures.any?
+  end
+
+  def self.declared_set(validator_class)
+    ErrorRegistry
+      .declarations_for(validator_class)
+      .to_set { |decl| [decl.error_class, decl.options[:kind]] }
+  end
+
+  def self.undeclared_extras(emitted, declared)
+    (emitted - declared).reject { |entry| UNIVERSAL_ERRORS.include?(entry.first) }
+  end
+
+  def self.format_failures(validator_class, missing, extra)
+    failures = []
+    failures << "[#{validator_class}] declared via raises but never emitted in spec: #{missing.to_a.inspect}" if missing.any?
+    failures << "[#{validator_class}] emitted but not declared via raises (and not part of the universal baseline): #{extra.inspect}" if extra.any?
+    failures
   end
 end
 

--- a/site/app/models/api_entreprise/endpoint.rb
+++ b/site/app/models/api_entreprise/endpoint.rb
@@ -27,6 +27,9 @@ class APIEntreprise::Endpoint < AbstractEndpoint
     @custom_provider_errors ||= error_examples('502').reject { |error_payload|
       %w[
         000
+        008
+        009
+        011
         051
         052
         053


### PR DESCRIPTION
Cette PR implémente le système d'exposition automatique des erreurs spécifiques par endpoint dans le swagger (et donc dans les fiches métier qui le consomment), et le valide en câblant l'URSSAF attestation de vigilance comme PoC.

Cf. [API-6703](https://linear.app/pole-api/issue/API-6703/refactor-exposition-des-erreurs-fd-dsl-raises-registre-par-endpoint) pour le contexte et l'analyse complète.

----

**Avant** : exposer les erreurs FD-spécifiques sur un endpoint reposait sur trois sources non synchronisées — `config/errors.yml` (textes), `subcode_config` Ruby (mapping `kind → subcode`), et push manuel dans les specs rswag. Conséquence : URSSAF/CIBTP exposaient leur catalogue, le reste des ~50 endpoints non.

**Après** : chaque interactor déclare ce qu'il émet via une DSL `raises`. Le registre agrège par organizer, et le helper rswag injecte automatiquement les exemples dans le swagger, pour être ensuite affiché sur le site (via une mécanique existante).

```ruby
class URSSAF::AttestationsSociales::ValidateResponse::RawBody < ValidateResponse
  raises ACOSSError, kind: :manual_verification_asked
  raises ACOSSError, kind: :ongoing_manual_verification
end
```

---

Next steps:

- Généraliser les déclarations `raises` aux ~50 autres `ValidateResponse`.
- Réconcilier le 504 : `common_network_error_request` hardcode encore son catalogue, alors que le contrôleur map déjà `:network_error` / `:provider_error` à 502.
- Étendre le garde-fou aux interactors hors `ValidateResponse` (`Documents::*`, `MakeRequest`).
- Helper rswag équivalent pour 404 (NotFoundError + dérivés spécifiques type `CIBTPMissingPaymentsError`, `DGFIPPotentialNotFoundError`).
