### PR TITLE
Fix NoMethodError when DataSubvention auth returns JSON without user/jwt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,10 @@ avec les conventions spécifiques :
 - `site/CLAUDE.md` — admin SIADE (front + back-office)
 - `mocks/CLAUDE.md` — mocks fournisseurs
 
+## Conventions transverses
+
+- Messages de commit rédigés en anglais.
+
 ## Outils partagés
 
 ### Sentry / Production Errors

--- a/siade/app/interactors/data_subvention/subventions/authenticate.rb
+++ b/siade/app/interactors/data_subvention/subventions/authenticate.rb
@@ -7,11 +7,11 @@ class DataSubvention::Subventions::Authenticate < AbstractGetToken
   end
 
   def access_token(response)
-    JSON.parse(response.body)['user']['jwt']['token']
+    JSON.parse(response.body).dig('user', 'jwt', 'token')
   end
 
   def expires_in(response)
-    JSON.parse(response.body)['user']['jwt']['expirateDate']
+    JSON.parse(response.body).dig('user', 'jwt', 'expirateDate')
   end
 
   def client_url

--- a/siade/spec/interactors/data_subvention/subventions/authenticate_spec.rb
+++ b/siade/spec/interactors/data_subvention/subventions/authenticate_spec.rb
@@ -12,4 +12,17 @@ RSpec.describe DataSubvention::Subventions::Authenticate, type: :interactor do
       expect(subject.token).to be_present
     end
   end
+
+  context 'when provider is down and replies with valid JSON missing the user/jwt structure' do
+    before do
+      stub_request(:post, "#{Siade.credentials[:data_subvention_url]}/auth/login")
+        .to_return(status: 500, body: '{"error":"Internal Server Error"}')
+    end
+
+    it { is_expected.to be_a_failure }
+
+    it 'fails with a ProviderUnknownError' do
+      expect(subject.errors.first).to be_a(ProviderUnknownError)
+    end
+  end
 end


### PR DESCRIPTION
Fixes:
- https://errors.data.gouv.fr/organizations/sentry/issues/288903/
- https://errors.data.gouv.fr/organizations/sentry/issues/288905/
- https://errors.data.gouv.fr/organizations/sentry/issues/288908/
- https://errors.data.gouv.fr/organizations/sentry/issues/288909/