### PR TITLE
Enhance 404 message for CNAV endpoints

### DIFF
--- a/commons/endpoints/api_particulier/cnaf_msa_quotient_familial.yml
+++ b/commons/endpoints/api_particulier/cnaf_msa_quotient_familial.yml
@@ -208,6 +208,9 @@ fiche:
 
           {:.fr-highlight}
           > **Le code COG du pays de naissance est obligatoire pour tous les appels.** Pour simplifier le parcours des usagers, évitez de demander aux particuliers nés en France de saisir leur pays de naissance, puisque vous pouvez le paramétrer directement -code COG pays France `99100`-, dès qu'un particuloer renseigne les informations de sa commune de naissance (forcément en France).
+      - q: Comment connaître la caisse de rattachement (CNAF, MSA, RNCPS) en cas de 404 ?
+        a: |+
+          En cas de réponse 404 _(dossier allocataire absent)_, la caisse effectivement interrogée est indiquée dans le champ `meta.provider` de la réponse. Sa valeur peut être `CNAF`, `MSA` ou `RNCPS` selon la caisse de rattachement de l'allocataire.
 
     historique: |+
       **Ce que change le passage à la V.3 d'API Particulier:**

--- a/commons/swagger/openapi-particulier.yaml
+++ b/commons/swagger/openapi-particulier.yaml
@@ -1074,32 +1074,19 @@ paths:
           content:
             application/json:
               examples:
-                dossier_allocataire_absent_msa_10003:
+                dossier_allocataire_absent:
                   value:
                     errors:
-                    - code: '10003'
-                      title: Dossier allocataire absent MSA
-                      detail: Le dossier allocataire n'a pas été trouvé auprès de
-                        la MSA.
+                    - code: '36003'
+                      title: Dossier allocataire absent
+                      detail: Le dossier allocataire n'a pas été trouvé. Le fournisseur
+                        de données est précisé dans 'meta.provider'.
                       source:
                       meta:
-                        provider: MSA
-                  summary: Dossier allocataire absent MSA
-                  description: Le dossier allocataire n'a pas été trouvé auprès de
-                    la MSA.
-                dossier_allocataire_absent_cnaf_23003:
-                  value:
-                    errors:
-                    - code: '23003'
-                      title: Dossier allocataire absent CNAF
-                      detail: Le dossier allocataire n'a pas été trouvé auprès de
-                        la CNAF.
-                      source:
-                      meta:
-                        provider: CNAF
-                  summary: Dossier allocataire absent CNAF
-                  description: Le dossier allocataire n'a pas été trouvé auprès de
-                    la CNAF.
+                        provider: Sécurité sociale
+                  summary: Dossier allocataire absent
+                  description: Le dossier allocataire n'a pas été trouvé. Le fournisseur
+                    de données est précisé dans 'meta.provider'.
                 allocataire_non_reference_35003:
                   value:
                     errors:
@@ -1435,32 +1422,19 @@ paths:
           content:
             application/json:
               examples:
-                dossier_allocataire_absent_msa_10003:
+                dossier_allocataire_absent:
                   value:
                     errors:
-                    - code: '10003'
-                      title: Dossier allocataire absent MSA
-                      detail: Le dossier allocataire n'a pas été trouvé auprès de
-                        la MSA.
+                    - code: '36003'
+                      title: Dossier allocataire absent
+                      detail: Le dossier allocataire n'a pas été trouvé. Le fournisseur
+                        de données est précisé dans 'meta.provider'.
                       source:
                       meta:
-                        provider: MSA
-                  summary: Dossier allocataire absent MSA
-                  description: Le dossier allocataire n'a pas été trouvé auprès de
-                    la MSA.
-                dossier_allocataire_absent_cnaf_23003:
-                  value:
-                    errors:
-                    - code: '23003'
-                      title: Dossier allocataire absent CNAF
-                      detail: Le dossier allocataire n'a pas été trouvé auprès de
-                        la CNAF.
-                      source:
-                      meta:
-                        provider: CNAF
-                  summary: Dossier allocataire absent CNAF
-                  description: Le dossier allocataire n'a pas été trouvé auprès de
-                    la CNAF.
+                        provider: Sécurité sociale
+                  summary: Dossier allocataire absent
+                  description: Le dossier allocataire n'a pas été trouvé. Le fournisseur
+                    de données est précisé dans 'meta.provider'.
                 allocataire_non_reference_35003:
                   value:
                     errors:
@@ -1932,32 +1906,19 @@ paths:
           content:
             application/json:
               examples:
-                dossier_allocataire_absent_msa_10003:
+                dossier_allocataire_absent:
                   value:
                     errors:
-                    - code: '10003'
-                      title: Dossier allocataire absent MSA
-                      detail: Le dossier allocataire n'a pas été trouvé auprès de
-                        la MSA.
+                    - code: '36003'
+                      title: Dossier allocataire absent
+                      detail: Le dossier allocataire n'a pas été trouvé. Le fournisseur
+                        de données est précisé dans 'meta.provider'.
                       source:
                       meta:
-                        provider: MSA
-                  summary: Dossier allocataire absent MSA
-                  description: Le dossier allocataire n'a pas été trouvé auprès de
-                    la MSA.
-                dossier_allocataire_absent_cnaf_23003:
-                  value:
-                    errors:
-                    - code: '23003'
-                      title: Dossier allocataire absent CNAF
-                      detail: Le dossier allocataire n'a pas été trouvé auprès de
-                        la CNAF.
-                      source:
-                      meta:
-                        provider: CNAF
-                  summary: Dossier allocataire absent CNAF
-                  description: Le dossier allocataire n'a pas été trouvé auprès de
-                    la CNAF.
+                        provider: Sécurité sociale
+                  summary: Dossier allocataire absent
+                  description: Le dossier allocataire n'a pas été trouvé. Le fournisseur
+                    de données est précisé dans 'meta.provider'.
                 allocataire_non_reference_35003:
                   value:
                     errors:
@@ -2309,32 +2270,19 @@ paths:
           content:
             application/json:
               examples:
-                dossier_allocataire_absent_msa_10003:
+                dossier_allocataire_absent:
                   value:
                     errors:
-                    - code: '10003'
-                      title: Dossier allocataire absent MSA
-                      detail: Le dossier allocataire n'a pas été trouvé auprès de
-                        la MSA.
+                    - code: '36003'
+                      title: Dossier allocataire absent
+                      detail: Le dossier allocataire n'a pas été trouvé. Le fournisseur
+                        de données est précisé dans 'meta.provider'.
                       source:
                       meta:
-                        provider: MSA
-                  summary: Dossier allocataire absent MSA
-                  description: Le dossier allocataire n'a pas été trouvé auprès de
-                    la MSA.
-                dossier_allocataire_absent_cnaf_23003:
-                  value:
-                    errors:
-                    - code: '23003'
-                      title: Dossier allocataire absent CNAF
-                      detail: Le dossier allocataire n'a pas été trouvé auprès de
-                        la CNAF.
-                      source:
-                      meta:
-                        provider: CNAF
-                  summary: Dossier allocataire absent CNAF
-                  description: Le dossier allocataire n'a pas été trouvé auprès de
-                    la CNAF.
+                        provider: Sécurité sociale
+                  summary: Dossier allocataire absent
+                  description: Le dossier allocataire n'a pas été trouvé. Le fournisseur
+                    de données est précisé dans 'meta.provider'.
                 allocataire_non_reference_35003:
                   value:
                     errors:
@@ -2793,32 +2741,19 @@ paths:
           content:
             application/json:
               examples:
-                dossier_allocataire_absent_msa_10003:
+                dossier_allocataire_absent:
                   value:
                     errors:
-                    - code: '10003'
-                      title: Dossier allocataire absent MSA
-                      detail: Le dossier allocataire n'a pas été trouvé auprès de
-                        la MSA.
+                    - code: '36003'
+                      title: Dossier allocataire absent
+                      detail: Le dossier allocataire n'a pas été trouvé. Le fournisseur
+                        de données est précisé dans 'meta.provider'.
                       source:
                       meta:
-                        provider: MSA
-                  summary: Dossier allocataire absent MSA
-                  description: Le dossier allocataire n'a pas été trouvé auprès de
-                    la MSA.
-                dossier_allocataire_absent_cnaf_23003:
-                  value:
-                    errors:
-                    - code: '23003'
-                      title: Dossier allocataire absent CNAF
-                      detail: Le dossier allocataire n'a pas été trouvé auprès de
-                        la CNAF.
-                      source:
-                      meta:
-                        provider: CNAF
-                  summary: Dossier allocataire absent CNAF
-                  description: Le dossier allocataire n'a pas été trouvé auprès de
-                    la CNAF.
+                        provider: Sécurité sociale
+                  summary: Dossier allocataire absent
+                  description: Le dossier allocataire n'a pas été trouvé. Le fournisseur
+                    de données est précisé dans 'meta.provider'.
                 allocataire_non_reference_35003:
                   value:
                     errors:
@@ -3156,32 +3091,19 @@ paths:
           content:
             application/json:
               examples:
-                dossier_allocataire_absent_msa_10003:
+                dossier_allocataire_absent:
                   value:
                     errors:
-                    - code: '10003'
-                      title: Dossier allocataire absent MSA
-                      detail: Le dossier allocataire n'a pas été trouvé auprès de
-                        la MSA.
+                    - code: '36003'
+                      title: Dossier allocataire absent
+                      detail: Le dossier allocataire n'a pas été trouvé. Le fournisseur
+                        de données est précisé dans 'meta.provider'.
                       source:
                       meta:
-                        provider: MSA
-                  summary: Dossier allocataire absent MSA
-                  description: Le dossier allocataire n'a pas été trouvé auprès de
-                    la MSA.
-                dossier_allocataire_absent_cnaf_23003:
-                  value:
-                    errors:
-                    - code: '23003'
-                      title: Dossier allocataire absent CNAF
-                      detail: Le dossier allocataire n'a pas été trouvé auprès de
-                        la CNAF.
-                      source:
-                      meta:
-                        provider: CNAF
-                  summary: Dossier allocataire absent CNAF
-                  description: Le dossier allocataire n'a pas été trouvé auprès de
-                    la CNAF.
+                        provider: Sécurité sociale
+                  summary: Dossier allocataire absent
+                  description: Le dossier allocataire n'a pas été trouvé. Le fournisseur
+                    de données est précisé dans 'meta.provider'.
                 allocataire_non_reference_35003:
                   value:
                     errors:
@@ -3661,19 +3583,19 @@ paths:
           content:
             application/json:
               examples:
-                dossier_allocataire_absent_rncps_40003:
+                dossier_allocataire_absent:
                   value:
                     errors:
-                    - code: '40003'
-                      title: Dossier allocataire absent RNCPS
-                      detail: Le dossier allocataire n'a pas été trouvé auprès du
-                        RNCPS.
+                    - code: '36003'
+                      title: Dossier allocataire absent
+                      detail: Le dossier allocataire n'a pas été trouvé. Le fournisseur
+                        de données est précisé dans 'meta.provider'.
                       source:
                       meta:
-                        provider: RNCPS
-                  summary: Dossier allocataire absent RNCPS
-                  description: Le dossier allocataire n'a pas été trouvé auprès du
-                    RNCPS.
+                        provider: Sécurité sociale
+                  summary: Dossier allocataire absent
+                  description: Le dossier allocataire n'a pas été trouvé. Le fournisseur
+                    de données est précisé dans 'meta.provider'.
                 allocataire_non_reference_40003:
                   value:
                     errors:
@@ -4032,19 +3954,19 @@ paths:
           content:
             application/json:
               examples:
-                dossier_allocataire_absent_rncps_40003:
+                dossier_allocataire_absent:
                   value:
                     errors:
-                    - code: '40003'
-                      title: Dossier allocataire absent RNCPS
-                      detail: Le dossier allocataire n'a pas été trouvé auprès du
-                        RNCPS
+                    - code: '36003'
+                      title: Dossier allocataire absent
+                      detail: Le dossier allocataire n'a pas été trouvé. Le fournisseur
+                        de données est précisé dans 'meta.provider'.
                       source:
                       meta:
-                        provider: RNCPS
-                  summary: Dossier allocataire absent RNCPS
-                  description: Le dossier allocataire n'a pas été trouvé auprès du
-                    RNCPS
+                        provider: Sécurité sociale
+                  summary: Dossier allocataire absent
+                  description: Le dossier allocataire n'a pas été trouvé. Le fournisseur
+                    de données est précisé dans 'meta.provider'.
                 allocataire_non_reference_35003:
                   value:
                     errors:
@@ -5642,32 +5564,19 @@ paths:
           content:
             application/json:
               examples:
-                dossier_allocataire_absent_msa_10003:
+                dossier_allocataire_absent:
                   value:
                     errors:
-                    - code: '10003'
-                      title: Dossier allocataire absent MSA
-                      detail: Le dossier allocataire n'a pas été trouvé auprès de
-                        la MSA.
+                    - code: '36003'
+                      title: Dossier allocataire absent
+                      detail: Le dossier allocataire n'a pas été trouvé. Le fournisseur
+                        de données est précisé dans 'meta.provider'.
                       source:
                       meta:
-                        provider: MSA
-                  summary: Dossier allocataire absent MSA
-                  description: Le dossier allocataire n'a pas été trouvé auprès de
-                    la MSA.
-                dossier_allocataire_absent_cnaf_23003:
-                  value:
-                    errors:
-                    - code: '23003'
-                      title: Dossier allocataire absent CNAF
-                      detail: Le dossier allocataire n'a pas été trouvé auprès de
-                        la CNAF.
-                      source:
-                      meta:
-                        provider: CNAF
-                  summary: Dossier allocataire absent CNAF
-                  description: Le dossier allocataire n'a pas été trouvé auprès de
-                    la CNAF.
+                        provider: Sécurité sociale
+                  summary: Dossier allocataire absent
+                  description: Le dossier allocataire n'a pas été trouvé. Le fournisseur
+                    de données est précisé dans 'meta.provider'.
                 allocataire_non_reference_35003:
                   value:
                     errors:
@@ -6014,32 +5923,19 @@ paths:
           content:
             application/json:
               examples:
-                dossier_allocataire_absent_msa_10003:
+                dossier_allocataire_absent:
                   value:
                     errors:
-                    - code: '10003'
-                      title: Dossier allocataire absent MSA
-                      detail: Le dossier allocataire n'a pas été trouvé auprès de
-                        la MSA.
+                    - code: '36003'
+                      title: Dossier allocataire absent
+                      detail: Le dossier allocataire n'a pas été trouvé. Le fournisseur
+                        de données est précisé dans 'meta.provider'.
                       source:
                       meta:
-                        provider: MSA
-                  summary: Dossier allocataire absent MSA
-                  description: Le dossier allocataire n'a pas été trouvé auprès de
-                    la MSA.
-                dossier_allocataire_absent_cnaf_23003:
-                  value:
-                    errors:
-                    - code: '23003'
-                      title: Dossier allocataire absent CNAF
-                      detail: Le dossier allocataire n'a pas été trouvé auprès de
-                        la CNAF.
-                      source:
-                      meta:
-                        provider: CNAF
-                  summary: Dossier allocataire absent CNAF
-                  description: Le dossier allocataire n'a pas été trouvé auprès de
-                    la CNAF.
+                        provider: Sécurité sociale
+                  summary: Dossier allocataire absent
+                  description: Le dossier allocataire n'a pas été trouvé. Le fournisseur
+                    de données est précisé dans 'meta.provider'.
                 allocataire_non_reference_35003:
                   value:
                     errors:
@@ -7972,32 +7868,19 @@ paths:
           content:
             application/json:
               examples:
-                dossier_allocataire_absent_msa_10003:
+                dossier_allocataire_absent:
                   value:
                     errors:
-                    - code: '10003'
-                      title: Dossier allocataire absent MSA
-                      detail: Le dossier allocataire n'a pas été trouvé auprès de
-                        la MSA.
+                    - code: '36003'
+                      title: Dossier allocataire absent
+                      detail: Le dossier allocataire n'a pas été trouvé. Le fournisseur
+                        de données est précisé dans 'meta.provider'.
                       source:
                       meta:
-                        provider: MSA
-                  summary: Dossier allocataire absent MSA
-                  description: Le dossier allocataire n'a pas été trouvé auprès de
-                    la MSA.
-                dossier_allocataire_absent_cnaf_23003:
-                  value:
-                    errors:
-                    - code: '23003'
-                      title: Dossier allocataire absent CNAF
-                      detail: Le dossier allocataire n'a pas été trouvé auprès de
-                        la CNAF.
-                      source:
-                      meta:
-                        provider: CNAF
-                  summary: Dossier allocataire absent CNAF
-                  description: Le dossier allocataire n'a pas été trouvé auprès de
-                    la CNAF.
+                        provider: Sécurité sociale
+                  summary: Dossier allocataire absent
+                  description: Le dossier allocataire n'a pas été trouvé. Le fournisseur
+                    de données est précisé dans 'meta.provider'.
                 allocataire_non_reference_35003:
                   value:
                     errors:
@@ -8344,32 +8227,19 @@ paths:
           content:
             application/json:
               examples:
-                dossier_allocataire_absent_msa_10003:
+                dossier_allocataire_absent:
                   value:
                     errors:
-                    - code: '10003'
-                      title: Dossier allocataire absent MSA
-                      detail: Le dossier allocataire n'a pas été trouvé auprès de
-                        la MSA.
+                    - code: '36003'
+                      title: Dossier allocataire absent
+                      detail: Le dossier allocataire n'a pas été trouvé. Le fournisseur
+                        de données est précisé dans 'meta.provider'.
                       source:
                       meta:
-                        provider: MSA
-                  summary: Dossier allocataire absent MSA
-                  description: Le dossier allocataire n'a pas été trouvé auprès de
-                    la MSA.
-                dossier_allocataire_absent_cnaf_23003:
-                  value:
-                    errors:
-                    - code: '23003'
-                      title: Dossier allocataire absent CNAF
-                      detail: Le dossier allocataire n'a pas été trouvé auprès de
-                        la CNAF.
-                      source:
-                      meta:
-                        provider: CNAF
-                  summary: Dossier allocataire absent CNAF
-                  description: Le dossier allocataire n'a pas été trouvé auprès de
-                    la CNAF.
+                        provider: Sécurité sociale
+                  summary: Dossier allocataire absent
+                  description: Le dossier allocataire n'a pas été trouvé. Le fournisseur
+                    de données est précisé dans 'meta.provider'.
                 allocataire_non_reference_35003:
                   value:
                     errors:

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_adulte_handicape_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_adulte_handicape_with_civility_spec.rb
@@ -96,12 +96,12 @@ RSpec.describe 'API Particulier CNAV: allocation adulte handicape with civility'
         describe 'when the aah is not found' do
           # rubocop:disable RSpec/ContextWording
           response '404', 'Dossier allocataire inexistant. Le document ne peut être édité.' do
+            build_dossier_allocataire_absent_rswag_example
+
             context 'Dossier non trouvé MSA' do
               before do
                 stub_cnav_404('allocation_adulte_handicape', 'MSA')
               end
-
-              build_rswag_example(NotFoundError.new('MSA', "Le dossier allocataire n'a pas été trouvé auprès de la MSA.", title: 'Dossier allocataire absent MSA', with_identifiant_message: false))
 
               schema '$ref' => '#/components/schemas/Error'
 
@@ -112,8 +112,6 @@ RSpec.describe 'API Particulier CNAV: allocation adulte handicape with civility'
               before do
                 stub_cnav_404('allocation_adulte_handicape', 'CNAF')
               end
-
-              build_rswag_example(NotFoundError.new('CNAF', "Le dossier allocataire n'a pas été trouvé auprès de la CNAF.", title: 'Dossier allocataire absent CNAF', with_identifiant_message: false))
 
               schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_adulte_handicape_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_adulte_handicape_with_france_connect_spec.rb
@@ -62,12 +62,12 @@ RSpec.describe 'API Particulier: CNAV: Allocation Adulte Handicape with FranceCo
         describe 'when the aah is not found' do
           # rubocop:disable RSpec/ContextWording
           response '404', 'Dossier allocataire inexistant. Le document ne peut être édité.' do
+            build_dossier_allocataire_absent_rswag_example
+
             context 'Dossier non trouvé MSA' do
               before do
                 stub_cnav_404('allocation_adulte_handicape', 'MSA')
               end
-
-              build_rswag_example(NotFoundError.new('MSA', "Le dossier allocataire n'a pas été trouvé auprès de la MSA.", title: 'Dossier allocataire absent MSA', with_identifiant_message: false))
 
               schema '$ref' => '#/components/schemas/Error'
 
@@ -78,8 +78,6 @@ RSpec.describe 'API Particulier: CNAV: Allocation Adulte Handicape with FranceCo
               before do
                 stub_cnav_404('allocation_adulte_handicape', 'CNAF')
               end
-
-              build_rswag_example(NotFoundError.new('CNAF', "Le dossier allocataire n'a pas été trouvé auprès de la CNAF.", title: 'Dossier allocataire absent CNAF', with_identifiant_message: false))
 
               schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_enfant_handicape/allocation_enfant_handicape_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_enfant_handicape/allocation_enfant_handicape_with_civility_spec.rb
@@ -96,12 +96,12 @@ RSpec.describe 'API Particulier CNAV: Allocation enfant handicapé (AEEH) with c
         describe 'when the aeeh is not found' do
           # rubocop:disable RSpec/ContextWording
           response '404', 'Dossier allocataire inexistant. Le document ne peut être édité.' do
+            build_dossier_allocataire_absent_rswag_example
+
             context 'Dossier non trouvé MSA' do
               before do
                 stub_cnav_404('allocation_enfant_handicape', 'MSA')
               end
-
-              build_rswag_example(NotFoundError.new('MSA', "Le dossier allocataire n'a pas été trouvé auprès de la MSA.", title: 'Dossier allocataire absent MSA', with_identifiant_message: false))
 
               schema '$ref' => '#/components/schemas/Error'
 
@@ -112,8 +112,6 @@ RSpec.describe 'API Particulier CNAV: Allocation enfant handicapé (AEEH) with c
               before do
                 stub_cnav_404('allocation_enfant_handicape', 'CNAF')
               end
-
-              build_rswag_example(NotFoundError.new('CNAF', "Le dossier allocataire n'a pas été trouvé auprès de la CNAF.", title: 'Dossier allocataire absent CNAF', with_identifiant_message: false))
 
               schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_enfant_handicape/allocation_enfant_handicape_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_enfant_handicape/allocation_enfant_handicape_with_france_connect_spec.rb
@@ -62,12 +62,12 @@ RSpec.describe 'API Particulier: CNAV: Allocation enfant handicapé (AEEH) with 
         describe 'when the aeeh is not found' do
           # rubocop:disable RSpec/ContextWording
           response '404', 'Dossier allocataire inexistant. Le document ne peut être édité.' do
+            build_dossier_allocataire_absent_rswag_example
+
             context 'Dossier non trouvé MSA' do
               before do
                 stub_cnav_404('allocation_enfant_handicape', 'MSA')
               end
-
-              build_rswag_example(NotFoundError.new('MSA', "Le dossier allocataire n'a pas été trouvé auprès de la MSA.", title: 'Dossier allocataire absent MSA', with_identifiant_message: false))
 
               schema '$ref' => '#/components/schemas/Error'
 
@@ -78,8 +78,6 @@ RSpec.describe 'API Particulier: CNAV: Allocation enfant handicapé (AEEH) with 
               before do
                 stub_cnav_404('allocation_enfant_handicape', 'CNAF')
               end
-
-              build_rswag_example(NotFoundError.new('CNAF', "Le dossier allocataire n'a pas été trouvé auprès de la CNAF.", title: 'Dossier allocataire absent CNAF', with_identifiant_message: false))
 
               schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_soutien_familial_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_soutien_familial_with_civility_spec.rb
@@ -96,12 +96,12 @@ RSpec.describe 'API Particulier CNAV: allocation soutien familial with civility'
         describe 'when the asf is not found' do
           # rubocop:disable RSpec/ContextWording
           response '404', 'Dossier allocataire inexistant. Le document ne peut être édité.' do
+            build_dossier_allocataire_absent_rswag_example
+
             context 'Dossier non trouvé MSA' do
               before do
                 stub_cnav_404('allocation_soutien_familial', 'MSA')
               end
-
-              build_rswag_example(NotFoundError.new('MSA', "Le dossier allocataire n'a pas été trouvé auprès de la MSA.", title: 'Dossier allocataire absent MSA', with_identifiant_message: false))
 
               schema '$ref' => '#/components/schemas/Error'
 
@@ -112,8 +112,6 @@ RSpec.describe 'API Particulier CNAV: allocation soutien familial with civility'
               before do
                 stub_cnav_404('allocation_soutien_familial', 'CNAF')
               end
-
-              build_rswag_example(NotFoundError.new('CNAF', "Le dossier allocataire n'a pas été trouvé auprès de la CNAF.", title: 'Dossier allocataire absent CNAF', with_identifiant_message: false))
 
               schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_soutien_familial_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_soutien_familial_with_france_connect_spec.rb
@@ -62,12 +62,12 @@ RSpec.describe 'API Particulier: CNAV: Allocation Soutien Familial with FranceCo
         describe 'when the asf is not found' do
           # rubocop:disable RSpec/ContextWording
           response '404', 'Dossier allocataire inexistant. Le document ne peut être édité.' do
+            build_dossier_allocataire_absent_rswag_example
+
             context 'Dossier non trouvé MSA' do
               before do
                 stub_cnav_404('allocation_soutien_familial', 'MSA')
               end
-
-              build_rswag_example(NotFoundError.new('MSA', "Le dossier allocataire n'a pas été trouvé auprès de la MSA.", title: 'Dossier allocataire absent MSA', with_identifiant_message: false))
 
               schema '$ref' => '#/components/schemas/Error'
 
@@ -78,8 +78,6 @@ RSpec.describe 'API Particulier: CNAV: Allocation Soutien Familial with FranceCo
               before do
                 stub_cnav_404('allocation_soutien_familial', 'CNAF')
               end
-
-              build_rswag_example(NotFoundError.new('CNAF', "Le dossier allocataire n'a pas été trouvé auprès de la CNAF.", title: 'Dossier allocataire absent CNAF', with_identifiant_message: false))
 
               schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/complementaire_sante_solidaire_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/complementaire_sante_solidaire_with_civility_spec.rb
@@ -96,12 +96,12 @@ RSpec.describe 'API Particulier CNAV: complementaire sante solidaire with civili
         describe 'when the css is not found' do
           # rubocop:disable RSpec/ContextWording
           response '404', 'Dossier allocataire inexistant. Le document ne peut être édité.' do
+            build_dossier_allocataire_absent_rswag_example
+
             context 'Dossier non trouvé RNCPS' do
               before do
                 stub_cnav_404('complementaire_sante_solidaire', 'RNCPS')
               end
-
-              build_rswag_example(NotFoundError.new('RNCPS', "Le dossier allocataire n'a pas été trouvé auprès du RNCPS.", title: 'Dossier allocataire absent RNCPS', with_identifiant_message: false))
 
               schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/complementaire_sante_solidaire_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/complementaire_sante_solidaire_with_france_connect_spec.rb
@@ -62,12 +62,12 @@ RSpec.describe 'API Particulier: CNAV: Complementaire Sante Solidaire with Franc
         describe 'when the css is not found' do
           # rubocop:disable RSpec/ContextWording
           response '404', 'Dossier allocataire inexistant. Le document ne peut être édité.' do
+            build_dossier_allocataire_absent_rswag_example
+
             context 'Dossier non trouvé RNCPS' do
               before do
                 stub_cnav_404('complementaire_sante_solidaire', 'RNCPS')
               end
-
-              build_rswag_example(NotFoundError.new('RNCPS', "Le dossier allocataire n'a pas été trouvé auprès du RNCPS", title: 'Dossier allocataire absent RNCPS', with_identifiant_message: false))
 
               schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/prime_activite_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/prime_activite_with_civility_spec.rb
@@ -96,12 +96,12 @@ RSpec.describe 'API Particulier CNAV: prime activite with civility', api: :parti
         describe 'when the pa is not found' do
           # rubocop:disable RSpec/ContextWording
           response '404', 'Dossier allocataire inexistant. Le document ne peut être édité.' do
+            build_dossier_allocataire_absent_rswag_example
+
             context 'Dossier non trouvé MSA' do
               before do
                 stub_cnav_404('prime_activite', 'MSA')
               end
-
-              build_rswag_example(NotFoundError.new('MSA', "Le dossier allocataire n'a pas été trouvé auprès de la MSA.", title: 'Dossier allocataire absent MSA', with_identifiant_message: false))
 
               schema '$ref' => '#/components/schemas/Error'
 
@@ -112,8 +112,6 @@ RSpec.describe 'API Particulier CNAV: prime activite with civility', api: :parti
               before do
                 stub_cnav_404('prime_activite', 'CNAF')
               end
-
-              build_rswag_example(NotFoundError.new('CNAF', "Le dossier allocataire n'a pas été trouvé auprès de la CNAF.", title: 'Dossier allocataire absent CNAF', with_identifiant_message: false))
 
               schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/prime_activite_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/prime_activite_with_france_connect_spec.rb
@@ -62,12 +62,12 @@ RSpec.describe 'API Particulier: CNAV: Prime Activite with FranceConnect', api: 
         describe 'when the pa is not found' do
           # rubocop:disable RSpec/ContextWording
           response '404', 'Dossier allocataire inexistant. Le document ne peut être édité.' do
+            build_dossier_allocataire_absent_rswag_example
+
             context 'Dossier non trouvé MSA' do
               before do
                 stub_cnav_404('prime_activite', 'MSA')
               end
-
-              build_rswag_example(NotFoundError.new('MSA', "Le dossier allocataire n'a pas été trouvé auprès de la MSA.", title: 'Dossier allocataire absent MSA', with_identifiant_message: false))
 
               schema '$ref' => '#/components/schemas/Error'
 
@@ -78,8 +78,6 @@ RSpec.describe 'API Particulier: CNAV: Prime Activite with FranceConnect', api: 
               before do
                 stub_cnav_404('prime_activite', 'CNAF')
               end
-
-              build_rswag_example(NotFoundError.new('CNAF', "Le dossier allocataire n'a pas été trouvé auprès de la CNAF.", title: 'Dossier allocataire absent CNAF', with_identifiant_message: false))
 
               schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/revenu_solidarite_active_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/revenu_solidarite_active_with_civility_spec.rb
@@ -96,12 +96,12 @@ RSpec.describe 'API Particulier CNAV: Revenu de solidarité active with civility
         describe 'when the rsa is not found' do
           # rubocop:disable RSpec/ContextWording
           response '404', 'Dossier allocataire inexistant. Le document ne peut être édité.' do
+            build_dossier_allocataire_absent_rswag_example
+
             context 'Dossier non trouvé MSA' do
               before do
                 stub_cnav_404('revenu_solidarite_active', 'MSA')
               end
-
-              build_rswag_example(NotFoundError.new('MSA', "Le dossier allocataire n'a pas été trouvé auprès de la MSA.", title: 'Dossier allocataire absent MSA', with_identifiant_message: false))
 
               schema '$ref' => '#/components/schemas/Error'
 
@@ -112,8 +112,6 @@ RSpec.describe 'API Particulier CNAV: Revenu de solidarité active with civility
               before do
                 stub_cnav_404('revenu_solidarite_active', 'CNAF')
               end
-
-              build_rswag_example(NotFoundError.new('CNAF', "Le dossier allocataire n'a pas été trouvé auprès de la CNAF.", title: 'Dossier allocataire absent CNAF', with_identifiant_message: false))
 
               schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/revenu_solidarite_active_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/revenu_solidarite_active_with_france_connect_spec.rb
@@ -62,12 +62,12 @@ RSpec.describe 'API Particulier: CNAV: Revenu Solidarite Active with FranceConne
         describe 'when the rsa is not found' do
           # rubocop:disable RSpec/ContextWording
           response '404', 'Dossier allocataire inexistant. Le document ne peut être édité.' do
+            build_dossier_allocataire_absent_rswag_example
+
             context 'Dossier non trouvé MSA' do
               before do
                 stub_cnav_404('revenu_solidarite_active', 'MSA')
               end
-
-              build_rswag_example(NotFoundError.new('MSA', "Le dossier allocataire n'a pas été trouvé auprès de la MSA.", title: 'Dossier allocataire absent MSA', with_identifiant_message: false))
 
               schema '$ref' => '#/components/schemas/Error'
 
@@ -78,8 +78,6 @@ RSpec.describe 'API Particulier: CNAV: Revenu Solidarite Active with FranceConne
               before do
                 stub_cnav_404('revenu_solidarite_active', 'CNAF')
               end
-
-              build_rswag_example(NotFoundError.new('CNAF', "Le dossier allocataire n'a pas été trouvé auprès de la CNAF.", title: 'Dossier allocataire absent CNAF', with_identifiant_message: false))
 
               schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/support/rswag_common_responses.rb
+++ b/siade/spec/support/rswag_common_responses.rb
@@ -106,6 +106,28 @@ module RSwagCommonResponses
   end
 
   # rubocop:disable Metrics/MethodLength
+  def build_dossier_allocataire_absent_rswag_example
+    title = 'Dossier allocataire absent'
+    detail = "Le dossier allocataire n'a pas été trouvé. Le fournisseur de données est précisé dans 'meta.provider'."
+
+    example 'application/json', :dossier_allocataire_absent,
+      {
+        errors: [
+          {
+            code: '36003',
+            title:,
+            detail:,
+            source: nil,
+            meta: { provider: 'Sécurité sociale' }
+          }
+        ]
+      },
+      title,
+      detail
+  end
+  # rubocop:enable Metrics/MethodLength
+
+  # rubocop:disable Metrics/MethodLength
   def build_rswag_example(error, key = nil)
     payload = if metadata[:api] == :particulierv2
                 {


### PR DESCRIPTION
CNAF/MSA 404 errors works only for QF, not other endpoints. Make it generic because it's only an example.