### PR TITLE
Retry once on Errno::EBADF before failing as ProviderUnavailable

### DIFF
--- a/siade/app/interactors/make_request.rb
+++ b/siade/app/interactors/make_request.rb
@@ -62,6 +62,16 @@ class MakeRequest < ApplicationInteractor
     fail_to_request_provider!(ProviderTimeoutError)
   rescue Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::EHOSTUNREACH
     fail_to_request_provider!(ProviderUnavailable)
+  rescue Errno::EBADF
+    context.http_retry_count ||= 0
+
+    if context.http_retry_count < 1
+      context.http_retry_count += 1
+
+      retry
+    else
+      fail_to_request_provider!(ProviderUnavailable)
+    end
   rescue Errno::ENETUNREACH
     context.errors << NetworkError.new
     context.fail!

--- a/siade/spec/interactors/make_request_spec.rb
+++ b/siade/spec/interactors/make_request_spec.rb
@@ -107,6 +107,21 @@ RSpec.describe MakeRequest, type: :interactor do
       end
     end
 
+    context 'for an EBADF (bad file descriptor) error' do
+      let!(:stubbed_request) do
+        stub_request(:get, uri.to_s).to_raise(Errno::EBADF)
+      end
+
+      it { is_expected.to be_a_failure }
+
+      it 'retries once then adds ProviderUnavailable to errors' do
+        subject
+
+        expect(stubbed_request).to have_been_requested.times(2)
+        expect(subject.errors).to include(instance_of(ProviderUnavailable))
+      end
+    end
+
     context 'for a network unreachable error' do
       before do
         stub_request(:get, uri.to_s).to_raise(


### PR DESCRIPTION
Closes https://errors.data.gouv.fr/organizations/sentry/issues/289408/

A production event surfaced `Errno::EBADF: Bad file descriptor - SSL_write` while writing on a Net::HTTP socket. EBADF on SSL_write means OpenSSL tried to write on a file descriptor that was already closed/invalid by the time the syscall ran. The most likely cause is internal to our process, not the remote: a keep-alive socket reaped under us, GC racing the write and finalizing the underlying IO, or a signal interrupting the syscall at the wrong moment. It is therefore not a logic bug we can fix at the call site, nor a real provider outage, so bubbling up a 500 or short-circuiting straight to ProviderUnavailable both misrepresent what happened.

Treat it as a transient transport glitch: retry once (2 attempts total) reusing the existing http_retry_count machinery, then fall back to ProviderUnavailable so the recipient gets a clean 502 instead of an unhandled 500. The behaviour is provider-agnostic on purpose, since EBADF can hit any upstream call. Retry kept at 1 because the event is rarissime and we don't want to amplify load on a provider if the root cause ever turns out to be on their side.