### PR TITLE
Advertise the official Ruby SDKs in user-facing docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ avec les conventions spécifiques :
 - `siade/CLAUDE.md` — backend SIADE (API Entreprise / API Particulier)
 - `site/CLAUDE.md` — admin SIADE (front + back-office)
 - `mocks/CLAUDE.md` — mocks fournisseurs
+- `clients/` — SDKs officiels (`clients/SPECS.md` normatif, `clients/ruby/`
+  implémentation de référence ; autres langages à venir)
 
 ## Conventions transverses
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@ Built and maintained by [DINUM](https://www.numerique.gouv.fr/) (Direction Inter
 - [`siade/`](siade/) — API application (Système d'Information des API de l'État)
 - [`site/`](site/) — Admin / APIM / documentation (formerly [`etalab/admin_api_entreprise`](https://github.com/etalab/admin_api_entreprise))
 - [`mocks/`](mocks/) — Test data and sandbox mock server for API Entreprise (v3+) and API Particulier staging environments
+- [`clients/`](clients/) — SDKs officiels construits sur les specs OpenAPI versionnées dans [`commons/swagger/`](commons/swagger). Implémentation de référence en Ruby dans [`clients/ruby/`](clients/ruby) ; autres langages à venir en suivant [`clients/SPECS.md`](clients/SPECS.md).
 
 ## Getting started
 
 - API: see [`siade/README.md`](siade/README.md)
 - Site: see [`site/README.md`](site/README.md)
 - Mocks: see [`mocks/README.md`](mocks/README.md)
+- Clients: see [`clients/README.md`](clients/README.md)
 
 ## Scripts
 

--- a/site/config/changelogs.yml
+++ b/site/config/changelogs.yml
@@ -1,3 +1,11 @@
+- date: 2026-05-05
+  scope: both
+  title: "SDKs officiels : Ruby disponible"
+  description: |
+    Une famille de **SDKs officiels** est désormais publiée dans le dossier [`clients/`](https://github.com/datagouv/apistration/tree/develop/clients) du dépôt, construite au-dessus des specs OpenAPI versionnées. Première implémentation disponible : **Ruby** ([`clients/ruby/`](https://github.com/datagouv/apistration/tree/develop/clients/ruby)), avec les gems `api_entreprise` et `api_particulier` (auth, enveloppe JSON:API, hiérarchie d'erreurs, rate-limit, retry opt-in, validateurs SIRET/SIREN).
+
+    Les ports dans d'autres langages (Node, Python, PHP, Java) suivront le contrat normatif [`SPECS.md`](https://github.com/datagouv/apistration/blob/develop/clients/SPECS.md).
+
 - date: 2026-05-04
   scope: api_particulier
   title: "CNAV : lieu de naissance optionnel"

--- a/site/config/locales/api_entreprise/documentation.fr.yml
+++ b/site/config/locales/api_entreprise/documentation.fr.yml
@@ -332,6 +332,24 @@ fr:
 
                   La réponse JSON renvoie la liste des API autorisées. Retrouvez-leurs spécifications techniques dans le [Swagger](<%= developers_openapi_path %>){:target="_blank_"}.
 
+          - anchor: 'sdks-officiels'
+            title: SDKs officiels&nbsp;📦
+            content: |+
+              Des **SDKs officiels** construits sur le [Swagger](<%= developers_openapi_path %>) sont publiés dans le dossier [`clients/`](https://github.com/datagouv/apistration/tree/develop/clients){:target="_blank"} du dépôt. Ils encapsulent l'authentification, l'enveloppe JSON:API, la hiérarchie d'erreurs, le rate-limit (avec retry opt-in sur 429&nbsp;/ 502&nbsp;/ 503) et les validateurs SIRET&nbsp;/ SIREN&nbsp;: vous écrivez du code métier, le SDK gère la plomberie HTTP.
+
+              {:.fr-highlight}
+              > Le contrat normatif langage-agnostique est décrit dans [`SPECS.md`](https://github.com/datagouv/apistration/blob/develop/clients/SPECS.md){:target="_blank"}. Les implémentations qui le suivent sont garanties iso-comportementales d'un langage à l'autre.
+
+              **Implémentations disponibles&nbsp;:**
+
+              {:.fr-table}
+              | Langage | Statut | Lien |
+              |---|---|---|
+              | Ruby | ✅ Disponible — implémentation de référence | [`clients/ruby/api_entreprise`](https://github.com/datagouv/apistration/tree/develop/clients/ruby/api_entreprise){:target="_blank"} |
+              | Node, Python, PHP, Java | 🚧 À venir | — |
+
+              Vous souhaitez contribuer un port dans un autre langage&nbsp;? Suivez la checklist de conformité de [`SPECS.md`](https://github.com/datagouv/apistration/blob/develop/clients/SPECS.md){:target="_blank"} et inspirez-vous de l'implémentation Ruby.
+
           - anchor: 'kit-de-mise-en-production'
             title: Kit de mise en production&nbsp;🚀
             subsections:

--- a/site/config/locales/api_particulier/documentation.fr.yml
+++ b/site/config/locales/api_particulier/documentation.fr.yml
@@ -564,6 +564,24 @@ fr:
 
                   La réponse JSON renvoie la liste des API et champs autorisées. Retrouvez-leurs spécifications techniques dans le [Swagger](<%= developers_openapi_path %>){:target="_blank_"}.
 
+          - anchor: 'sdks-officiels'
+            title: SDKs officiels&nbsp;📦
+            content: |+
+              Des **SDKs officiels** construits sur le [Swagger](<%= developers_openapi_path %>) sont publiés dans le dossier [`clients/`](https://github.com/datagouv/apistration/tree/develop/clients){:target="_blank"} du dépôt. Ils encapsulent l'authentification, l'enveloppe JSON:API, la hiérarchie d'erreurs, le rate-limit (avec retry opt-in sur 429&nbsp;/ 502&nbsp;/ 503) et les validateurs SIRET&nbsp;/ SIREN&nbsp;: vous écrivez du code métier, le SDK gère la plomberie HTTP.
+
+              {:.fr-highlight}
+              > Le contrat normatif langage-agnostique est décrit dans [`SPECS.md`](https://github.com/datagouv/apistration/blob/develop/clients/SPECS.md){:target="_blank"}. Les implémentations qui le suivent sont garanties iso-comportementales d'un langage à l'autre.
+
+              **Implémentations disponibles&nbsp;:**
+
+              {:.fr-table}
+              | Langage | Statut | Lien |
+              |---|---|---|
+              | Ruby | ✅ Disponible — implémentation de référence | [`clients/ruby/api_particulier`](https://github.com/datagouv/apistration/tree/develop/clients/ruby/api_particulier){:target="_blank"} |
+              | Node, Python, PHP, Java | 🚧 À venir | — |
+
+              Vous souhaitez contribuer un port dans un autre langage&nbsp;? Suivez la checklist de conformité de [`SPECS.md`](https://github.com/datagouv/apistration/blob/develop/clients/SPECS.md){:target="_blank"} et inspirez-vous de l'implémentation Ruby.
+
           - anchor: 'kit-de-mise-en-production'
             title: Kit de mise en production&nbsp;🚀
             subsections:


### PR DESCRIPTION
Until now nothing on the site or in the repo's top-level docs pointed to clients/, so consumers had no way to discover the gems even though both api_entreprise and api_particulier ship a fully-tested Ruby implementation.