### PR TITLE
Newsletter hebdomadaire des nouveautés

### DIFF
--- a/site/app/controllers/api_entreprise/changelog_subscriptions_controller.rb
+++ b/site/app/controllers/api_entreprise/changelog_subscriptions_controller.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class APIEntreprise::ChangelogSubscriptionsController < APIEntrepriseController
+  include ChangelogSubscriptionsManagement
+end

--- a/site/app/controllers/api_particulier/changelog_subscriptions_controller.rb
+++ b/site/app/controllers/api_particulier/changelog_subscriptions_controller.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class APIParticulier::ChangelogSubscriptionsController < APIParticulierController
+  include ChangelogSubscriptionsManagement
+end

--- a/site/app/controllers/concerns/changelog_subscriptions_management.rb
+++ b/site/app/controllers/concerns/changelog_subscriptions_management.rb
@@ -1,0 +1,51 @@
+module ChangelogSubscriptionsManagement
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :authenticate_user!, except: :destroy_via_token
+  end
+
+  def create
+    current_user.changelog_subscriptions.create!(scope: namespace_scope) unless current_user.changelog_subscriptions.active.exists?(scope: namespace_scope)
+
+    success_message(title: t('shared.changelog_subscriptions.create.success.title'))
+
+    redirect_to changelogs_path
+  end
+
+  def destroy
+    subscription = current_user.changelog_subscriptions.active.find_by(scope: namespace_scope)
+    subscription&.disable!
+
+    success_message(title: t('shared.changelog_subscriptions.destroy.success.title'))
+
+    redirect_to changelogs_path
+  end
+
+  def destroy_via_token
+    subscription = ChangelogSubscription.active.for_scope(namespace_scope).find_by(unsubscribe_token: params[:token])
+
+    if subscription
+      subscription.disable!
+      success_message(title: t('shared.changelog_subscriptions.destroy_via_token.success.title'))
+    else
+      error_message(title: t('shared.changelog_subscriptions.destroy_via_token.error.title'))
+    end
+
+    redirect_to changelogs_path
+  end
+
+  private
+
+  def authenticate_user!
+    return if user_signed_in?
+
+    error_message(title: t('concerns.sessions_management.unauthorized.signed_out.error.title'))
+
+    redirect_to login_path
+  end
+
+  def namespace_scope
+    namespace
+  end
+end

--- a/site/app/helpers/mailer_url_helper.rb
+++ b/site/app/helpers/mailer_url_helper.rb
@@ -1,0 +1,12 @@
+module MailerUrlHelper
+  def absolutize_links(html)
+    return html if html.blank?
+
+    options = ActionMailer::Base.default_url_options
+    protocol = options[:protocol] || (Rails.env.production? ? 'https' : 'http')
+    host = options[:host]
+    return html if host.blank?
+
+    html.gsub(%r{href="/([^"]*)"}, %(href="#{protocol}://#{host}/\\1")).html_safe
+  end
+end

--- a/site/app/jobs/weekly_changelog_digest_job.rb
+++ b/site/app/jobs/weekly_changelog_digest_job.rb
@@ -1,0 +1,50 @@
+class WeeklyChangelogDigestJob < ApplicationJob
+  queue_as :default
+
+  MAILERS = {
+    'api_entreprise' => APIEntreprise::ChangelogMailer,
+    'api_particulier' => APIParticulier::ChangelogMailer
+  }.freeze
+
+  def perform(reference_date: Time.zone.today)
+    range = previous_iso_week_range(reference_date)
+
+    MAILERS.each_key do |scope|
+      enqueue_for_scope(scope, range)
+    end
+  end
+
+  private
+
+  def enqueue_for_scope(scope, range)
+    entries = entries_for(scope, range)
+    return if entries.empty?
+
+    payload = entries.map { |entry| entry_attributes(entry) }
+
+    ChangelogSubscription.active.for_scope(scope).find_each do |subscription|
+      MAILERS.fetch(scope).weekly(subscription.id, payload).deliver_later
+    end
+  end
+
+  def entries_for(scope, range)
+    ChangelogEntry.for(scope.to_sym).select { |entry| range.cover?(entry.date) }
+  end
+
+  def previous_iso_week_range(reference_date)
+    monday_this_week = reference_date.beginning_of_week(:monday)
+    monday_previous_week = monday_this_week - 7.days
+    sunday_previous_week = monday_this_week - 1.day
+
+    monday_previous_week..sunday_previous_week
+  end
+
+  def entry_attributes(entry)
+    {
+      date: entry.date,
+      scope: entry.scope,
+      title: entry.title,
+      description: entry.description
+    }
+  end
+end

--- a/site/app/mailers/api_entreprise/changelog_mailer.rb
+++ b/site/app/mailers/api_entreprise/changelog_mailer.rb
@@ -1,0 +1,14 @@
+class APIEntreprise::ChangelogMailer < APIEntrepriseMailer
+  before_action :attach_logos
+
+  helper :application
+  helper :mailer_url
+
+  def weekly(subscription_id, entry_attributes)
+    @subscription = ChangelogSubscription.find(subscription_id)
+    @user = @subscription.user
+    @entries = entry_attributes.map { |attrs| ChangelogEntry.new(**attrs.symbolize_keys) }
+
+    mail(to: @user.email, subject: t('api_entreprise.changelog_mailer.weekly.subject')) { |format| format.html }
+  end
+end

--- a/site/app/mailers/api_particulier/changelog_mailer.rb
+++ b/site/app/mailers/api_particulier/changelog_mailer.rb
@@ -1,0 +1,14 @@
+class APIParticulier::ChangelogMailer < APIParticulierMailer
+  before_action :attach_logos
+
+  helper :application
+  helper :mailer_url
+
+  def weekly(subscription_id, entry_attributes)
+    @subscription = ChangelogSubscription.find(subscription_id)
+    @user = @subscription.user
+    @entries = entry_attributes.map { |attrs| ChangelogEntry.new(**attrs.symbolize_keys) }
+
+    mail(to: @user.email, subject: t('api_particulier.changelog_mailer.weekly.subject')) { |format| format.html }
+  end
+end

--- a/site/app/models/changelog_subscription.rb
+++ b/site/app/models/changelog_subscription.rb
@@ -1,0 +1,43 @@
+class ChangelogSubscription < ApplicationRecord
+  SCOPES = %w[api_entreprise api_particulier].freeze
+
+  belongs_to :user
+
+  before_validation :ensure_unsubscribe_token, on: :create
+
+  validates :scope, presence: true, inclusion: { in: SCOPES }
+  validates :user_id, uniqueness: { scope: :scope, conditions: -> { active } }
+  validates :unsubscribe_token, presence: true, uniqueness: true
+
+  scope :active, -> { where(disabled_at: nil) }
+  scope :disabled, -> { where.not(disabled_at: nil) }
+  scope :for_scope, ->(scope) { where(scope: scope.to_s) }
+
+  def active?
+    disabled_at.nil?
+  end
+
+  def disable!
+    return if disabled_at.present?
+
+    update!(disabled_at: Time.current)
+  end
+
+  def covers?(entry_scope)
+    entry_scope == scope || entry_scope == 'both'
+  end
+
+  private
+
+  def ensure_unsubscribe_token
+    return if unsubscribe_token.present?
+
+    loop do
+      candidate = SecureRandom.urlsafe_base64(32)
+      next if self.class.exists?(unsubscribe_token: candidate)
+
+      self.unsubscribe_token = candidate
+      break
+    end
+  end
+end

--- a/site/app/models/user.rb
+++ b/site/app/models/user.rb
@@ -6,6 +6,8 @@ class User < ApplicationRecord
 
   has_many :tokens, through: :authorization_requests
 
+  has_many :changelog_subscriptions, dependent: :destroy
+
   belongs_to :editor,
     optional: true
 
@@ -42,6 +44,10 @@ class User < ApplicationRecord
 
   def confirmed?
     oauth_api_gouv_id.present?
+  end
+
+  def subscribed_to_changelog?(scope)
+    changelog_subscriptions.active.exists?(scope: scope.to_s)
   end
 
   def full_name

--- a/site/app/views/api_entreprise/authorization_request_mailer/_block_subscribed_newsletter.html.mjml
+++ b/site/app/views/api_entreprise/authorization_request_mailer/_block_subscribed_newsletter.html.mjml
@@ -5,13 +5,16 @@
         🔔 Lettres d'informations et notifications
       </h3>
       <p>
-        <b>Vous êtes par défaut abonné à nos lettres d'informations.</b>
-        <br />
-          Pour être informé des maintenances et des incidents de l'API Entreprise, abonnez-vous dès maintenant depuis
-          notre page d'état des API :
+        Pour être informé des maintenances et des incidents de l'API Entreprise, abonnez-vous depuis notre page d'état des API&nbsp;:
         <a target="_blank" href="https://status.entreprise.api.gouv.fr/">
           <b><u>status.entreprise.api.gouv.fr</u></b>
         </a>
+      </p>
+      <p>
+        Pour recevoir chaque lundi le récapitulatif des nouveautés techniques, inscrivez-vous à notre newsletter hebdomadaire automatique sur
+        <a target="_blank" href="<%= changelogs_url %>">
+          <b><u>la page des nouveautés</u></b>
+        </a>.
       </p>
     </mj-text>
   </mj-column>

--- a/site/app/views/api_entreprise/changelog_mailer/_block_unsubscribe_changelog.html.mjml
+++ b/site/app/views/api_entreprise/changelog_mailer/_block_unsubscribe_changelog.html.mjml
@@ -1,0 +1,12 @@
+<mj-section mj-class="section-block">
+  <mj-column>
+    <mj-text mj-class="secondary-link">
+      <p>
+        Vous recevez cet email car vous êtes inscrit à la newsletter hebdomadaire des nouveautés d'API Entreprise.
+        <a target="_blank" href="<%= changelog_unsubscribe_token_url(token: @subscription.unsubscribe_token) %>">
+          Se désinscrire
+        </a>
+      </p>
+    </mj-text>
+  </mj-column>
+</mj-section>

--- a/site/app/views/api_entreprise/changelog_mailer/weekly.html.mjml
+++ b/site/app/views/api_entreprise/changelog_mailer/weekly.html.mjml
@@ -1,0 +1,41 @@
+<%= render partial: "shared/api_entreprise/mailers/header" %>
+<mj-section mj-class="section-banner" background-color="#d5dbef">
+  <mj-column>
+    <mj-divider />
+    <mj-text>
+      <h1>
+        Les nouveautés de la semaine&nbsp;📰
+      </h1>
+    </mj-text>
+  </mj-column>
+</mj-section>
+<mj-section mj-class="section-main">
+  <mj-column>
+    <mj-text>
+      <p>Bonjour,</p>
+      <p>
+        Voici le récapitulatif des nouveautés publiées la semaine dernière sur API Entreprise&nbsp;:
+      </p>
+    </mj-text>
+  </mj-column>
+</mj-section>
+<% @entries.each do |entry| %>
+  <mj-section mj-class="section-block-gris-clair">
+    <mj-column>
+      <mj-text>
+        <h3><%= entry.title %></h3>
+        <p style="color: #666;"><i><%= l(entry.date, format: :long) %></i></p>
+        <%= absolutize_links(markdown_to_html(entry.description, hard_wrap: false)) %>
+      </mj-text>
+    </mj-column>
+  </mj-section>
+<% end %>
+<mj-section mj-class="section-block">
+  <mj-column>
+    <mj-button href="<%= changelogs_url %>">
+      Voir toutes les nouveautés
+    </mj-button>
+  </mj-column>
+</mj-section>
+<%= render partial: "block_unsubscribe_changelog" %>
+<%= render partial: "shared/api_entreprise/mailers/footer" %>

--- a/site/app/views/api_particulier/authorization_request_mailer/_block_subscribed_newsletter.html.mjml
+++ b/site/app/views/api_particulier/authorization_request_mailer/_block_subscribed_newsletter.html.mjml
@@ -5,13 +5,16 @@
         🔔 Lettres d'informations et notifications
       </h3>
       <p>
-        <b>Vous êtes par défaut abonné à nos lettres d'informations.</b>
-        <br />
-          Pour être informé des maintenances et des incidents de l'API Particulier, abonnez-vous dès maintenant depuis
-          notre page d'état des API :
+        Pour être informé des maintenances et des incidents de l'API Particulier, abonnez-vous depuis notre page d'état des API&nbsp;:
         <a target="_blank" href="https://status.particulier.api.gouv.fr/">
           <b><u>status.particulier.api.gouv.fr</u></b>
         </a>
+      </p>
+      <p>
+        Pour recevoir chaque lundi le récapitulatif des nouveautés techniques, inscrivez-vous à notre newsletter hebdomadaire automatique sur
+        <a target="_blank" href="<%= changelogs_url %>">
+          <b><u>la page des nouveautés</u></b>
+        </a>.
       </p>
     </mj-text>
   </mj-column>

--- a/site/app/views/api_particulier/changelog_mailer/_block_unsubscribe_changelog.html.mjml
+++ b/site/app/views/api_particulier/changelog_mailer/_block_unsubscribe_changelog.html.mjml
@@ -1,0 +1,12 @@
+<mj-section mj-class="section-block">
+  <mj-column>
+    <mj-text mj-class="secondary-link">
+      <p>
+        Vous recevez cet email car vous êtes inscrit à la newsletter hebdomadaire des nouveautés d'API Particulier.
+        <a target="_blank" href="<%= changelog_unsubscribe_token_url(token: @subscription.unsubscribe_token) %>">
+          Se désinscrire
+        </a>
+      </p>
+    </mj-text>
+  </mj-column>
+</mj-section>

--- a/site/app/views/api_particulier/changelog_mailer/weekly.html.mjml
+++ b/site/app/views/api_particulier/changelog_mailer/weekly.html.mjml
@@ -1,0 +1,41 @@
+<%= render partial: "shared/api_particulier/mailers/header" %>
+<mj-section mj-class="section-banner" background-color="#d5dbef">
+  <mj-column>
+    <mj-divider />
+    <mj-text>
+      <h1>
+        Les nouveautés de la semaine&nbsp;📰
+      </h1>
+    </mj-text>
+  </mj-column>
+</mj-section>
+<mj-section mj-class="section-main">
+  <mj-column>
+    <mj-text>
+      <p>Bonjour,</p>
+      <p>
+        Voici le récapitulatif des nouveautés publiées la semaine dernière sur API Particulier&nbsp;:
+      </p>
+    </mj-text>
+  </mj-column>
+</mj-section>
+<% @entries.each do |entry| %>
+  <mj-section mj-class="section-block-gris-clair">
+    <mj-column>
+      <mj-text>
+        <h3><%= entry.title %></h3>
+        <p style="color: #666;"><i><%= l(entry.date, format: :long) %></i></p>
+        <%= absolutize_links(markdown_to_html(entry.description, hard_wrap: false)) %>
+      </mj-text>
+    </mj-column>
+  </mj-section>
+<% end %>
+<mj-section mj-class="section-block">
+  <mj-column>
+    <mj-button href="<%= changelogs_url %>">
+      Voir toutes les nouveautés
+    </mj-button>
+  </mj-column>
+</mj-section>
+<%= render partial: "block_unsubscribe_changelog" %>
+<%= render partial: "shared/api_particulier/mailers/footer" %>

--- a/site/app/views/shared/changelogs/_subscription.html.erb
+++ b/site/app/views/shared/changelogs/_subscription.html.erb
@@ -1,0 +1,21 @@
+<div class="fr-callout fr-mb-6w">
+  <% if !user_signed_in? %>
+    <p class="fr-callout__text">
+      <%= t('.anonymous_html', login_url: login_path).html_safe %>
+    </p>
+  <% elsif current_user.subscribed_to_changelog?(namespace) %>
+    <h2 class="fr-callout__title fr-h4"><%= t('.subscribed.heading') %></h2>
+    <p class="fr-callout__text"><%= t('.subscribed.description') %></p>
+    <%= button_to t('.subscribed.submit'),
+                   changelog_unsubscribe_path,
+                   method: :delete,
+                   class: 'fr-btn fr-btn--secondary' %>
+  <% else %>
+    <h2 class="fr-callout__title fr-h4"><%= t('.subscribe.heading') %></h2>
+    <p class="fr-callout__text"><%= t('.subscribe.description').html_safe %></p>
+    <%= button_to t('.subscribe.submit'),
+                   changelog_subscribe_path,
+                   method: :post,
+                   class: 'fr-btn' %>
+  <% end %>
+</div>

--- a/site/app/views/shared/changelogs/index.html.erb
+++ b/site/app/views/shared/changelogs/index.html.erb
@@ -8,6 +8,8 @@
       <%= t('.description').html_safe %>
     </p>
 
+    <%= render 'shared/changelogs/subscription' %>
+
     <% if @entries_by_year.empty? %>
       <p><%= t('.empty') %></p>
     <% else %>

--- a/site/config/locales/fr.yml
+++ b/site/config/locales/fr.yml
@@ -41,6 +41,28 @@ fr:
         title: "Nouveautés"
         description: "L'historique des évolutions du service&nbsp;: nouvelles API, mises à jour de fiches, dépréciations et améliorations."
         empty: "Aucune nouveauté à afficher pour le moment."
+      subscription:
+        anonymous_html: "Vous pouvez recevoir les nouveautés par email&nbsp;: <a href=\"%{login_url}\">connectez-vous</a> pour vous inscrire à notre newsletter hebdomadaire automatique."
+        subscribe:
+          heading: "Recevoir les nouveautés par email"
+          description: "Inscrivez-vous à notre newsletter&nbsp;: un récapitulatif automatique des dernières nouveautés vous sera envoyé chaque lundi à 2h."
+          submit: "S'inscrire à la newsletter hebdomadaire"
+        subscribed:
+          heading: "Vous êtes inscrit à la newsletter"
+          description: "Vous recevez chaque lundi à 2h un récapitulatif automatique des nouveautés de la semaine précédente."
+          submit: "Se désinscrire"
+    changelog_subscriptions:
+      create:
+        success:
+          title: "Vous êtes inscrit à la newsletter des nouveautés."
+      destroy:
+        success:
+          title: "Vous êtes désinscrit de la newsletter des nouveautés."
+      destroy_via_token:
+        success:
+          title: "Vous êtes désinscrit de la newsletter des nouveautés."
+        error:
+          title: "Lien de désinscription invalide ou déjà utilisé."
     cas_usages:
       show:
         label: "Cas d'usage"

--- a/site/config/locales/mailers.fr.yml
+++ b/site/config/locales/mailers.fr.yml
@@ -50,6 +50,9 @@ fr:
         link_description: Un lien vers un jeton d'accès API Entreprise vient d'être généré à votre intention. Vous pouvez accéder à ce jeton via le lien
       banned:
         subject: 🔑⚠️ Votre token d'accès API Entreprise a été banni
+    changelog_mailer:
+      weekly:
+        subject: 📰 Les nouveautés API Entreprise de la semaine
 
   api_particulier:
     authorization_request_mailer:
@@ -101,6 +104,10 @@ fr:
         subject: Une nouvelle demande a été déposé pour API Particulier
       approve:
         subject: Une nouvelle demande a été validé pour API Particulier
+
+    changelog_mailer:
+      weekly:
+        subject: 📰 Les nouveautés API Particulier de la semaine
   shared:
     audit_mailer:
       notify:

--- a/site/config/routes/api_entreprise.rb
+++ b/site/config/routes/api_entreprise.rb
@@ -66,6 +66,9 @@ constraints(APIEntrepriseDomainConstraint.new) do
     get '/blog/:id', to: 'blog_posts#show', as: :blog_post
 
     get '/nouveautes', to: 'changelogs#index', as: :changelogs
+    post '/nouveautes/inscription', to: 'changelog_subscriptions#create', as: :changelog_subscribe
+    delete '/nouveautes/inscription', to: 'changelog_subscriptions#destroy', as: :changelog_unsubscribe
+    get '/nouveautes/desinscription/:token', to: 'changelog_subscriptions#destroy_via_token', as: :changelog_unsubscribe_token
 
     get '/apis/status', to: 'pages#current_status', as: :current_status
 

--- a/site/config/routes/api_particulier.rb
+++ b/site/config/routes/api_particulier.rb
@@ -73,6 +73,9 @@ constraints(APIParticulierDomainConstraint.new) do
     get '/blog/:id', to: 'blog_posts#show', as: :blog_post
 
     get '/nouveautes', to: 'changelogs#index', as: :changelogs
+    post '/nouveautes/inscription', to: 'changelog_subscriptions#create', as: :changelog_subscribe
+    delete '/nouveautes/inscription', to: 'changelog_subscriptions#destroy', as: :changelog_unsubscribe
+    get '/nouveautes/desinscription/:token', to: 'changelog_subscriptions#destroy_via_token', as: :changelog_unsubscribe_token
 
     get '/infolettre', to: 'pages#newsletter', as: :newsletter
     get '/mentions-legales', to: 'pages#mentions', as: :mentions

--- a/site/config/schedule.yml
+++ b/site/config/schedule.yml
@@ -2,6 +2,9 @@ development:
   token_expiration_notice:
     cron: '0 1 * * *'
     class: 'TokenExpirationNoticeJob'
+  weekly_changelog_digest:
+    cron: '0 2 * * 1'
+    class: 'WeeklyChangelogDigestJob'
 
 production: &deployed
   token_expiration_notice:
@@ -10,6 +13,9 @@ production: &deployed
   healthcheck:
     cron: '*/5 * * * *'
     class: 'HealthcheckJob'
+  weekly_changelog_digest:
+    cron: '0 2 * * 1'
+    class: 'WeeklyChangelogDigestJob'
 
 staging: *deployed
 sandbox: *deployed

--- a/site/db/migrate/20260505100000_create_changelog_subscriptions.rb
+++ b/site/db/migrate/20260505100000_create_changelog_subscriptions.rb
@@ -1,0 +1,18 @@
+class CreateChangelogSubscriptions < ActiveRecord::Migration[8.0]
+  def change
+    create_table :changelog_subscriptions, id: :uuid do |t|
+      t.uuid :user_id, null: false
+      t.string :scope, null: false
+      t.string :unsubscribe_token, null: false
+      t.datetime :disabled_at
+      t.timestamps
+    end
+
+    add_index :changelog_subscriptions, %i[user_id scope],
+      unique: true,
+      where: 'disabled_at IS NULL',
+      name: 'index_changelog_subscriptions_on_user_id_and_scope_active'
+    add_index :changelog_subscriptions, :unsubscribe_token, unique: true
+    add_foreign_key :changelog_subscriptions, :users, validate: false
+  end
+end

--- a/site/db/schema.rb
+++ b/site/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_18_100001) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_05_100000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"
@@ -70,6 +70,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_18_100001) do
     t.index ["scopes"], name: "index_authorization_requests_on_scopes", using: :gin
   end
 
+  create_table "changelog_subscriptions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "disabled_at"
+    t.string "scope", null: false
+    t.string "unsubscribe_token", null: false
+    t.datetime "updated_at", null: false
+    t.uuid "user_id", null: false
+    t.index ["unsubscribe_token"], name: "index_changelog_subscriptions_on_unsubscribe_token", unique: true
+    t.index ["user_id", "scope"], name: "index_changelog_subscriptions_on_user_id_and_scope_active", unique: true, where: "(disabled_at IS NULL)"
+  end
+
   create_table "editor_delegations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "authorization_request_id", null: false
     t.datetime "created_at", null: false
@@ -85,7 +96,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_18_100001) do
     t.uuid "editor_id", null: false
     t.integer "exp", null: false
     t.integer "iat"
+    t.jsonb "scopes", default: [], null: false
     t.datetime "updated_at", null: false
+    t.index ["scopes"], name: "index_editor_tokens_on_scopes", using: :gin
   end
 
   create_table "editors", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -208,6 +221,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_18_100001) do
     t.string "scopes", default: "", null: false
     t.string "state"
     t.string "token", null: false
+    t.jsonb "token_ids", default: [], null: false
     t.index ["application_id"], name: "index_oauth_access_grants_on_application_id"
     t.index ["resource_owner_id"], name: "index_oauth_access_grants_on_resource_owner_id"
     t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
@@ -223,6 +237,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_18_100001) do
     t.datetime "revoked_at"
     t.string "scopes"
     t.string "token", null: false
+    t.jsonb "token_ids", default: [], null: false
     t.index ["application_id"], name: "index_oauth_access_tokens_on_application_id"
     t.index ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true
     t.index ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id"
@@ -232,14 +247,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_18_100001) do
   create_table "oauth_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.boolean "confidential", default: true, null: false
     t.datetime "created_at", null: false
-    t.uuid "editor_id"
     t.string "name", null: false
     t.text "redirect_uri", null: false
     t.string "scopes", default: "", null: false
     t.string "secret", null: false
     t.string "uid", null: false
     t.datetime "updated_at", null: false
-    t.index ["editor_id"], name: "index_oauth_applications_on_editor_id"
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end
 
@@ -312,9 +325,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_18_100001) do
   end
 
   add_foreign_key "authorization_request_security_settings", "authorization_requests"
+  add_foreign_key "changelog_subscriptions", "users", validate: false
   add_foreign_key "editor_delegations", "authorization_requests"
   add_foreign_key "editor_delegations", "editors"
-  add_foreign_key "editor_tokens", "editors"
   add_foreign_key "magic_links", "tokens"
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_grants", "users", column: "resource_owner_id"

--- a/site/spec/factories/changelog_subscriptions.rb
+++ b/site/spec/factories/changelog_subscriptions.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :changelog_subscription do
+    user
+    scope { 'api_entreprise' }
+
+    trait :api_particulier do
+      scope { 'api_particulier' }
+    end
+  end
+end

--- a/site/spec/features/api_entreprise/changelog_subscriptions_spec.rb
+++ b/site/spec/features/api_entreprise/changelog_subscriptions_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../../support/shared_examples/features/changelog_subscriptions'
+
+RSpec.describe 'Changelog subscriptions', app: :api_entreprise do
+  it_behaves_like 'a changelog subscription feature', :api_entreprise
+end

--- a/site/spec/features/api_particulier/changelog_subscriptions_spec.rb
+++ b/site/spec/features/api_particulier/changelog_subscriptions_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../../support/shared_examples/features/changelog_subscriptions'
+
+RSpec.describe 'Changelog subscriptions', app: :api_particulier do
+  it_behaves_like 'a changelog subscription feature', :api_particulier
+end

--- a/site/spec/jobs/weekly_changelog_digest_job_spec.rb
+++ b/site/spec/jobs/weekly_changelog_digest_job_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.describe WeeklyChangelogDigestJob do
+  include ActiveJob::TestHelper
+
+  let(:reference_date) { Date.new(2026, 5, 11) }
+  let(:previous_monday) { Date.new(2026, 5, 4) }
+  let(:previous_sunday) { Date.new(2026, 5, 10) }
+
+  before { clear_enqueued_jobs }
+
+  def stub_entries(entries)
+    allow(ChangelogEntry).to receive(:for).with(:api_entreprise).and_return(entries[:api_entreprise] || [])
+    allow(ChangelogEntry).to receive(:for).with(:api_particulier).and_return(entries[:api_particulier] || [])
+  end
+
+  context 'with no subscriptions' do
+    it 'does not enqueue any mailer' do
+      stub_entries(api_entreprise: [build_entry('api_entreprise', previous_monday)])
+
+      expect {
+        described_class.perform_now(reference_date:)
+      }.not_to change(enqueued_jobs, :size)
+    end
+  end
+
+  context 'with subscribers and entries within the previous ISO week' do
+    let!(:entreprise_subscription) { create(:changelog_subscription, scope: 'api_entreprise') }
+    let!(:particulier_subscription) { create(:changelog_subscription, :api_particulier) }
+
+    it 'enqueues a weekly mail per subscriber per scope' do
+      stub_entries(
+        api_entreprise: [build_entry('api_entreprise', previous_monday)],
+        api_particulier: [build_entry('api_particulier', previous_sunday)]
+      )
+
+      expect {
+        described_class.perform_now(reference_date:)
+      }.to change(enqueued_jobs, :size).by(2)
+    end
+
+    it 'skips a scope when no entry was published' do
+      stub_entries(
+        api_entreprise: [build_entry('api_entreprise', previous_monday)],
+        api_particulier: []
+      )
+
+      expect {
+        described_class.perform_now(reference_date:)
+      }.to change(enqueued_jobs, :size).by(1)
+    end
+
+    it 'skips disabled subscriptions' do
+      entreprise_subscription.disable!
+      particulier_subscription.disable!
+      stub_entries(
+        api_entreprise: [build_entry('api_entreprise', previous_monday)],
+        api_particulier: [build_entry('api_particulier', previous_sunday)]
+      )
+
+      expect {
+        described_class.perform_now(reference_date:)
+      }.not_to change(enqueued_jobs, :size)
+    end
+
+    it 'ignores entries outside the previous ISO week' do
+      stub_entries(
+        api_entreprise: [build_entry('api_entreprise', reference_date)],
+        api_particulier: [build_entry('api_particulier', previous_monday - 1.day)]
+      )
+
+      expect {
+        described_class.perform_now(reference_date:)
+      }.not_to change(enqueued_jobs, :size)
+    end
+  end
+
+  def build_entry(scope, date)
+    ChangelogEntry.new(date:, scope:, title: "Entry #{date}", description: 'desc')
+  end
+end

--- a/site/spec/mailers/api_entreprise/changelog_mailer_spec.rb
+++ b/site/spec/mailers/api_entreprise/changelog_mailer_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe APIEntreprise::ChangelogMailer do
+  describe '#weekly' do
+    subject(:mail) { described_class.weekly(subscription.id, entries) }
+
+    let(:subscription) { create(:changelog_subscription, scope: 'api_entreprise') }
+    let(:entries) do
+      [
+        { date: Date.new(2026, 5, 5), scope: 'api_entreprise', title: 'Nouvelle fiche', description: 'Lorem' }
+      ]
+    end
+
+    it 'is sent to the subscriber' do
+      expect(mail.to).to eq([subscription.user.email])
+    end
+
+    it 'has the localized subject' do
+      expect(mail.subject).to eq(I18n.t('api_entreprise.changelog_mailer.weekly.subject'))
+    end
+
+    it 'renders the entries' do
+      expect(mail.body.encoded).to include('Nouvelle fiche')
+    end
+
+    it 'includes the unsubscribe token link' do
+      expect(mail.html_part.body.decoded).to include(subscription.unsubscribe_token)
+    end
+  end
+end

--- a/site/spec/mailers/api_particulier/changelog_mailer_spec.rb
+++ b/site/spec/mailers/api_particulier/changelog_mailer_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe APIParticulier::ChangelogMailer do
+  describe '#weekly' do
+    subject(:mail) { described_class.weekly(subscription.id, entries) }
+
+    let(:subscription) { create(:changelog_subscription, :api_particulier) }
+    let(:entries) do
+      [
+        { date: Date.new(2026, 5, 5), scope: 'api_particulier', title: 'Nouvelle fiche', description: 'Lorem' }
+      ]
+    end
+
+    it 'is sent to the subscriber' do
+      expect(mail.to).to eq([subscription.user.email])
+    end
+
+    it 'has the localized subject' do
+      expect(mail.subject).to eq(I18n.t('api_particulier.changelog_mailer.weekly.subject'))
+    end
+
+    it 'renders the entries' do
+      expect(mail.body.encoded).to include('Nouvelle fiche')
+    end
+
+    it 'includes the unsubscribe token link' do
+      expect(mail.html_part.body.decoded).to include(subscription.unsubscribe_token)
+    end
+  end
+end

--- a/site/spec/mailers/previews/api_entreprise/changelog_mailer_preview.rb
+++ b/site/spec/mailers/previews/api_entreprise/changelog_mailer_preview.rb
@@ -1,0 +1,28 @@
+class APIEntreprise::ChangelogMailerPreview < ActionMailer::Preview
+  def weekly
+    APIEntreprise::ChangelogMailer.weekly(subscription.id, entry_attributes)
+  end
+
+  private
+
+  def subscription
+    ChangelogSubscription.for_scope('api_entreprise').first ||
+      ChangelogSubscription.create!(user: User.first, scope: 'api_entreprise')
+  end
+
+  def entry_attributes
+    entries = ChangelogEntry.for(:api_entreprise).first(3)
+    entries = [fallback_entry] if entries.empty?
+
+    entries.map { |entry| { date: entry.date, scope: entry.scope, title: entry.title, description: entry.description } }
+  end
+
+  def fallback_entry
+    ChangelogEntry.new(
+      date: Date.current,
+      scope: 'api_entreprise',
+      title: 'Exemple de nouveauté',
+      description: 'Description **markdown** de la nouveauté.'
+    )
+  end
+end

--- a/site/spec/mailers/previews/api_particulier/changelog_mailer_preview.rb
+++ b/site/spec/mailers/previews/api_particulier/changelog_mailer_preview.rb
@@ -1,0 +1,28 @@
+class APIParticulier::ChangelogMailerPreview < ActionMailer::Preview
+  def weekly
+    APIParticulier::ChangelogMailer.weekly(subscription.id, entry_attributes)
+  end
+
+  private
+
+  def subscription
+    ChangelogSubscription.for_scope('api_particulier').first ||
+      ChangelogSubscription.create!(user: User.first, scope: 'api_particulier')
+  end
+
+  def entry_attributes
+    entries = ChangelogEntry.for(:api_particulier).first(3)
+    entries = [fallback_entry] if entries.empty?
+
+    entries.map { |entry| { date: entry.date, scope: entry.scope, title: entry.title, description: entry.description } }
+  end
+
+  def fallback_entry
+    ChangelogEntry.new(
+      date: Date.current,
+      scope: 'api_particulier',
+      title: 'Exemple de nouveauté',
+      description: 'Description **markdown** de la nouveauté.'
+    )
+  end
+end

--- a/site/spec/models/changelog_subscription_spec.rb
+++ b/site/spec/models/changelog_subscription_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+RSpec.describe ChangelogSubscription do
+  describe 'factory' do
+    it 'is valid' do
+      expect(build(:changelog_subscription)).to be_valid
+    end
+  end
+
+  describe 'validations' do
+    it 'requires a known scope' do
+      subscription = build(:changelog_subscription, scope: 'foo')
+
+      expect(subscription).not_to be_valid
+      expect(subscription.errors[:scope]).to be_present
+    end
+
+    it 'requires uniqueness on user/scope pair' do
+      existing = create(:changelog_subscription)
+      duplicate = build(:changelog_subscription, user: existing.user, scope: existing.scope)
+
+      expect(duplicate).not_to be_valid
+    end
+
+    it 'allows the same user to subscribe to both scopes' do
+      user = create(:user)
+      create(:changelog_subscription, user:, scope: 'api_entreprise')
+      other = build(:changelog_subscription, user:, scope: 'api_particulier')
+
+      expect(other).to be_valid
+    end
+
+    it 'allows resubscribing once a previous subscription is disabled' do
+      previous = create(:changelog_subscription)
+      previous.disable!
+      other = build(:changelog_subscription, user: previous.user, scope: previous.scope)
+
+      expect(other).to be_valid
+    end
+  end
+
+  describe '#disable!' do
+    it 'sets disabled_at and keeps the row' do
+      subscription = create(:changelog_subscription)
+
+      expect { subscription.disable! }.to change(subscription, :disabled_at).from(nil)
+      expect(described_class.exists?(subscription.id)).to be true
+    end
+
+    it 'is idempotent' do
+      subscription = create(:changelog_subscription, disabled_at: 1.day.ago)
+      original = subscription.disabled_at
+
+      subscription.disable!
+
+      expect(subscription.reload.disabled_at).to be_within(1.second).of(original)
+    end
+  end
+
+  describe 'unsubscribe_token' do
+    it 'is generated automatically on create' do
+      subscription = create(:changelog_subscription)
+
+      expect(subscription.unsubscribe_token).to be_present
+    end
+
+    it 'is unique across subscriptions' do
+      first = create(:changelog_subscription)
+      second = create(:changelog_subscription, user: create(:user))
+
+      expect(first.unsubscribe_token).not_to eq(second.unsubscribe_token)
+    end
+  end
+
+  describe '#covers?' do
+    let(:subscription) { build(:changelog_subscription, scope: 'api_entreprise') }
+
+    it { expect(subscription.covers?('api_entreprise')).to be true }
+    it { expect(subscription.covers?('both')).to be true }
+    it { expect(subscription.covers?('api_particulier')).to be false }
+  end
+end

--- a/site/spec/support/shared_examples/features/changelog_subscriptions.rb
+++ b/site/spec/support/shared_examples/features/changelog_subscriptions.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'a changelog subscription feature' do |scope|
+  describe 'subscription block on /nouveautes' do
+    let(:user) { create(:user) }
+
+    context 'when anonymous' do
+      it 'shows the login invitation' do
+        visit changelogs_path
+
+        expect(page).to have_link(href: login_path)
+      end
+    end
+
+    context 'when signed in and not subscribed' do
+      before { login_as(user) }
+
+      it 'shows the subscribe button' do
+        visit changelogs_path
+
+        expect(page).to have_button(I18n.t('shared.changelogs.subscription.subscribe.submit'))
+      end
+
+      it 'subscribes the user' do
+        visit changelogs_path
+        click_button I18n.t('shared.changelogs.subscription.subscribe.submit')
+
+        expect(user.reload.subscribed_to_changelog?(scope)).to be true
+      end
+    end
+
+    context 'when signed in and already subscribed' do
+      before do
+        create(:changelog_subscription, user:, scope: scope.to_s)
+        login_as(user)
+      end
+
+      it 'shows the unsubscribe button' do
+        visit changelogs_path
+
+        expect(page).to have_button(I18n.t('shared.changelogs.subscription.subscribed.submit'))
+      end
+
+      it 'unsubscribes the user' do
+        visit changelogs_path
+        click_button I18n.t('shared.changelogs.subscription.subscribed.submit')
+
+        expect(user.reload.subscribed_to_changelog?(scope)).to be false
+      end
+    end
+  end
+
+  describe 'token-based unsubscription' do
+    let(:subscription) { create(:changelog_subscription, scope: scope.to_s) }
+
+    it 'disables the subscription via token' do
+      visit changelog_unsubscribe_token_path(token: subscription.unsubscribe_token)
+
+      expect(subscription.reload.active?).to be false
+    end
+
+    it 'shows an error for an invalid token' do
+      visit changelog_unsubscribe_token_path(token: 'unknown')
+
+      expect(page).to have_current_path(changelogs_path)
+    end
+  end
+end


### PR DESCRIPTION
Les utilisateurs n'avaient aucun moyen d'être notifiés des évolutions techniques d'API Entreprise / API Particulier — il fallait revenir consulter `/nouveautes` à la main. 

Cette PR ajoute une newsletter opt-in, envoyée chaque lundi à 2h, qui résume automatiquement les entrées du changelog publiées la semaine ISO précédente. 

L'inscription se fait depuis la page `/nouveautes` (connexion requise), la désinscription depuis la page ou via un lien token persistant inclus dans chaque email. 

Les emails de validation d'habilitation mentionnent désormais cette newsletter.