### PR TITLE
Release api_particulier 0.1.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,13 @@ avec les conventions spécifiques :
 ## Conventions transverses
 
 - Messages de commit rédigés en anglais.
+- **Toute itération sur une signature d'API publique** (nouveau endpoint,
+  nouvelle version, paramètre ajouté/supprimé/renommé/rendu optionnel,
+  changement de format de réponse, dépréciation) doit s'accompagner d'une
+  itération sur les clients officiels dans `clients/` — au minimum
+  régénération du scaffolding (`clients/ruby/bin/scaffold_resources`) et
+  release SemVer-correcte (cf. skill `release-new-version`). Un changement
+  serveur sans mise à jour client = SDK qui ment à ses utilisateurs.
 
 ## Outils partagés
 

--- a/clients/.agents/skills
+++ b/clients/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/clients/.claude/skills/release-new-version/SKILL.md
+++ b/clients/.claude/skills/release-new-version/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: release-new-version
+description: Release a new version of an official API Entreprise / API Particulier SDK to its package registry (rubygems for Ruby). Covers version bump, CHANGELOG update, release PR, tag conventions, and the OIDC-published workflow. Use when the user mentions "release", "publier", "publish sdk", "bump version sdk", "nouvelle version sdk", "rubygems", or asks to ship a new version of `api_entreprise` / `api_particulier` (Ruby today, more languages to come).
+---
+
+# Release a new SDK version
+
+Source of truth for Ruby : [`clients/ruby/README.md`](../../../ruby/README.md)
+§"Publier une version sur rubygems.org". Read it before deviating.
+
+## Scope
+
+One gem at a time. `api_entreprise` and `api_particulier` versionnent
+indépendamment — ne jamais coupler les deux dans une même release.
+
+## Workflow (Ruby)
+
+1. **Branche release dédiée**
+   ```sh
+   git checkout -b release/api-<entreprise|particulier>-<X.Y.Z>
+   ```
+
+2. **Bump** `clients/ruby/<gem>/lib/<gem>/version.rb`. SemVer :
+   - patch : régénération scaffolding, changement OpenAPI rétro-compatible
+     (paramètre devient optionnel, nouveau champ de réponse).
+   - minor : nouvel endpoint, nouvelle méthode publique.
+   - major : breaking change (paramètre requis ajouté, méthode supprimée,
+     renommage).
+
+3. **CHANGELOG** `clients/ruby/<gem>/CHANGELOG.md` — format Keep a Changelog :
+   - Convertir `[Unreleased]` en `[X.Y.Z] - YYYY-MM-DD` quand la section
+     contient le contenu releasé, sinon ajouter une nouvelle section
+     `[X.Y.Z]` au-dessus de `[Unreleased]` (qui reste vide).
+   - Sections : `Added` / `Changed` / `Deprecated` / `Removed` / `Fixed` /
+     `Security`. Référencer le SHA upstream qui motive la release.
+
+4. **Tests locaux**
+   ```sh
+   cd clients/ruby/<gem> && bundle exec rspec
+   ```
+   Le `Gemfile.lock` est modifié par le bundle (`<gem> (X.Y.Z)`) — l'inclure
+   dans le commit.
+
+5. **Commit unique**
+   ```sh
+   git commit -m "Release <gem> X.Y.Z"
+   ```
+   Message détaillé sur le pourquoi (changement upstream, breaking, etc.).
+
+6. **PR vers `develop`** — review obligatoire, squash-merge.
+
+7. **Tag le commit de merge sur `develop`** (pas la branche release jetable —
+   sinon le tag pointe sur un commit orphelin) :
+   ```sh
+   git checkout develop && git pull
+   git tag ruby-api-<entreprise|particulier>-v<X.Y.Z>
+   git push origin ruby-api-<entreprise|particulier>-v<X.Y.Z>
+   ```
+
+8. **Workflow** `.github/workflows/clients-ruby.yml` se déclenche sur le tag :
+   - vérifie `tag_version == gemspec.version` ;
+   - relance rspec ;
+   - publie via `rubygems/release-gem@v1` (OIDC trusted publisher, environment
+     `rubygems`).
+
+   Surveiller la run, vérifier la version sur rubygems.org après succès.
+
+## Tags reconnus
+
+| Tag | Gem publié |
+|---|---|
+| `ruby-api-entreprise-v<X.Y.Z>` | `api_entreprise` |
+| `ruby-api-particulier-v<X.Y.Z>` | `api_particulier` |
+
+Tag invalide → step "Resolve gem from tag" échoue et stoppe le workflow.
+
+## Gotchas
+
+- Tag mal placé (sur la branche release jetable non mergée) : le commit n'est
+  atteignable depuis aucune branche permanente. Toujours tagger après merge,
+  sur `develop`.
+- Version dans `version.rb` ≠ tag : le job release échoue à
+  "Verify tag version matches gemspec version".
+- Ne jamais committer `Gemfile.lock` sans avoir bumpé `version.rb` avant —
+  divergence silencieuse.
+- Le `CHANGELOG.md` initial des gems publiait le contenu sous `[Unreleased]`
+  alors que `0.1.0` était déjà sur rubygems. Au premier patch, convertir
+  `[Unreleased]` → `[0.1.0]` puis ajouter `[0.1.1]` au-dessus.
+
+## Étendre ce skill
+
+Quand un nouveau langage rejoint `clients/` (Node, Python, PHP, Java) :
+ajouter une section `## Workflow (<langage>)` ici avec :
+- chemin du fichier de version (`package.json`, `pyproject.toml`, etc.) ;
+- format du tag attendu par le workflow CI correspondant ;
+- registry cible (npm, PyPI, Packagist, Maven Central) ;
+- éventuelles spécificités auth (OIDC, token secret, etc.).
+
+Mettre à jour le `description` frontmatter pour citer le nouveau langage et
+ses triggers.

--- a/clients/CLAUDE.md
+++ b/clients/CLAUDE.md
@@ -1,0 +1,30 @@
+# CLAUDE.md - Clients SDK
+
+Spec normative : [`SPECS.md`](SPECS.md). Implémentation de référence :
+[`ruby/`](ruby/) (les autres langages doivent s'y aligner).
+
+Lecture obligatoire selon la tâche :
+
+- Modifier la spec partagée → `SPECS.md`.
+- Toucher un client Ruby (resources, auth, errors, examples, gemspec) →
+  [`ruby/README.md`](ruby/README.md).
+- Synchroniser le swagger vendorisé → `ruby/bin/sync_commons`.
+- Régénérer les resources scaffoldées → `ruby/bin/scaffold_resources`.
+
+## Releaser un SDK
+
+Skill dédié : `release-new-version`
+([`/.claude/skills/release-new-version/SKILL.md`](.claude/skills/release-new-version/SKILL.md)).
+Couvre bump version, CHANGELOG, PR vers develop, tag sur le commit de
+merge, workflow CI.
+
+**Itérer sur le skill** dès que le flow de release évolue (nouveau langage,
+nouveau registry, changement de convention de tag, garde-fou ajouté au
+workflow). Le skill est la source d'instruction pour les futures releases —
+le laisser dériver = futures releases cassées.
+
+## Conventions
+
+- Messages de commit en anglais (cf. `CLAUDE.md` racine).
+- Une release = un gem = un tag. Ne jamais coupler `api_entreprise` et
+  `api_particulier` dans la même release.

--- a/clients/ruby/api_particulier/CHANGELOG.md
+++ b/clients/ruby/api_particulier/CHANGELOG.md
@@ -6,6 +6,15 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-05-05
+
+### Changed
+- CNAF DSS (`dss.*_identite`) : `code_cog_insee_pays_naissance` is now
+  optional, mirroring the upstream OpenAPI change that made the lieu de
+  naissance attributes facultatifs.
+
+## [0.1.0]
+
 ### Added
 - Initial release — conforms to `clients/SPECS.md` §1–§20.
 - `production` / `staging` environments with `base_url` override.

--- a/clients/ruby/api_particulier/Gemfile.lock
+++ b/clients/ruby/api_particulier/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    api_particulier (0.1.0)
+    api_particulier (0.1.1)
       faraday (~> 2.0)
       faraday-retry (~> 2.0)
 
@@ -60,7 +60,7 @@ DEPENDENCIES
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
-  api_particulier (0.1.0)
+  api_particulier (0.1.1)
   bigdecimal (4.1.1) sha256=1c09efab961da45203c8316b0cdaec0ff391dfadb952dd459584b63ebf8054ca
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962

--- a/clients/ruby/api_particulier/lib/api_particulier/version.rb
+++ b/clients/ruby/api_particulier/lib/api_particulier/version.rb
@@ -1,3 +1,3 @@
 module ApiParticulier
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.1.1'.freeze
 end


### PR DESCRIPTION
- Bump `api_particulier` Ruby SDK to 0.1.1.
- Publish the regenerated DSS resources from 84583ab62: `code_cog_insee_pays_naissance` is now optional on every `dss.*_identite` method (mirrors the upstream OpenAPI change making lieu de naissance facultatif côté CNAF).
- Backwards-compatible.

## Release flow
After squash-merge:

```
git tag ruby-api-particulier-v0.1.1 <merge-sha-on-develop>
git push origin ruby-api-particulier-v0.1.1
```

→ `clients-ruby.yml` build + push rubygems via OIDC.