### PR TITLE
Wire bundler/gem_tasks for rake release in Ruby SDKs

### DIFF
--- a/clients/ruby/api_entreprise/Gemfile
+++ b/clients/ruby/api_entreprise/Gemfile
@@ -2,6 +2,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :development do
+  gem 'rake', '~> 13.0'
+end
+
 group :test do
   gem 'rspec', '~> 3.12'
   gem 'webmock', '~> 3.19'

--- a/clients/ruby/api_entreprise/Gemfile.lock
+++ b/clients/ruby/api_entreprise/Gemfile.lock
@@ -29,6 +29,7 @@ GEM
     net-http (0.9.1)
       uri (>= 0.11.1)
     public_suffix (7.0.5)
+    rake (13.4.2)
     rexml (3.4.4)
     rspec (3.13.2)
       rspec-core (~> 3.13.0)
@@ -55,6 +56,7 @@ PLATFORMS
 
 DEPENDENCIES
   api_entreprise!
+  rake (~> 13.0)
   rspec (~> 3.12)
   webmock (~> 3.19)
 
@@ -72,6 +74,7 @@ CHECKSUMS
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
   rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587
   rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d

--- a/clients/ruby/api_entreprise/Rakefile
+++ b/clients/ruby/api_entreprise/Rakefile
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'

--- a/clients/ruby/api_particulier/Gemfile
+++ b/clients/ruby/api_particulier/Gemfile
@@ -2,6 +2,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :development do
+  gem 'rake', '~> 13.0'
+end
+
 group :test do
   gem 'rspec', '~> 3.12'
   gem 'webmock', '~> 3.19'

--- a/clients/ruby/api_particulier/Gemfile.lock
+++ b/clients/ruby/api_particulier/Gemfile.lock
@@ -29,6 +29,7 @@ GEM
     net-http (0.9.1)
       uri (>= 0.11.1)
     public_suffix (7.0.5)
+    rake (13.4.2)
     rexml (3.4.4)
     rspec (3.13.2)
       rspec-core (~> 3.13.0)
@@ -55,6 +56,7 @@ PLATFORMS
 
 DEPENDENCIES
   api_particulier!
+  rake (~> 13.0)
   rspec (~> 3.12)
   webmock (~> 3.19)
 
@@ -72,6 +74,7 @@ CHECKSUMS
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
   rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587
   rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d

--- a/clients/ruby/api_particulier/Rakefile
+++ b/clients/ruby/api_particulier/Rakefile
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'


### PR DESCRIPTION
## Summary
- The `rubygems/release-gem@v1` action publishes via `bundle exec rake release`. Both gems shipped without a `Rakefile` or `rake` dep → the action fails with `can't find executable rake for gem rake` (cf. failed run on tag `ruby-api-particulier-v0.1.1`).
- Adds the bundler boilerplate to both `api_entreprise` and `api_particulier`: `Rakefile` requiring `bundler/gem_tasks` + `rake ~> 13.0` in the `:development` group.
- Fixes both gems in one shot to avoid the same trap when releasing `api_entreprise` later.

## Follow-up after merge
Move the existing tag onto the merge commit and re-trigger the release workflow.