### PR TITLE
Skip release:source_control_push in CI for Ruby SDKs

### DIFF
--- a/clients/ruby/api_entreprise/Rakefile
+++ b/clients/ruby/api_entreprise/Rakefile
@@ -1,3 +1,10 @@
 # frozen_string_literal: true
 
 require 'bundler/gem_tasks'
+
+if ENV['CI']
+  Rake::Task['release:source_control_push'].clear
+  task 'release:source_control_push' do
+    puts 'Skipping release:source_control_push (CI: tag is the workflow trigger, already on origin).'
+  end
+end

--- a/clients/ruby/api_particulier/Rakefile
+++ b/clients/ruby/api_particulier/Rakefile
@@ -1,3 +1,10 @@
 # frozen_string_literal: true
 
 require 'bundler/gem_tasks'
+
+if ENV['CI']
+  Rake::Task['release:source_control_push'].clear
+  task 'release:source_control_push' do
+    puts 'Skipping release:source_control_push (CI: tag is the workflow trigger, already on origin).'
+  end
+end


### PR DESCRIPTION
## Summary
Follow-up to #98. The release run now reaches `bundle exec rake release` but explodes on `release:source_control_push`: the action checks out the tag (detached HEAD) and bundler tries `git push origin refs/heads/HEAD` → `src refspec does not match any`.

The `rubygems/release-gem@v1` action hardcodes `bundle exec rake release` and offers no command override, so the fix lives in the Rakefile: when `CI=true`, no-op `release:source_control_push` since the tag is the workflow trigger and already on origin. Locally, behaviour is unchanged.

## Follow-up after merge
Move tag again:
```
git tag -f ruby-api-particulier-v0.1.1 <new-merge-sha>
git push --force origin ruby-api-particulier-v0.1.1
```

## Test plan
- [x] `CI=true bundle exec rake release:source_control_push` prints the skip message and exits clean
- [x] `bundle exec rake -T` still lists `release` (locally, behaviour unchanged)
- [ ] Workflow `release` job goes past the rake step and publishes 0.1.1 to rubygems.org