### PR TITLE
Remove mocks/** trigger from API CI/CD pipeline

### DIFF
--- a/.github/workflows/_api-deploy.yml
+++ b/.github/workflows/_api-deploy.yml
@@ -1,0 +1,76 @@
+name: "API: Deploy (reusable)"
+
+on:
+  workflow_call:
+    inputs:
+      skip_production:
+        description: "Skip production deploy (mocks-only changes still merge to main and deploy staging)"
+        type: boolean
+        default: false
+
+jobs:
+  merge-with-main:
+    name: Merge develop with main
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/develop'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Force push develop to main
+        run: git push --force origin develop:main
+
+  staging:
+    name: Continuous deployment on staging
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/develop'
+    timeout-minutes: 10
+    needs:
+      - merge-with-main
+    strategy:
+      matrix:
+        host: [watchdoge3, watchdoge4]
+      fail-fast: false
+    environment: staging
+    env:
+      DEPLOY_HTTPS_LOGIN: ${{ secrets.DEPLOY_HTTPS_LOGIN }}
+      DEPLOY_HTTPS_PASSWORD: ${{ secrets.DEPLOY_HTTPS_PASSWORD }}
+      DEPLOY_HTTPS_REQUEST_URL: ${{ vars.DEPLOY_HTTPS_REQUEST_URL }}
+      DEPLOY_HTTPS_RESPONSE_URL: ${{ vars.DEPLOY_HTTPS_RESPONSE_URL }}
+      DEPLOY_HOST: host_${{ matrix.host }}
+      DEPLOY_APP: siadelibre_staging
+    steps:
+      - name: Download and run deploy script
+        shell: bash
+        run: |
+          git clone https://github.com/etalab/api-entreprise-integration
+          cd api-entreprise-integration
+          ./deploy-parteprise.sh
+
+  production:
+    name: Continuous deployment on production
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/develop' && !inputs.skip_production
+    timeout-minutes: 20
+    needs:
+      - merge-with-main
+      - staging
+    strategy:
+      matrix:
+        host: [watchdoge3, watchdoge4]
+      fail-fast: false
+    environment: production
+    env:
+      DEPLOY_HTTPS_LOGIN: ${{ secrets.DEPLOY_HTTPS_LOGIN }}
+      DEPLOY_HTTPS_PASSWORD: ${{ secrets.DEPLOY_HTTPS_PASSWORD }}
+      DEPLOY_HTTPS_REQUEST_URL: ${{ vars.DEPLOY_HTTPS_REQUEST_URL }}
+      DEPLOY_HTTPS_RESPONSE_URL: ${{ vars.DEPLOY_HTTPS_RESPONSE_URL }}
+      DEPLOY_HOST: host_${{ matrix.host }}
+      DEPLOY_APP: siadelibre_production
+    steps:
+      - name: Download and run deploy script
+        shell: bash
+        run: |
+          git clone https://github.com/etalab/api-entreprise-integration
+          cd api-entreprise-integration
+          ./deploy-parteprise.sh

--- a/.github/workflows/api-ci_cd.yml
+++ b/.github/workflows/api-ci_cd.yml
@@ -175,9 +175,8 @@ jobs:
           minimum_suite_coverage: 95
           coverage_path: siade/coverage/.last_run.json
 
-  merge-with-main:
-    name: Merge develop with main
-    runs-on: ubuntu-latest
+  deploy:
+    name: Deploy
     if: github.ref == 'refs/heads/develop'
     needs:
       - security
@@ -185,78 +184,5 @@ jobs:
       - check-swagger
       - check-zeitwerk
       - tests
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Force push develop to main
-        working-directory: .
-        run: |
-          git push --force origin develop:main
-
-  continuous-deployment-staging:
-    name: Continuous deployment on staging
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/develop'
-    timeout-minutes: 10
-    needs:
-      - security
-      - lint
-      - check-swagger
-      - check-zeitwerk
-      - tests
-      - merge-with-main
-    strategy:
-      matrix:
-        host: [watchdoge3, watchdoge4]
-      fail-fast: false
-    environment: staging
-    env:
-      DEPLOY_HTTPS_LOGIN: ${{ secrets.DEPLOY_HTTPS_LOGIN }}
-      DEPLOY_HTTPS_PASSWORD: ${{ secrets.DEPLOY_HTTPS_PASSWORD }}
-      DEPLOY_HTTPS_REQUEST_URL: ${{ vars.DEPLOY_HTTPS_REQUEST_URL }}
-      DEPLOY_HTTPS_RESPONSE_URL: ${{ vars.DEPLOY_HTTPS_RESPONSE_URL }}
-      DEPLOY_HOST: host_${{ matrix.host }}
-      DEPLOY_APP: siadelibre_staging
-    steps:
-      - name: Download and run deploy script
-        shell: bash
-        working-directory: .
-        run: |
-          git clone https://github.com/etalab/api-entreprise-integration
-          cd api-entreprise-integration
-          ./deploy-parteprise.sh
-
-  continuous-deployment-production:
-    name: Continuous deployment on production
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/develop'
-    timeout-minutes: 20
-    needs:
-      - security
-      - lint
-      - check-swagger
-      - check-zeitwerk
-      - tests
-      - merge-with-main
-      - continuous-deployment-staging
-    strategy:
-      matrix:
-        host: [watchdoge3, watchdoge4]
-      fail-fast: false
-    environment: production
-    env:
-      DEPLOY_HTTPS_LOGIN: ${{ secrets.DEPLOY_HTTPS_LOGIN }}
-      DEPLOY_HTTPS_PASSWORD: ${{ secrets.DEPLOY_HTTPS_PASSWORD }}
-      DEPLOY_HTTPS_REQUEST_URL: ${{ vars.DEPLOY_HTTPS_REQUEST_URL }}
-      DEPLOY_HTTPS_RESPONSE_URL: ${{ vars.DEPLOY_HTTPS_RESPONSE_URL }}
-      DEPLOY_HOST: host_${{ matrix.host }}
-      DEPLOY_APP: siadelibre_production
-    steps:
-      - name: Download and run deploy script
-        shell: bash
-        working-directory: .
-        run: |
-          git clone https://github.com/etalab/api-entreprise-integration
-          cd api-entreprise-integration
-          ./deploy-parteprise.sh
+    uses: ./.github/workflows/_api-deploy.yml
+    secrets: inherit

--- a/.github/workflows/api-ci_cd.yml
+++ b/.github/workflows/api-ci_cd.yml
@@ -12,7 +12,6 @@ on:
     paths:
       - 'siade/**'
       - 'commons/**'
-      - 'mocks/**'
 jobs:
   security:
     name: Brakeman

--- a/.github/workflows/api-deploy-on-mocks-change.yml
+++ b/.github/workflows/api-deploy-on-mocks-change.yml
@@ -1,0 +1,14 @@
+name: "API: Deploy on mocks change"
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - 'mocks/**'
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/_api-deploy.yml
+    secrets: inherit
+    with:
+      skip_production: true


### PR DESCRIPTION
The siade test suite does not consume payloads from the mocks/ directory.
MockDataBackend specs use local fixtures (spec/fixtures/mock_payloads),
not the config/mock_payloads symlink pointing to ../../mocks/payloads.
Running the full API CI (tests, brakeman, lint) on feature branches that
only touch mocks/ is wasteful — mocks have their own dedicated test
workflow (mocks-tests.yml).

But siade reads mocks/ at runtime via the config/mock_payloads symlink,
so dropping the trigger also removed the only path deploying mocks to
staging on develop. Fixed by extracting the deploy jobs into a reusable
workflow and adding api-deploy-on-mocks-change.yml that runs on
develop+mocks/** with skip_production=true: merge-to-main + staging,
no siade CI rerun, no prod (mocks are staging-only).