### PR TITLE
(WIP) Support NIR identification mode for CNAV

### DIFF
--- a/siade/app/interactors/cnav/make_request.rb
+++ b/siade/app/interactors/cnav/make_request.rb
@@ -56,6 +56,8 @@ class CNAV::MakeRequest < MakeRequest::Get
 
   # rubocop:disable Metrics/AbcSize
   def request_params
+    return request_params_with_nir if context.params[:nir].present?
+
     {
       nomUsage: transliterate(context.params[:nom_usage]),
       nomNaissance: transliterate(context.params[:nom_naissance]),
@@ -69,6 +71,14 @@ class CNAV::MakeRequest < MakeRequest::Get
     }.compact
   end
   # rubocop:enable Metrics/AbcSize
+
+  def request_params_with_nir
+    {
+      numAssure: context.params[:nir],
+      nomNaissance: context.params[:nom_naissance],
+      listePrenoms: liste_prenoms
+    }.compact
+  end
 
   private
 

--- a/siade/spec/interactors/cnav/make_request_spec.rb
+++ b/siade/spec/interactors/cnav/make_request_spec.rb
@@ -240,6 +240,41 @@ RSpec.describe CNAV::MakeRequest, type: :make_request do
     end
   end
 
+  describe 'with NIR params' do
+    let(:params) do
+      {
+        nir: '1234567890123',
+        nom_naissance: 'DUPONT',
+        request_id:
+      }
+    end
+
+    let!(:stubbed_request) do
+      stub_request(:get, Siade.credentials[:cnav_complementaire_sante_solidaire_url]).with(
+        query: { numAssure: '1234567890123', nomNaissance: 'DUPONT' },
+        headers: {
+          'Content-Type' => 'application/json',
+          'Authorization' => 'Bearer super_valid_token',
+          'X-APIPART-FSFINAL' => valid_siret,
+          'X-Correlation-ID' => request_id
+        }
+      ).to_return(
+        status: 200,
+        body: read_payload_file('cnav/complementaire_sante_solidaire/make_request_valid.json')
+      )
+    end
+
+    it { is_expected.to be_a_success }
+
+    its(:response) { is_expected.to be_a(Net::HTTPOK) }
+
+    it 'calls url with NIR param only' do
+      make_call
+
+      expect(stubbed_request).to have_been_requested
+    end
+  end
+
   describe 'when not from france' do
     let(:params) do
       {

--- a/siade/spec/interactors/cnav/quotient_familial_v2/make_request_spec.rb
+++ b/siade/spec/interactors/cnav/quotient_familial_v2/make_request_spec.rb
@@ -89,6 +89,48 @@ RSpec.describe CNAV::QuotientFamilialV2::MakeRequest, type: :make_request do
     end
   end
 
+  describe 'with NIR params' do
+    let(:params) do
+      {
+        nir: '1234567890123',
+        nom_naissance: 'DUPONT',
+        annee: 2024,
+        mois: 8,
+        request_id:
+      }
+    end
+
+    let!(:stubbed_request) do
+      stub_request(:get, Siade.credentials[:cnav_quotient_familial_v2_url]).with(
+        query: {
+          numAssure: '1234567890123',
+          nomNaissance: 'DUPONT',
+          anneeDemandee: 2024,
+          moisDemande: '08'
+        },
+        headers: {
+          'Content-Type' => 'application/json',
+          'Authorization' => 'Bearer super_valid_token',
+          'X-APIPART-FSFINAL' => valid_siret,
+          'X-Correlation-ID' => request_id
+        }
+      ).to_return(
+        status: 200,
+        body: read_payload_file('cnav/quotient_familial_v2/make_request_valid.json')
+      )
+    end
+
+    it { is_expected.to be_a_success }
+
+    its(:response) { is_expected.to be_a(Net::HTTPOK) }
+
+    it 'calls url with NIR and period params' do
+      make_call
+
+      expect(stubbed_request).to have_been_requested
+    end
+  end
+
   describe 'with FranceConnect params' do
     let(:params) do
       {


### PR DESCRIPTION
Allows CNAV API calls using NIR (numAssure) instead of full civility params. When nir param is present, sends numAssure + optional nomNaissance/listePrenoms.

Ref https://linear.app/pole-api/issue/API-4467

Raw import de https://github.com/etalab/siade/pull/1995