### PR TITLE
feat(provider): narrow dashboard habilitations to scopes of selected routes

### DIFF
--- a/site/app/queries/provider/dashboard_query.rb
+++ b/site/app/queries/provider/dashboard_query.rb
@@ -258,11 +258,19 @@ class Provider::DashboardQuery # rubocop:disable Metrics/ClassLength
   end
 
   def habilitation_scope_clause
-    scopes = provider.scopes.presence
+    scopes = habilitation_scopes.presence
     return Arel.sql('1=0') if scopes.blank?
 
     array_literal = ActiveRecord::Base.sanitize_sql_array(['ARRAY[?]::text[]', scopes])
     Arel.sql("scopes ?| #{array_literal}")
+  end
+
+  def habilitation_scopes
+    controllers = requested_controllers
+    return provider.scopes if controllers.nil?
+    return [] if controllers.empty?
+
+    RouteScopesStore.scopes_for_controllers(controllers)
   end
 
   def filter_apis

--- a/site/app/stores/route_scopes_store.rb
+++ b/site/app/stores/route_scopes_store.rb
@@ -1,0 +1,30 @@
+require 'singleton'
+
+class RouteScopesStore
+  include Singleton
+
+  def self.scopes_for(controller)
+    instance.index[controller] || []
+  end
+
+  def self.scopes_for_controllers(controllers)
+    controllers.flat_map { |controller| scopes_for(controller) }.uniq
+  end
+
+  def index
+    load_index if Rails.env.development?
+    @index
+  end
+
+  private
+
+  def initialize
+    load_index
+    super
+  end
+
+  def load_index
+    config = YAML.safe_load_file(Rails.root.join('config/route_scopes.yml'), aliases: true)
+    @index = (config['shared'] || {}).transform_values { |scopes| Array(scopes) }
+  end
+end

--- a/site/config/route_scopes.yml
+++ b/site/config/route_scopes.yml
@@ -1,0 +1,1 @@
+../../commons/data/authorizations.yml

--- a/site/spec/queries/provider/dashboard_query_spec.rb
+++ b/site/spec/queries/provider/dashboard_query_spec.rb
@@ -159,6 +159,22 @@ RSpec.describe Provider::DashboardQuery do
       expect(hab[:scopes]).to include('unites_legales_etablissements_insee')
     end
 
+    it 'narrows habilitations to scopes mapped to the selected routes' do
+      create(:authorization_request, :with_organization,
+        intitule: 'Unites only', external_id: 'AR-UNITES', api: 'entreprise',
+        siret: '13002526500013', scopes: ['entreprises'], status: :validated)
+
+      narrow = Provider::DashboardFilter.new(provider, 'entreprise', routes: [insee_etablissements])
+      external_ids = described_class.new(provider, narrow).habilitations.pluck(:external_id)
+      expect(external_ids).to include('AR-1')
+      expect(external_ids).not_to include('AR-UNITES')
+    end
+
+    it 'returns no habilitation when the route filter excludes every provider controller' do
+      foreign = Provider::DashboardFilter.new(provider, 'entreprise', routes: [dgfip_chiffres])
+      expect(described_class.new(provider, foreign).habilitations).to be_empty
+    end
+
     it 'excludes draft and archived habilitations' do
       create(:authorization_request,
         intitule: 'Draft',


### PR DESCRIPTION
Iteration on the original Metabase dashboards (97 / 102) we replaced in 97af634a44 / 161ee723c6. The Metabase habilitations question matched every active authorization_request whose `scopes` jsonb intersected `provider.scopes`, i.e. the full provider-level scope list, with no route filter; we mirrored that 1:1 when porting to Rails. The Metabase behaviour was acceptable because the dashboard had no per-route filter in the first place. Now that the in-house dashboard exposes a route checkbox, that 1:1 port becomes inconsistent: checking a subset of a provider's routes still lists habilitations covering routes the user had unchecked. Consumers were already filtered correctly via `match_routes`; habilitations were the odd one out.

Not a user-visible API change, so no changelog entry.