### PR TITLE
Document transcogage mechanism in CNAV/CNAF-MSA endpoint FAQs

### DIFF
--- a/commons/endpoints/api_particulier/cnaf_msa_allocation_education_enfant_handicape.yml
+++ b/commons/endpoints/api_particulier/cnaf_msa_allocation_education_enfant_handicape.yml
@@ -149,7 +149,7 @@ fiche:
                 {:.fr-icon-arrow-right-line .fr-link--icon-right}
                 [✒️ **Aider les usagers à renseigner leur lieu de naissance par code COG** - Lire la publication du 08/11/2023](https://particulier.api.gouv.fr/blog/parametre-lieu-naissance-code-cog){:target="_blank"}
 
-              - *Option 2 : L'API est appelée avec le nom de la commune de naissance et le code du département de naissance*. La date de naissance est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG.
+              - *Option 2 : L'API est appelée avec le nom de la commune de naissance et le code du département de naissance*. La date de naissance (a minima l'année) est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG. Ce mécanisme est appelé **transcogage** : à partir du triplet _(nom de la commune de naissance, année de naissance, code du département de naissance)_, l'API interroge le référentiel des métadonnées de l'INSEE pour retrouver le code COG de la commune à l'année de naissance. Si plusieurs communes correspondent au nom fourni, le code département permet de lever l'ambiguïté. Cette option ne fonctionne que pour les particuliers nés en France.
 
           - **Pour les particuliers nés à l'étranger**: le code COG pays est obigatoire.
 

--- a/commons/endpoints/api_particulier/cnaf_msa_prestation_de_service_unique.yml
+++ b/commons/endpoints/api_particulier/cnaf_msa_prestation_de_service_unique.yml
@@ -140,3 +140,20 @@ fiche:
 
           [Pour en savoir plus sur la PSU et les règles d'attribution de cette aide aux établissements d'accueil du jeune enfant](https://www.caf.fr/sites/default/files/medias/631/Partenaires/PDF%20_Part/EAJE/Corps%20de%20la%20circulaire%20Psu20180205101510.pdf){:target="_blank"}
 
+      - q: <a name="renseigner-lieu-de-naissance"></a> Appel avec l'identité pivot, comment renseigner le lieu de naissance ?
+        a: |+
+         Lorsque l'API est appelée avec l'identité pivot, pour identifier correctement le particulier, le système d'information a besoin de récupérer le lieu de naissance du particulier.
+
+          - **Pour les particuliers nés en France**: le code COG pays `99100` est obigatoire. La commune de naissance est également obligatoire et peut-être renseignée via deux options différentes&nbsp;:
+
+              - *Option 1 : L'API est appelée avec le code COG commune lui-même*. Pour aider les usagers à renseigner leur code COG, consultez la publication suivante :
+                {:.fr-icon-arrow-right-line .fr-link--icon-right}
+                [✒️ **Aider les usagers à renseigner leur lieu de naissance par code COG** - Lire la publication du 08/11/2023](https://particulier.api.gouv.fr/blog/parametre-lieu-naissance-code-cog){:target="_blank"}
+
+              - *Option 2 : L'API est appelée avec le nom de la commune de naissance et le code du département de naissance*. La date de naissance (a minima l'année) est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG. Ce mécanisme est appelé **transcogage** : à partir du triplet _(nom de la commune de naissance, année de naissance, code du département de naissance)_, l'API interroge le référentiel des métadonnées de l'INSEE pour retrouver le code COG de la commune à l'année de naissance. Si plusieurs communes correspondent au nom fourni, le code département permet de lever l'ambiguïté. Cette option ne fonctionne que pour les particuliers nés en France.
+
+          - **Pour les particuliers nés à l'étranger**: le code COG pays est obigatoire.
+
+          {:.fr-highlight}
+          > **Le code COG du pays de naissance est obligatoire pour tous les appels.** Pour simplifier le parcours des usagers, évitez de demander aux particuliers nés en France de saisir leur pays de naissance, puisque vous pouvez le paramétrer directement -code COG pays France `99100`-, dès qu'un particuloer renseigne les informations de sa commune de naissance (forcément en France).
+

--- a/commons/endpoints/api_particulier/cnaf_msa_quotient_familial.yml
+++ b/commons/endpoints/api_particulier/cnaf_msa_quotient_familial.yml
@@ -203,7 +203,7 @@ fiche:
                 {:.fr-icon-arrow-right-line .fr-link--icon-right}
                 [✒️ **Aider les usagers à renseigner leur lieu de naissance par code COG** - Lire la publication du 08/11/2023](https://particulier.api.gouv.fr/blog/parametre-lieu-naissance-code-cog){:target="_blank"}
 
-              - *Option 2 : L'API est appelée avec le nom de la commune de naissance et le code du département de naissance*. La date de naissance est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG.
+              - *Option 2 : L'API est appelée avec le nom de la commune de naissance et le code du département de naissance*. La date de naissance (a minima l'année) est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG. Ce mécanisme est appelé **transcogage** : à partir du triplet _(nom de la commune de naissance, année de naissance, code du département de naissance)_, l'API interroge le référentiel des métadonnées de l'INSEE pour retrouver le code COG de la commune à l'année de naissance. Si plusieurs communes correspondent au nom fourni, le code département permet de lever l'ambiguïté. Cette option ne fonctionne que pour les particuliers nés en France.
 
           - **Pour les particuliers nés à l'étranger**: le code COG pays est obigatoire.
 

--- a/commons/endpoints/api_particulier/cnav_allocation_adulte_handicape.yml
+++ b/commons/endpoints/api_particulier/cnav_allocation_adulte_handicape.yml
@@ -89,8 +89,8 @@ fiche:
                 {:.fr-icon-arrow-right-line .fr-link--icon-right}
                 [✒️ **Aider les usagers à renseigner leur lieu de naissance par code COG** - Lire la publication du 08/11/2023](https://particulier.api.gouv.fr/blog/parametre-lieu-naissance-code-cog){:target="_blank"}
 
-              - *Option 2 : L'API est appelée avec le nom de la commune de naissance et le code du département de naissance*. La date de naissance est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG.
-          
+              - *Option 2 : L'API est appelée avec le nom de la commune de naissance et le code du département de naissance*. La date de naissance (a minima l'année) est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG. Ce mécanisme est appelé **transcogage** : à partir du triplet _(nom de la commune de naissance, année de naissance, code du département de naissance)_, l'API interroge le référentiel des métadonnées de l'INSEE pour retrouver le code COG de la commune à l'année de naissance. Si plusieurs communes correspondent au nom fourni, le code département permet de lever l'ambiguïté. Cette option ne fonctionne que pour les particuliers nés en France.
+
           - **Pour les particuliers nés à l'étranger**: le code COG pays est obigatoire.
 
           {:.fr-highlight}

--- a/commons/endpoints/api_particulier/cnav_allocation_soutien_familial.yml
+++ b/commons/endpoints/api_particulier/cnav_allocation_soutien_familial.yml
@@ -84,8 +84,8 @@ fiche:
                 {:.fr-icon-arrow-right-line .fr-link--icon-right}
                 [✒️ **Aider les usagers à renseigner leur lieu de naissance par code COG** - Lire la publication du 08/11/2023](https://particulier.api.gouv.fr/blog/parametre-lieu-naissance-code-cog){:target="_blank"}
 
-              - *Option 2 : L'API est appelée avec le nom de la commune de naissance et le code du département de naissance*. La date de naissance est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG.
-          
+              - *Option 2 : L'API est appelée avec le nom de la commune de naissance et le code du département de naissance*. La date de naissance (a minima l'année) est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG. Ce mécanisme est appelé **transcogage** : à partir du triplet _(nom de la commune de naissance, année de naissance, code du département de naissance)_, l'API interroge le référentiel des métadonnées de l'INSEE pour retrouver le code COG de la commune à l'année de naissance. Si plusieurs communes correspondent au nom fourni, le code département permet de lever l'ambiguïté. Cette option ne fonctionne que pour les particuliers nés en France.
+
           - **Pour les particuliers nés à l'étranger**: le code COG pays est obigatoire.
 
           {:.fr-highlight}

--- a/commons/endpoints/api_particulier/cnav_complementaire_sante_solidaire.yml
+++ b/commons/endpoints/api_particulier/cnav_complementaire_sante_solidaire.yml
@@ -103,8 +103,8 @@ fiche:
                 {:.fr-icon-arrow-right-line .fr-link--icon-right}
                 [✒️ **Aider les usagers à renseigner leur lieu de naissance par code COG** - Lire la publication du 08/11/2023](https://particulier.api.gouv.fr/blog/parametre-lieu-naissance-code-cog){:target="_blank"}
 
-              - *Option 2 : L'API est appelée avec le nom de la commune de naissance et le code du département de naissance*. La date de naissance est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG.
-          
+              - *Option 2 : L'API est appelée avec le nom de la commune de naissance et le code du département de naissance*. La date de naissance (a minima l'année) est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG. Ce mécanisme est appelé **transcogage** : à partir du triplet _(nom de la commune de naissance, année de naissance, code du département de naissance)_, l'API interroge le référentiel des métadonnées de l'INSEE pour retrouver le code COG de la commune à l'année de naissance. Si plusieurs communes correspondent au nom fourni, le code département permet de lever l'ambiguïté. Cette option ne fonctionne que pour les particuliers nés en France.
+
           - **Pour les particuliers nés à l'étranger**: le code COG pays est obigatoire.
 
           {:.fr-highlight}

--- a/commons/endpoints/api_particulier/cnav_prime_activite.yml
+++ b/commons/endpoints/api_particulier/cnav_prime_activite.yml
@@ -86,8 +86,8 @@ fiche:
                 {:.fr-icon-arrow-right-line .fr-link--icon-right}
                 [✒️ **Aider les usagers à renseigner leur lieu de naissance par code COG** - Lire la publication du 08/11/2023](https://particulier.api.gouv.fr/blog/parametre-lieu-naissance-code-cog){:target="_blank"}
 
-              - *Option 2 : L'API est appelée avec le nom de la commune de naissance et le code du département de naissance*. La date de naissance est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG.
-          
+              - *Option 2 : L'API est appelée avec le nom de la commune de naissance et le code du département de naissance*. La date de naissance (a minima l'année) est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG. Ce mécanisme est appelé **transcogage** : à partir du triplet _(nom de la commune de naissance, année de naissance, code du département de naissance)_, l'API interroge le référentiel des métadonnées de l'INSEE pour retrouver le code COG de la commune à l'année de naissance. Si plusieurs communes correspondent au nom fourni, le code département permet de lever l'ambiguïté. Cette option ne fonctionne que pour les particuliers nés en France.
+
           - **Pour les particuliers nés à l'étranger**: le code COG pays est obigatoire.
 
           {:.fr-highlight}

--- a/commons/endpoints/api_particulier/cnav_revenu_solidarite_active.yml
+++ b/commons/endpoints/api_particulier/cnav_revenu_solidarite_active.yml
@@ -86,11 +86,13 @@ fiche:
           {:.fr-icon-arrow-right-line .fr-link--icon-right}
           [✒️ **Aider les usagers à renseigner leur lieu de naissance par code COG** - Lire la publication du 08/11/2023](https://particulier.api.gouv.fr/blog/parametre-lieu-naissance-code-cog){:target="_blank"}
 
-          **Option 2 : L'API est appelée avec le nom de la commune de naissance et code* du département de naissance**
+          **Option 2 : L'API est appelée avec le nom de la commune de naissance et code du département de naissance (transcogage)**
 
-          Cette option à pour objectif de faciliter vos développements, mais elle n'est pas exhaustive puisque les usagers nés à l'étranger ne pourront pas être identifiés. 
+          Cette option a pour objectif de faciliter vos développements, mais elle n'est pas exhaustive puisque les usagers nés à l'étranger ne pourront pas être identifiés.
 
-          Avec cette option, vous pouvez appeler l'API avec le nom de la commune de naissance et le code du département de naissance. La date de naissance est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG.
+          Avec cette option, vous pouvez appeler l'API avec le nom de la commune de naissance et le code du département de naissance. La date de naissance (a minima l'année) est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG.
+
+          Ce mécanisme est appelé **transcogage** : à partir du triplet _(nom de la commune de naissance, année de naissance, code du département de naissance)_, l'API interroge le référentiel des métadonnées de l'INSEE pour retrouver le code COG de la commune à l'année de naissance. Si plusieurs communes correspondent au nom fourni, le code département permet de lever l'ambiguïté.
     historique: |+
       **Ce que change le passage à la V.3 d'API Particulier:**
 

--- a/commons/endpoints/api_particulier/v2_cnaf_msa_quotient_familial_v2.yml
+++ b/commons/endpoints/api_particulier/v2_cnaf_msa_quotient_familial_v2.yml
@@ -211,8 +211,8 @@ fiche:
                 {:.fr-icon-arrow-right-line .fr-link--icon-right}
                 [✒️ **Aider les usagers à renseigner leur lieu de naissance par code COG** - Lire la publication du 08/11/2023](https://particulier.api.gouv.fr/blog/parametre-lieu-naissance-code-cog){:target="_blank"}
 
-              - *Option 2 : L'API est appelée avec le nom de la commune de naissance et le code du département de naissance*. La date de naissance est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG.
-          
+              - *Option 2 : L'API est appelée avec le nom de la commune de naissance et le code du département de naissance*. La date de naissance (a minima l'année) est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG. Ce mécanisme est appelé **transcogage** : à partir du triplet _(nom de la commune de naissance, année de naissance, code du département de naissance)_, l'API interroge le référentiel des métadonnées de l'INSEE pour retrouver le code COG de la commune à l'année de naissance. Si plusieurs communes correspondent au nom fourni, le code département permet de lever l'ambiguïté. Cette option ne fonctionne que pour les particuliers nés en France.
+
           - **Pour les particuliers nés à l'étranger**: le code COG pays est obigatoire.
 
           {:.fr-highlight}

--- a/commons/endpoints/api_particulier/v2_cnav_allocation_adulte_handicape.yml
+++ b/commons/endpoints/api_particulier/v2_cnav_allocation_adulte_handicape.yml
@@ -81,8 +81,8 @@ fiche:
                 {:.fr-icon-arrow-right-line .fr-link--icon-right}
                 [✒️ **Aider les usagers à renseigner leur lieu de naissance par code COG** - Lire la publication du 08/11/2023](https://particulier.api.gouv.fr/blog/parametre-lieu-naissance-code-cog){:target="_blank"}
 
-              - *Option 2 : L'API est appelée avec le nom de la commune de naissance et le code du département de naissance*. La date de naissance est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG.
-          
+              - *Option 2 : L'API est appelée avec le nom de la commune de naissance et le code du département de naissance*. La date de naissance (a minima l'année) est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG. Ce mécanisme est appelé **transcogage** : à partir du triplet _(nom de la commune de naissance, année de naissance, code du département de naissance)_, l'API interroge le référentiel des métadonnées de l'INSEE pour retrouver le code COG de la commune à l'année de naissance. Si plusieurs communes correspondent au nom fourni, le code département permet de lever l'ambiguïté. Cette option ne fonctionne que pour les particuliers nés en France.
+
           - **Pour les particuliers nés à l'étranger**: le code COG pays est obigatoire.
 
           {:.fr-highlight}

--- a/commons/endpoints/api_particulier/v2_cnav_allocation_soutien_familial.yml
+++ b/commons/endpoints/api_particulier/v2_cnav_allocation_soutien_familial.yml
@@ -77,8 +77,8 @@ fiche:
                 {:.fr-icon-arrow-right-line .fr-link--icon-right}
                 [✒️ **Aider les usagers à renseigner leur lieu de naissance par code COG** - Lire la publication du 08/11/2023](https://particulier.api.gouv.fr/blog/parametre-lieu-naissance-code-cog){:target="_blank"}
 
-              - *Option 2 : L'API est appelée avec le nom de la commune de naissance et le code du département de naissance*. La date de naissance est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG.
-          
+              - *Option 2 : L'API est appelée avec le nom de la commune de naissance et le code du département de naissance*. La date de naissance (a minima l'année) est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG. Ce mécanisme est appelé **transcogage** : à partir du triplet _(nom de la commune de naissance, année de naissance, code du département de naissance)_, l'API interroge le référentiel des métadonnées de l'INSEE pour retrouver le code COG de la commune à l'année de naissance. Si plusieurs communes correspondent au nom fourni, le code département permet de lever l'ambiguïté. Cette option ne fonctionne que pour les particuliers nés en France.
+
           - **Pour les particuliers nés à l'étranger**: le code COG pays est obigatoire.
 
           {:.fr-highlight}

--- a/commons/endpoints/api_particulier/v2_cnav_complementaire_sante_solidaire.yml
+++ b/commons/endpoints/api_particulier/v2_cnav_complementaire_sante_solidaire.yml
@@ -91,8 +91,8 @@ fiche:
                 {:.fr-icon-arrow-right-line .fr-link--icon-right}
                 [✒️ **Aider les usagers à renseigner leur lieu de naissance par code COG** - Lire la publication du 08/11/2023](https://particulier.api.gouv.fr/blog/parametre-lieu-naissance-code-cog){:target="_blank"}
 
-              - *Option 2 : L'API est appelée avec le nom de la commune de naissance et le code du département de naissance*. La date de naissance est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG.
-          
+              - *Option 2 : L'API est appelée avec le nom de la commune de naissance et le code du département de naissance*. La date de naissance (a minima l'année) est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG. Ce mécanisme est appelé **transcogage** : à partir du triplet _(nom de la commune de naissance, année de naissance, code du département de naissance)_, l'API interroge le référentiel des métadonnées de l'INSEE pour retrouver le code COG de la commune à l'année de naissance. Si plusieurs communes correspondent au nom fourni, le code département permet de lever l'ambiguïté. Cette option ne fonctionne que pour les particuliers nés en France.
+
           - **Pour les particuliers nés à l'étranger**: le code COG pays est obigatoire.
 
           {:.fr-highlight}

--- a/commons/endpoints/api_particulier/v2_cnav_prime_activite.yml
+++ b/commons/endpoints/api_particulier/v2_cnav_prime_activite.yml
@@ -82,8 +82,8 @@ fiche:
                 {:.fr-icon-arrow-right-line .fr-link--icon-right}
                 [✒️ **Aider les usagers à renseigner leur lieu de naissance par code COG** - Lire la publication du 08/11/2023](https://particulier.api.gouv.fr/blog/parametre-lieu-naissance-code-cog){:target="_blank"}
 
-              - *Option 2 : L'API est appelée avec le nom de la commune de naissance et le code du département de naissance*. La date de naissance est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG.
-          
+              - *Option 2 : L'API est appelée avec le nom de la commune de naissance et le code du département de naissance*. La date de naissance (a minima l'année) est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG. Ce mécanisme est appelé **transcogage** : à partir du triplet _(nom de la commune de naissance, année de naissance, code du département de naissance)_, l'API interroge le référentiel des métadonnées de l'INSEE pour retrouver le code COG de la commune à l'année de naissance. Si plusieurs communes correspondent au nom fourni, le code département permet de lever l'ambiguïté. Cette option ne fonctionne que pour les particuliers nés en France.
+
           - **Pour les particuliers nés à l'étranger**: le code COG pays est obigatoire.
 
           {:.fr-highlight}

--- a/commons/endpoints/api_particulier/v2_cnav_revenu_solidarite_active.yml
+++ b/commons/endpoints/api_particulier/v2_cnav_revenu_solidarite_active.yml
@@ -82,8 +82,10 @@ fiche:
           {:.fr-icon-arrow-right-line .fr-link--icon-right}
           [✒️ **Aider les usagers à renseigner leur lieu de naissance par code COG** - Lire la publication du 08/11/2023](https://particulier.api.gouv.fr/blog/parametre-lieu-naissance-code-cog){:target="_blank"}
 
-          **Option 2 : L'API est appelée avec le nom de la commune de naissance et code* du département de naissance**
+          **Option 2 : L'API est appelée avec le nom de la commune de naissance et code du département de naissance (transcogage)**
 
-          Cette option à pour objectif de faciliter vos développements, mais elle n'est pas exhaustive puisque les usagers nés à l'étranger ne pourront pas être identifiés. 
+          Cette option a pour objectif de faciliter vos développements, mais elle n'est pas exhaustive puisque les usagers nés à l'étranger ne pourront pas être identifiés.
 
-          Avec cette option, vous pouvez appeler l'API avec le nom de la commune de naissance et le code du département de naissance. La date de naissance est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG.
+          Avec cette option, vous pouvez appeler l'API avec le nom de la commune de naissance et le code du département de naissance. La date de naissance (a minima l'année) est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG.
+
+          Ce mécanisme est appelé **transcogage** : à partir du triplet _(nom de la commune de naissance, année de naissance, code du département de naissance)_, l'API interroge le référentiel des métadonnées de l'INSEE pour retrouver le code COG de la commune à l'année de naissance. Si plusieurs communes correspondent au nom fourni, le code département permet de lever l'ambiguïté.


### PR DESCRIPTION
Explain in the "how to provide birthplace" FAQ that Option 2 uses a mechanism called transcogage: the triplet (commune name, birth year, department code) is resolved to a COG code via the INSEE metadata API. The department disambiguates when multiple communes share the same name. This option only works for people born in France.

Applied to all 14 CNAV/CNAF-MSA endpoint files (v2 and v3). Added the missing FAQ entry to the PSU endpoint.