### PR TITLE
Extract transcogage logic into a dedicated module

### DIFF
--- a/siade/app/controllers/api_particulier/v3_and_more/cnav/abstract_civility_controller.rb
+++ b/siade/app/controllers/api_particulier/v3_and_more/cnav/abstract_civility_controller.rb
@@ -12,10 +12,6 @@ class APIParticulier::V3AndMore::CNAV::AbstractCivilityController < APIParticuli
 
   protected
 
-  def transcogage?
-    false
-  end
-
   def cache_key
     "#{request.path}:#{api_params.to_query}"
   end

--- a/siade/app/controllers/api_particulier/v3_and_more/cnous/etudiant_boursier_with_civility_controller.rb
+++ b/siade/app/controllers/api_particulier/v3_and_more/cnous/etudiant_boursier_with_civility_controller.rb
@@ -1,5 +1,6 @@
 class APIParticulier::V3AndMore::CNOUS::EtudiantBoursierWithCivilityController < APIParticulier::V3AndMore::BaseController
   include APIParticulier::CivilityParameters
+  include APIParticulier::Transcogage
 
   def show
     if organizer.success?
@@ -8,12 +9,6 @@ class APIParticulier::V3AndMore::CNOUS::EtudiantBoursierWithCivilityController <
     else
       render_errors(organizer)
     end
-  end
-
-  protected
-
-  def transcogage?
-    true
   end
 
   private

--- a/siade/app/controllers/api_particulier/v3_and_more/dsnj/service_national_with_civility_controller.rb
+++ b/siade/app/controllers/api_particulier/v3_and_more/dsnj/service_national_with_civility_controller.rb
@@ -12,10 +12,6 @@ class APIParticulier::V3AndMore::DSNJ::ServiceNationalWithCivilityController < A
 
   private
 
-  def transcogage?
-    false
-  end
-
   def organizer_params
     civility_parameters
   end

--- a/siade/app/controllers/api_particulier/v3_and_more/gip_mds/service_civique_with_civility_controller.rb
+++ b/siade/app/controllers/api_particulier/v3_and_more/gip_mds/service_civique_with_civility_controller.rb
@@ -12,10 +12,6 @@ class APIParticulier::V3AndMore::GIPMDS::ServiceCiviqueWithCivilityController < 
 
   private
 
-  def transcogage?
-    false
-  end
-
   def organizer_params
     civility_parameters
   end

--- a/siade/app/controllers/api_particulier/v3_and_more/men/scolarites_with_civility_controller.rb
+++ b/siade/app/controllers/api_particulier/v3_and_more/men/scolarites_with_civility_controller.rb
@@ -12,10 +12,6 @@ class APIParticulier::V3AndMore::MEN::ScolaritesWithCivilityController < APIPart
 
   private
 
-  def transcogage?
-    false
-  end
-
   def organizer_params
     civility_parameters
       .merge({

--- a/siade/app/controllers/api_particulier/v3_and_more/mesri/statut_etudiant_with_civility_controller.rb
+++ b/siade/app/controllers/api_particulier/v3_and_more/mesri/statut_etudiant_with_civility_controller.rb
@@ -1,5 +1,6 @@
 class APIParticulier::V3AndMore::MESRI::StatutEtudiantWithCivilityController < APIParticulier::V3AndMore::BaseController
   include APIParticulier::CivilityParameters
+  include APIParticulier::Transcogage
 
   def show
     if organizer.success?
@@ -8,12 +9,6 @@ class APIParticulier::V3AndMore::MESRI::StatutEtudiantWithCivilityController < A
     else
       render_errors(organizer)
     end
-  end
-
-  protected
-
-  def transcogage?
-    true
   end
 
   private

--- a/siade/app/controllers/concerns/api_particulier/civility_parameters.rb
+++ b/siade/app/controllers/concerns/api_particulier/civility_parameters.rb
@@ -26,34 +26,10 @@ module APIParticulier::CivilityParameters
   protected
 
   def extract_code_cog_insee_commune_naissance
-    code_cog = params[:codeCogInseeCommuneNaissance].presence
-
-    if transcogage? && transcogage_params?
-      extract_code_commune_organizer = INSEE::CommuneINSEECode.call(params: transcogage_params)
-
-      code_cog ||= extract_code_commune_organizer.bundled_data.data.code_insee if extract_code_commune_organizer.success?
-    end
-
-    code_cog
-  end
-
-  def transcogage?
-    raise NotImplementedError
+    params[:codeCogInseeCommuneNaissance].presence
   end
 
   private
-
-  def transcogage_params
-    @transcogage_params ||= {
-      nom_commune_naissance: params[:nomCommuneNaissance],
-      annee_date_naissance: params[:anneeDateNaissance],
-      code_cog_insee_departement_naissance: params[:codeCogInseeDepartementNaissance]
-    }
-  end
-
-  def transcogage_params?
-    %i[nom_commune_naissance annee_date_naissance code_cog_insee_departement_naissance].all? { |key| transcogage_params[key].present? }
-  end
 
   def civility_param(param)
     params[param]

--- a/siade/app/controllers/concerns/api_particulier/transcogage.rb
+++ b/siade/app/controllers/concerns/api_particulier/transcogage.rb
@@ -1,0 +1,27 @@
+module APIParticulier::Transcogage
+  protected
+
+  def extract_code_cog_insee_commune_naissance
+    code_cog = params[:codeCogInseeCommuneNaissance].presence
+
+    return code_cog if code_cog || !transcogage_params?
+
+    result = INSEE::CommuneINSEECode.call(params: transcogage_params)
+
+    result.success? ? result.bundled_data.data.code_insee : code_cog
+  end
+
+  private
+
+  def transcogage_params
+    @transcogage_params ||= {
+      nom_commune_naissance: params[:nomCommuneNaissance],
+      annee_date_naissance: params[:anneeDateNaissance],
+      code_cog_insee_departement_naissance: params[:codeCogInseeDepartementNaissance]
+    }
+  end
+
+  def transcogage_params?
+    %i[nom_commune_naissance annee_date_naissance code_cog_insee_departement_naissance].all? { |key| transcogage_params[key].present? }
+  end
+end


### PR DESCRIPTION
Replace the `transcogage?` boolean method pattern with an explicit `APIParticulier::Transcogage` module. Controllers that support transcogage (MESRI, CNOUS) now include both `CivilityParameters` and `Transcogage`. The module overrides `extract_code_cog_insee_commune_naissance` to resolve the COG code via the INSEE API when the triplet (commune name, birth year, department code) is provided.

Controllers that don't support transcogage (CNAV, GIP-MDS, MEN, DSNJ) no longer need to define `transcogage?` at all — CivilityParameters simply returns the raw codeCogInseeCommuneNaissance param.