### PR TITLE
Make CNAV birth place commune params optional, keep country code mandatory

### DIFF
--- a/commons/endpoints/_swagger_shared/cnav.yml
+++ b/commons/endpoints/_swagger_shared/cnav.yml
@@ -579,7 +579,7 @@ cnav:
           minLength: 5
           maxLength: 5
           example: '08480'
-          description: "Code Insee à 5 chiffres du lieu de naissance de la personne. Ne pas remplir si la personne est née à l'étranger ou si présence de jeton FranceConnect. En l'absence de jeton FranceConnect et du triplet (nomCommuneNaissance, anneeDateDeNaissance, codeInseeDepartementNaissance), le champ est obligatoire si la personne est née en France"
+          description: "Code Insee à 5 chiffres du lieu de naissance de la personne. Ne pas remplir si la personne est née à l'étranger ou si présence de jeton FranceConnect. Fortement recommandé pour les personnes nées en France afin de maximiser les chances d'identification."
         codePaysLieuDeNaissance:
           description: "Code Insee à 5 chiffres du pays de naissance (France = 99100). Obligatoire si absence de jeton FranceConnect."
           type: string
@@ -597,13 +597,13 @@ cnav:
           type: string
           minLength: 1
           example: 'Gennevilliers'
-          description: "Nom de la commune de naissance. En l'absence de jeton FranceConnect et du codeInseeLieuDeNaissance, ce paramètre est obligatoire si la personne est née en France"
+          description: "Nom de la commune de naissance. Fortement recommandé pour les personnes nées en France. Alternative au codeInseeLieuDeNaissance, à utiliser avec codeInseeDepartementNaissance et la date de naissance complète."
         codeInseeDepartementNaissance:
           type: string
           minLength: 2
           maxLength: 3
           example: '92'
-          description: "Code INSEE du département de naissance. En l'absence de jeton FranceConnect et du codeInseeLieuDeNaissance, ce paramètre est obligatoire si la personne est née en France"
+          description: "Code INSEE du département de naissance. Fortement recommandé pour les personnes nées en France. À utiliser avec nomCommuneNaissance et la date de naissance complète."
 
     c2s:
       title: Statut complémentaire santé solidaire (C2S)

--- a/commons/endpoints/api_particulier/cnaf_msa_allocation_education_enfant_handicape.yml
+++ b/commons/endpoints/api_particulier/cnaf_msa_allocation_education_enfant_handicape.yml
@@ -59,33 +59,28 @@ fiche:
           <div class="fr-collapse" id="accordion-106">
           <div class="fr-mb-0">
           <ul>
-            <li>Nom de naissance<sup>*</sup>, nom d'usage, prénoms<sup>1</sup>, sexe<sup>*</sup>, date de naissance de l'allocataire<sup>**</sup>&nbsp;;</li>
-            <li>Lieu de naissance&nbsp;:
+            <li>Nom de naissance<sup>1</sup>, nom d'usage, prénoms<sup>3</sup>, sexe<sup>1</sup>, date de naissance de l'allocataire<sup>2</sup>, code COG du pays de naissance<sup>1</sup>&nbsp;;</li>
+            <li>Commune de naissance <em>(<a href="#poids-parametres-identification">fortement recommandé</a>)</em>&nbsp;:
             <ul>
               <li>
-              <em>Si le lieu de naissance est en France,</em> la commune de naissance est obligatoire, elle peut être saisie de deux façons différentes :
+              <em>Si le lieu de naissance est en France,</em> la commune de naissance peut être saisie de deux façons différentes :
               <ul>
                 <li class="fr-text--sm fr-mb-0">
-                Option 1 : Code COG de la commune de naissance<sup>*</sup>. <a href="#renseigner-lieu-de-naissance">En savoir plus</a>&nbsp;;
+                Option 1 : Code COG de la commune de naissance. <a href="#renseigner-lieu-de-naissance">En savoir plus</a>&nbsp;;
                 </li>
                 <li class="fr-text--sm fr-mb-0">
-                Option 2 : Nom de la commune de naissance<sup>*</sup> et code du département de naissance<sup>*</sup>. Pour cette option, la date de naissance est obligatoire. <a href="#renseigner-lieu-de-naissance">En savoir plus</a>.
+                Option 2 : Nom de la commune de naissance et code du département de naissance. Pour cette option, la date de naissance est obligatoire. <a href="#renseigner-lieu-de-naissance">En savoir plus</a>.
                 </li>
               </ul>
-              Pour chacune des deux options ci-dessus, le code COG de la France <code>99100</code><sup>*</sup> doit également être renseigné en paramètre d'appel. Vous n'avez pas besoin de le demander à l'usager, il peut être déduit de la commune de naissance.
-              </li>
-              <li class="fr-mt-2v">
-              <em>Si le lieu de naissance est à l'étranger&nbsp;:</em> code COG du pays de naissance<sup>*</sup>.
               </li>
             </ul>
             </li>
           </ul>
           </div>
-          <span class="fr-text--xs">
-          <sup>*</sup> Obligatoire | <sup>**</sup> Obligatoire pour l'option 2 du lieu de naissance.
-          </span>
           <span class="fr-text--xs fr-m-0">
-          <sup>1</sup> Fournir plusieurs prénoms permet de limiter les risques d'homonymie mais un seul prénom peut fonctionner. Attention, l'usager doit compléter chaque prénom dans un champ distinct.
+          <sup>1</sup> Obligatoire<br>
+          <sup>2</sup> Obligatoire pour l'option 2 du lieu de naissance.<br>
+          <sup>3</sup> Fournir plusieurs prénoms permet de limiter les risques d'homonymie mais un seul prénom peut fonctionner. Attention, l'usager doit compléter chaque prénom dans un champ distinct.
           </span>
 
           </div>
@@ -139,11 +134,23 @@ fiche:
         a: |+
           L'enfant sera uniquement rattaché au parent qui en a la charge. Dans le cas d'une situation de résidence alternée, l'allocation apparaîtra uniquement sur le compte du parent qui bénéficie de toutes les prestations ou, si aucun des deux n'était allocataire avant la séparation, au premier qui en fait la demande. Les conditions pour bénéficier d'un complément AEEH doivent être remplies par l'allocataire qui a la charge de l'enfant. 
 
+      - q: <a name="poids-parametres-identification"></a> Quels paramètres ont le plus de poids dans l'algorithme d'identification ?
+        a: |+
+          L'algorithme d'identification du fournisseur de données s'appuie sur l'ensemble des paramètres d'entrée, mais certains ont un **poids plus important** :
+
+          - **Nom de naissance** ;
+          - **Année de naissance** ;
+          - **Lieu de naissance**.
+
+          Si ces trois informations sont correctement fournies, le particulier peut être identifié même si les autres paramètres comportent des erreurs. En revanche, si ces informations ne sont pas renseignées ou sont erronées, **le risque de recevoir une réponse 404** _(dossier allocataire absent)_ **augmente significativement**.
+
+          {:.fr-highlight}
+          > **Il est donc fortement recommandé de renseigner le lieu de naissance** afin de maximiser les chances d'identification du particulier.
       - q: <a name="renseigner-lieu-de-naissance"></a> Appel avec l'identité pivot, comment renseigner le lieu de naissance ?
         a: |+
-         Lorsque l'API est appelée avec l'identité pivot, pour identifier correctement le particulier, le système d'information a besoin de récupérer le lieu de naissance du particulier.
+         Lorsque l'API est appelée avec l'identité pivot, le lieu de naissance est [fortement recommandé](#poids-parametres-identification) pour identifier correctement le particulier.
 
-          - **Pour les particuliers nés en France**: le code COG pays `99100` est obigatoire. La commune de naissance est également obligatoire et peut-être renseignée via deux options différentes&nbsp;:
+          - **Pour les particuliers nés en France**: le code COG pays `99100` doit être renseigné. La commune de naissance peut être renseignée via deux options différentes&nbsp;:
 
               - *Option 1 : L'API est appelée avec le code COG commune lui-même*. Pour aider les usagers à renseigner leur code COG, consultez la publication suivante :
                 {:.fr-icon-arrow-right-line .fr-link--icon-right}
@@ -151,8 +158,8 @@ fiche:
 
               - *Option 2 : L'API est appelée avec le nom de la commune de naissance et le code du département de naissance*. La date de naissance est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG.
 
-          - **Pour les particuliers nés à l'étranger**: le code COG pays est obigatoire.
+          - **Pour les particuliers nés à l'étranger**: le code COG pays doit être renseigné.
 
           {:.fr-highlight}
-          > **Le code COG du pays de naissance est obligatoire pour tous les appels.** Pour simplifier le parcours des usagers, évitez de demander aux particuliers nés en France de saisir leur pays de naissance, puisque vous pouvez le paramétrer directement -code COG pays France `99100`-, dès qu'un particuloer renseigne les informations de sa commune de naissance (forcément en France).
+          > **Le code COG du pays de naissance est obligatoire pour tous les appels.** Pour simplifier le parcours des usagers, évitez de demander aux particuliers nés en France de saisir leur pays de naissance, puisque vous pouvez le paramétrer directement -code COG pays France `99100`-, dès qu'un particulier renseigne les informations de sa commune de naissance (forcément en France).
 

--- a/commons/endpoints/api_particulier/cnaf_msa_prestation_de_service_unique.yml
+++ b/commons/endpoints/api_particulier/cnaf_msa_prestation_de_service_unique.yml
@@ -82,33 +82,23 @@ fiche:
           <div class="fr-collapse" id="accordion-106">
           <div class="fr-mb-0">
           <ul>
-            <li>Nom de naissance<sup>*</sup>, nom d'usage, prénoms<sup>1</sup>, sexe<sup>*</sup>, date de naissance de l'allocataire<sup>**</sup>&nbsp;;</li>
-            <li>Lieu de naissance&nbsp;:
+            <li>Nom de naissance<sup>1</sup>, nom d'usage, prénoms<sup>3</sup>, sexe<sup>1</sup>, date de naissance de l'allocataire<sup>2</sup>, code COG du pays de naissance<sup>1</sup>&nbsp;;</li>
+            <li>Commune de naissance <em>(<a href="#poids-parametres-identification">fortement recommandé</a>)</em>&nbsp;: peut être renseignée de deux façons différentes :
             <ul>
-              <li>
-              <em>Si le lieu de naissance est en France,</em> la commune de naissance est obligatoire, elle peut être saisie de deux façons différentes :
-              <ul>
-                <li class="fr-text--sm fr-mb-0">
-                Option 1 : Code COG de la commune de naissance<sup>*</sup>. <a href="#renseigner-lieu-de-naissance">En savoir plus</a>&nbsp;;
-                </li>
-                <li class="fr-text--sm fr-mb-0">
-                Option 2 : Nom de la commune de naissance<sup>*</sup> et code du département de naissance<sup>*</sup>. Pour cette option, la date de naissance est obligatoire. <a href="#renseigner-lieu-de-naissance">En savoir plus</a>.
-                </li>
-              </ul>
-              Pour chacune des deux options ci-dessus, le code COG de la France <code>99100</code><sup>*</sup> doit également être renseigné en paramètre d'appel. Vous n'avez pas besoin de le demander à l'usager, il peut être déduit de la commune de naissance.
+              <li class="fr-text--sm fr-mb-0">
+              Option 1 : Code COG de la commune de naissance. <a href="#renseigner-lieu-de-naissance">En savoir plus</a>&nbsp;;
               </li>
-              <li class="fr-mt-2v">
-              <em>Si le lieu de naissance est à l'étranger&nbsp;:</em> code COG du pays de naissance<sup>*</sup>.
+              <li class="fr-text--sm fr-mb-0">
+              Option 2 : Nom de la commune de naissance et code du département de naissance. Pour cette option, la date de naissance est obligatoire. <a href="#renseigner-lieu-de-naissance">En savoir plus</a>.
               </li>
             </ul>
             </li>
           </ul>
           </div>
-          <span class="fr-text--xs">
-          <sup>*</sup> Obligatoire | <sup>**</sup> Obligatoire pour l'option 2 du lieu de naissance.
-          </span>
           <span class="fr-text--xs fr-m-0">
-          <sup>1</sup> Fournir plusieurs prénoms permet de limiter les risques d'homonymie mais un seul prénom peut fonctionner. Attention, l'usager doit compléter chaque prénom dans un champ distinct.
+          <sup>1</sup> Obligatoire<br>
+          <sup>2</sup> Obligatoire pour l'option 2 du lieu de naissance.<br>
+          <sup>3</sup> Fournir plusieurs prénoms permet de limiter les risques d'homonymie mais un seul prénom peut fonctionner. Attention, l'usager doit compléter chaque prénom dans un champ distinct.
           </span>
           <blockquote class="fr-highlight fr-highlight--caution">
 
@@ -139,4 +129,33 @@ fiche:
           Elle correspond à la prise en charge de 66 % du prix de revient horaire d’un établissement d'accueil du jeune enfant (eaje), dans la limite du prix plafond fixé par la CNAF et la MSA, déduction faite des participations familiales.
 
           [Pour en savoir plus sur la PSU et les règles d'attribution de cette aide aux établissements d'accueil du jeune enfant](https://www.caf.fr/sites/default/files/medias/631/Partenaires/PDF%20_Part/EAJE/Corps%20de%20la%20circulaire%20Psu20180205101510.pdf){:target="_blank"}
+
+      - q: <a name="poids-parametres-identification"></a> Quels paramètres ont le plus de poids dans l'algorithme d'identification ?
+        a: |+
+          L'algorithme d'identification du fournisseur de données s'appuie sur l'ensemble des paramètres d'entrée, mais certains ont un **poids plus important** :
+
+          - **Nom de naissance** ;
+          - **Année de naissance** ;
+          - **Lieu de naissance**.
+
+          Si ces trois informations sont correctement fournies, le particulier peut être identifié même si les autres paramètres comportent des erreurs. En revanche, si ces informations ne sont pas renseignées ou sont erronées, **le risque de recevoir une réponse 404** _(dossier allocataire absent)_ **augmente significativement**.
+
+          {:.fr-highlight}
+          > **Il est donc fortement recommandé de renseigner le lieu de naissance** afin de maximiser les chances d'identification du particulier.
+      - q: <a name="renseigner-lieu-de-naissance"></a> Appel avec l'identité pivot, comment renseigner le lieu de naissance ?
+        a: |+
+         Lorsque l'API est appelée avec l'identité pivot, le lieu de naissance est [fortement recommandé](#poids-parametres-identification) pour identifier correctement le particulier.
+
+          - **Pour les particuliers nés en France**: le code COG pays `99100` doit être renseigné. La commune de naissance peut être renseignée via deux options différentes&nbsp;:
+
+              - *Option 1 : L'API est appelée avec le code COG commune lui-même*. Pour aider les usagers à renseigner leur code COG, consultez la publication suivante :
+                {:.fr-icon-arrow-right-line .fr-link--icon-right}
+                [✒️ **Aider les usagers à renseigner leur lieu de naissance par code COG** - Lire la publication du 08/11/2023](https://particulier.api.gouv.fr/blog/parametre-lieu-naissance-code-cog){:target="_blank"}
+
+              - *Option 2 : L'API est appelée avec le nom de la commune de naissance et le code du département de naissance*. La date de naissance est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG.
+
+          - **Pour les particuliers nés à l'étranger**: le code COG pays doit être renseigné.
+
+          {:.fr-highlight}
+          > **Le code COG du pays de naissance est obligatoire pour tous les appels.** Pour simplifier le parcours des usagers, évitez de demander aux particuliers nés en France de saisir leur pays de naissance, puisque vous pouvez le paramétrer directement -code COG pays France `99100`-, dès qu'un particulier renseigne les informations de sa commune de naissance (forcément en France).
 

--- a/commons/endpoints/api_particulier/cnaf_msa_quotient_familial.yml
+++ b/commons/endpoints/api_particulier/cnaf_msa_quotient_familial.yml
@@ -74,33 +74,23 @@ fiche:
           <div class="fr-collapse" id="accordion-106">
           <div class="fr-mb-0">
           <ul>
-            <li>Nom de naissance<sup>*</sup>, nom d'usage, prénoms<sup>1</sup>, sexe<sup>*</sup>, date de naissance de l'allocataire<sup>**</sup>&nbsp;;</li>
-            <li>Lieu de naissance&nbsp;:
+            <li>Nom de naissance<sup>1</sup>, nom d'usage, prénoms<sup>3</sup>, sexe<sup>1</sup>, date de naissance de l'allocataire<sup>2</sup>, code COG du pays de naissance<sup>1</sup>&nbsp;;</li>
+            <li>Commune de naissance <em>(<a href="#poids-parametres-identification">fortement recommandé</a>)</em>&nbsp;: peut être renseignée de deux façons différentes :
             <ul>
-              <li>
-              <em>Si le lieu de naissance est en France,</em> la commune de naissance est obligatoire, elle peut être saisie de deux façons différentes :
-              <ul>
-                <li class="fr-text--sm fr-mb-0">
-                Option 1 : Code COG de la commune de naissance<sup>*</sup>. <a href="#renseigner-lieu-de-naissance">En savoir plus</a>&nbsp;;
-                </li>
-                <li class="fr-text--sm fr-mb-0">
-                Option 2 : Nom de la commune de naissance<sup>*</sup> et code du département de naissance<sup>*</sup>. Pour cette option, la date de naissance est obligatoire. <a href="#renseigner-lieu-de-naissance">En savoir plus</a>.
-                </li>
-              </ul>
-              Pour chacune des deux options ci-dessus, le code COG de la France <code>99100</code><sup>*</sup> doit également être renseigné en paramètre d'appel. Vous n'avez pas besoin de le demander à l'usager, il peut être déduit de la commune de naissance.
+              <li class="fr-text--sm fr-mb-0">
+              Option 1 : Code COG de la commune de naissance. <a href="#renseigner-lieu-de-naissance">En savoir plus</a>&nbsp;;
               </li>
-              <li class="fr-mt-2v">
-              <em>Si le lieu de naissance est à l'étranger&nbsp;:</em> code COG du pays de naissance<sup>*</sup>.
+              <li class="fr-text--sm fr-mb-0">
+              Option 2 : Nom de la commune de naissance et code du département de naissance. Pour cette option, la date de naissance est obligatoire. <a href="#renseigner-lieu-de-naissance">En savoir plus</a>.
               </li>
             </ul>
             </li>
           </ul>
           </div>
-          <span class="fr-text--xs">
-          <sup>*</sup> Obligatoire | <sup>**</sup> Obligatoire pour l'option 2 du lieu de naissance.
-          </span>
           <span class="fr-text--xs fr-m-0">
-          <sup>1</sup> Fournir plusieurs prénoms permet de limiter les risques d'homonymie mais un seul prénom peut fonctionner. Attention, l'usager doit compléter chaque prénom dans un champ distinct.
+          <sup>1</sup> Obligatoire<br>
+          <sup>2</sup> Obligatoire pour l'option 2 du lieu de naissance.<br>
+          <sup>3</sup> Fournir plusieurs prénoms permet de limiter les risques d'homonymie mais un seul prénom peut fonctionner. Attention, l'usager doit compléter chaque prénom dans un champ distinct.
           </span>
 
           </div>
@@ -193,11 +183,23 @@ fiche:
           _Voici les plafonds de rémunération pour que l'enfant soit considéré à charge, entre 2021 et 2024 :_
           ![Tableau décrivant les plafonds de rémunération de l'enfant majeur entre 2021 et 2024](<%= image_path('api_particulier/api-qf_plafond-remuneration-enfant-majeur.png') %>)
 
+      - q: <a name="poids-parametres-identification"></a> Quels paramètres ont le plus de poids dans l'algorithme d'identification ?
+        a: |+
+          L'algorithme d'identification du fournisseur de données s'appuie sur l'ensemble des paramètres d'entrée, mais certains ont un **poids plus important** :
+
+          - **Nom de naissance** ;
+          - **Année de naissance** ;
+          - **Lieu de naissance**.
+
+          Si ces trois informations sont correctement fournies, le particulier peut être identifié même si les autres paramètres comportent des erreurs. En revanche, si ces informations ne sont pas renseignées ou sont erronées, **le risque de recevoir une réponse 404** _(dossier allocataire absent)_ **augmente significativement**.
+
+          {:.fr-highlight}
+          > **Il est donc fortement recommandé de renseigner le lieu de naissance** afin de maximiser les chances d'identification du particulier.
       - q: <a name="renseigner-lieu-de-naissance"></a> Appel avec l'identité pivot, comment renseigner le lieu de naissance ?
         a: |+
-         Lorsque l'API est appelée avec l'identité pivot, pour identifier correctement le particulier, le système d'information a besoin de récupérer le lieu de naissance du particulier.
+         Lorsque l'API est appelée avec l'identité pivot, le lieu de naissance est [fortement recommandé](#poids-parametres-identification) pour identifier correctement le particulier.
 
-          - **Pour les particuliers nés en France**: le code COG pays `99100` est obigatoire. La commune de naissance est également obligatoire et peut-être renseignée via deux options différentes&nbsp;:
+          - **Pour les particuliers nés en France**: le code COG pays `99100` doit être renseigné. La commune de naissance peut être renseignée via deux options différentes&nbsp;:
 
               - *Option 1 : L'API est appelée avec le code COG commune lui-même*. Pour aider les usagers à renseigner leur code COG, consultez la publication suivante :
                 {:.fr-icon-arrow-right-line .fr-link--icon-right}
@@ -205,10 +207,10 @@ fiche:
 
               - *Option 2 : L'API est appelée avec le nom de la commune de naissance et le code du département de naissance*. La date de naissance est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG.
 
-          - **Pour les particuliers nés à l'étranger**: le code COG pays est obigatoire.
+          - **Pour les particuliers nés à l'étranger**: le code COG pays doit être renseigné.
 
           {:.fr-highlight}
-          > **Le code COG du pays de naissance est obligatoire pour tous les appels.** Pour simplifier le parcours des usagers, évitez de demander aux particuliers nés en France de saisir leur pays de naissance, puisque vous pouvez le paramétrer directement -code COG pays France `99100`-, dès qu'un particuloer renseigne les informations de sa commune de naissance (forcément en France).
+          > **Le code COG du pays de naissance est obligatoire pour tous les appels.** Pour simplifier le parcours des usagers, évitez de demander aux particuliers nés en France de saisir leur pays de naissance, puisque vous pouvez le paramétrer directement -code COG pays France `99100`-, dès qu'un particulier renseigne les informations de sa commune de naissance (forcément en France).
       - q: Comment connaître la caisse de rattachement (CNAF, MSA, RNCPS) en cas de 404 ?
         a: |+
           En cas de réponse 404 _(dossier allocataire absent)_, la caisse effectivement interrogée est indiquée dans le champ `meta.provider` de la réponse. Sa valeur peut être `CNAF`, `MSA` ou `RNCPS` selon la caisse de rattachement de l'allocataire.

--- a/commons/endpoints/api_particulier/cnav_allocation_adulte_handicape.yml
+++ b/commons/endpoints/api_particulier/cnav_allocation_adulte_handicape.yml
@@ -33,21 +33,17 @@ fiche:
         **Avec les données d'identité** : 
           
           {:.fr-mb-0}
-          - Nom de naissance<sup>\*</sup>, nom d'usage, prénoms<sup>1</sup>, sexe<sup>\*</sup>, date de naissance de l'allocataire<sup>\**</sup>&nbsp;;
-          - Lieu de naissance&nbsp;: 
-              - *Si le lieu de naissance est en France,* la commune de naissance est obligatoire, elle peut être saisie de deux façons différentes :
-                  - {:.fr-text--sm .fr-mb-0} Option 1 : Code COG de la commune de naissance<sup>\*</sup>. [En savoir plus](#renseigner-lieu-de-naissance)&nbsp;;
-                  - {:.fr-text--sm .fr-mb-0} Option 2 : Nom de la commune de naissance<sup>\*</sup> et code du département de naissance<sup>\*</sup>. Pour cette option, la date de naissance est obligatoire. [En savoir plus](#renseigner-lieu-de-naissance).
-                  
-                Pour chacune des deux options ci-dessus, le code COG de la France `99100`<sup>\*</sup> doit également être renseigné en paramètre d'appel. Vous n'avez pas besoin de le demander à l'usager, il peut être déduit de la commune de naissance.
-              - *Si le lieu de naissance est à l'étranger&nbsp;:* code COG du pays de naissance<sup>\*</sup>.
+          - Nom de naissance<sup>1</sup>, nom d'usage, prénoms<sup>3</sup>, sexe<sup>1</sup>, date de naissance de l'allocataire<sup>2</sup>, code COG du pays de naissance<sup>1</sup>&nbsp;;
+          - Commune de naissance _([fortement recommandé](#poids-parametres-identification))_&nbsp;:
+              - *Si le lieu de naissance est en France,* la commune de naissance peut être saisie de deux façons différentes :
+                  - {:.fr-text--sm .fr-mb-0} Option 1 : Code COG de la commune de naissance. [En savoir plus](#renseigner-lieu-de-naissance)&nbsp;;
+                  - {:.fr-text--sm .fr-mb-0} Option 2 : Nom de la commune de naissance et code du département de naissance. Pour cette option, la date de naissance est obligatoire. [En savoir plus](#renseigner-lieu-de-naissance).
 
 
-        <span class="fr-text--xs">
-        <sup>\*</sup> Obligatoire | <sup>\**</sup> Obligatoire pour l'option 2 du lieu de naissance.
-        </span>
         <span class="fr-text--xs fr-m-0">
-        <sup>1</sup> Fournir plusieurs prénoms permet de limiter les risques d'homonymie mais un seul prénom peut fonctionner. Attention, l'usager doit compléter chaque prénom dans un champ distinct.
+        <sup>1</sup> Obligatoire<br>
+        <sup>2</sup> Obligatoire pour l'option 2 du lieu de naissance.<br>
+        <sup>3</sup> Fournir plusieurs prénoms permet de limiter les risques d'homonymie mais un seul prénom peut fonctionner. Attention, l'usager doit compléter chaque prénom dans un champ distinct.
         </span>
 
         
@@ -79,22 +75,25 @@ fiche:
           - **Lieu de naissance**.
 
           Si ces trois informations sont correctement fournies, le particulier peut être identifié même si les autres paramètres comportent des erreurs. En revanche, si ces informations ne sont pas renseignées ou sont erronées, **le risque de recevoir une réponse 404** _(dossier allocataire absent)_ **augmente significativement**.
+
+          {:.fr-highlight}
+          > **Il est donc fortement recommandé de renseigner le lieu de naissance** afin de maximiser les chances d'identification du particulier.
       - q: <a name="renseigner-lieu-de-naissance"></a> Appel avec l'identité pivot, comment renseigner le lieu de naissance ?
         a: |+
-         Lorsque l'API est appelée avec l'identité pivot, pour identifier correctement le particulier, le système d'information a besoin de récupérer le lieu de naissance du particulier.
+         Lorsque l'API est appelée avec l'identité pivot, le lieu de naissance est [fortement recommandé](#poids-parametres-identification) pour identifier correctement le particulier.
 
-          - **Pour les particuliers nés en France**: le code COG pays `99100` est obigatoire. La commune de naissance est également obligatoire et peut-être renseignée via deux options différentes&nbsp;:
+          - **Pour les particuliers nés en France**: le code COG pays `99100` doit être renseigné. La commune de naissance peut être renseignée via deux options différentes&nbsp;:
 
               - *Option 1 : L'API est appelée avec le code COG commune lui-même*. Pour aider les usagers à renseigner leur code COG, consultez la publication suivante :
                 {:.fr-icon-arrow-right-line .fr-link--icon-right}
                 [✒️ **Aider les usagers à renseigner leur lieu de naissance par code COG** - Lire la publication du 08/11/2023](https://particulier.api.gouv.fr/blog/parametre-lieu-naissance-code-cog){:target="_blank"}
 
               - *Option 2 : L'API est appelée avec le nom de la commune de naissance et le code du département de naissance*. La date de naissance est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG.
-          
-          - **Pour les particuliers nés à l'étranger**: le code COG pays est obigatoire.
+
+          - **Pour les particuliers nés à l'étranger**: le code COG pays doit être renseigné.
 
           {:.fr-highlight}
-          > **Le code COG du pays de naissance est obligatoire pour tous les appels.** Pour simplifier le parcours des usagers, évitez de demander aux particuliers nés en France de saisir leur pays de naissance, puisque vous pouvez le paramétrer directement -code COG pays France `99100`-, dès qu'un particuloer renseigne les informations de sa commune de naissance (forcément en France).
+          > **Le code COG du pays de naissance est obligatoire pour tous les appels.** Pour simplifier le parcours des usagers, évitez de demander aux particuliers nés en France de saisir leur pays de naissance, puisque vous pouvez le paramétrer directement -code COG pays France `99100`-, dès qu'un particulier renseigne les informations de sa commune de naissance (forcément en France).
     historique: |+
       **Ce que change le passage à la V.3 d'API Particulier:**
 

--- a/commons/endpoints/api_particulier/cnav_allocation_soutien_familial.yml
+++ b/commons/endpoints/api_particulier/cnav_allocation_soutien_familial.yml
@@ -30,20 +30,16 @@ fiche:
         **Avec les données d'identité** : 
           
           {:.fr-mb-0}
-          - Nom de naissance<sup>\*</sup>, nom d'usage, prénoms<sup>1</sup>, sexe<sup>\*</sup>, date de naissance de l'allocataire<sup>\**</sup>&nbsp;;
-          - Lieu de naissance&nbsp;: 
-              - *Si le lieu de naissance est en France,* la commune de naissance est obligatoire, elle peut être saisie de deux façons différentes :
-                  - {:.fr-text--sm .fr-mb-0} Option 1 : Code COG de la commune de naissance<sup>\*</sup>. [En savoir plus](#renseigner-lieu-de-naissance)&nbsp;;
-                  - {:.fr-text--sm .fr-mb-0} Option 2 : Nom de la commune de naissance<sup>\*</sup> et code du département de naissance<sup>\*</sup>. Pour cette option, la date de naissance est obligatoire. [En savoir plus](#renseigner-lieu-de-naissance).
-                  
-                Pour chacune des deux options ci-dessus, le code COG de la France `99100`<sup>\*</sup> doit également être renseigné en paramètre d'appel. Vous n'avez pas besoin de le demander à l'usager, il peut être déduit de la commune de naissance.
-              - *Si le lieu de naissance est à l'étranger&nbsp;:* code COG du pays de naissance<sup>\*</sup>.
+          - Nom de naissance<sup>1</sup>, nom d'usage, prénoms<sup>3</sup>, sexe<sup>1</sup>, date de naissance de l'allocataire<sup>2</sup>, code COG du pays de naissance<sup>1</sup>&nbsp;;
+          - Commune de naissance _([fortement recommandé](#poids-parametres-identification))_&nbsp;:
+              - *Si le lieu de naissance est en France,* la commune de naissance peut être saisie de deux façons différentes :
+                  - {:.fr-text--sm .fr-mb-0} Option 1 : Code COG de la commune de naissance. [En savoir plus](#renseigner-lieu-de-naissance)&nbsp;;
+                  - {:.fr-text--sm .fr-mb-0} Option 2 : Nom de la commune de naissance et code du département de naissance. Pour cette option, la date de naissance est obligatoire. [En savoir plus](#renseigner-lieu-de-naissance).
 
-        <span class="fr-text--xs">
-        <sup>\*</sup> Obligatoire | <sup>\**</sup> Obligatoire pour l'option 2 du lieu de naissance.
-        </span>
         <span class="fr-text--xs fr-m-0">
-        <sup>1</sup> Fournir plusieurs prénoms permet de limiter les risques d'homonymie mais un seul prénom peut fonctionner. Attention, l'usager doit compléter chaque prénom dans un champ distinct.
+        <sup>1</sup> Obligatoire<br>
+        <sup>2</sup> Obligatoire pour l'option 2 du lieu de naissance.<br>
+        <sup>3</sup> Fournir plusieurs prénoms permet de limiter les risques d'homonymie mais un seul prénom peut fonctionner. Attention, l'usager doit compléter chaque prénom dans un champ distinct.
         </span>
 
        
@@ -74,22 +70,25 @@ fiche:
           - **Lieu de naissance**.
 
           Si ces trois informations sont correctement fournies, le particulier peut être identifié même si les autres paramètres comportent des erreurs. En revanche, si ces informations ne sont pas renseignées ou sont erronées, **le risque de recevoir une réponse 404** _(dossier allocataire absent)_ **augmente significativement**.
+
+          {:.fr-highlight}
+          > **Il est donc fortement recommandé de renseigner le lieu de naissance** afin de maximiser les chances d'identification du particulier.
       - q: <a name="renseigner-lieu-de-naissance"></a> Appel avec l'identité pivot, comment renseigner le lieu de naissance ?
         a: |+
-         Lorsque l'API est appelée avec l'identité pivot, pour identifier correctement le particulier, le système d'information a besoin de récupérer le lieu de naissance du particulier.
+         Lorsque l'API est appelée avec l'identité pivot, le lieu de naissance est [fortement recommandé](#poids-parametres-identification) pour identifier correctement le particulier.
 
-          - **Pour les particuliers nés en France**: le code COG pays `99100` est obigatoire. La commune de naissance est également obligatoire et peut-être renseignée via deux options différentes&nbsp;:
+          - **Pour les particuliers nés en France**: le code COG pays `99100` doit être renseigné. La commune de naissance peut être renseignée via deux options différentes&nbsp;:
 
               - *Option 1 : L'API est appelée avec le code COG commune lui-même*. Pour aider les usagers à renseigner leur code COG, consultez la publication suivante :
                 {:.fr-icon-arrow-right-line .fr-link--icon-right}
                 [✒️ **Aider les usagers à renseigner leur lieu de naissance par code COG** - Lire la publication du 08/11/2023](https://particulier.api.gouv.fr/blog/parametre-lieu-naissance-code-cog){:target="_blank"}
 
               - *Option 2 : L'API est appelée avec le nom de la commune de naissance et le code du département de naissance*. La date de naissance est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG.
-          
-          - **Pour les particuliers nés à l'étranger**: le code COG pays est obigatoire.
+
+          - **Pour les particuliers nés à l'étranger**: le code COG pays doit être renseigné.
 
           {:.fr-highlight}
-          > **Le code COG du pays de naissance est obligatoire pour tous les appels.** Pour simplifier le parcours des usagers, évitez de demander aux particuliers nés en France de saisir leur pays de naissance, puisque vous pouvez le paramétrer directement -code COG pays France `99100`-, dès qu'un particuloer renseigne les informations de sa commune de naissance (forcément en France).
+          > **Le code COG du pays de naissance est obligatoire pour tous les appels.** Pour simplifier le parcours des usagers, évitez de demander aux particuliers nés en France de saisir leur pays de naissance, puisque vous pouvez le paramétrer directement -code COG pays France `99100`-, dès qu'un particulier renseigne les informations de sa commune de naissance (forcément en France).
 
     historique: |+
       **Ce que change le passage à la V.3 d'API Particulier:**

--- a/commons/endpoints/api_particulier/cnav_complementaire_sante_solidaire.yml
+++ b/commons/endpoints/api_particulier/cnav_complementaire_sante_solidaire.yml
@@ -35,21 +35,17 @@ fiche:
         **Avec les données d'identité** : 
           
           {:.fr-mb-0}
-          - Nom de naissance<sup>\*</sup>, nom d'usage, prénoms<sup>1</sup>, sexe<sup>\*</sup>, date de naissance de l'allocataire<sup>\**</sup>&nbsp;;
-          - Lieu de naissance&nbsp;: 
-              - *Si le lieu de naissance est en France,* la commune de naissance est obligatoire, elle peut être saisie de deux façons différentes :
-                  - {:.fr-text--sm .fr-mb-0} Option 1 : Code COG de la commune de naissance<sup>\*</sup>. [En savoir plus](#renseigner-lieu-de-naissance)&nbsp;;
-                  - {:.fr-text--sm .fr-mb-0} Option 2 : Nom de la commune de naissance<sup>\*</sup> et code du département de naissance<sup>\*</sup>. Pour cette option, la date de naissance est obligatoire. [En savoir plus](#renseigner-lieu-de-naissance).
-                  
-                Pour chacune des deux options ci-dessus, le code COG de la France `99100`<sup>\*</sup> doit également être renseigné en paramètre d'appel. Vous n'avez pas besoin de le demander à l'usager, il peut être déduit de la commune de naissance.
-              - *Si le lieu de naissance est à l'étranger&nbsp;:* code COG du pays de naissance<sup>\*</sup>.
+          - Nom de naissance<sup>1</sup>, nom d'usage, prénoms<sup>3</sup>, sexe<sup>1</sup>, date de naissance de l'allocataire<sup>2</sup>, code COG du pays de naissance<sup>1</sup>&nbsp;;
+          - Commune de naissance _([fortement recommandé](#poids-parametres-identification))_&nbsp;:
+              - *Si le lieu de naissance est en France,* la commune de naissance peut être saisie de deux façons différentes :
+                  - {:.fr-text--sm .fr-mb-0} Option 1 : Code COG de la commune de naissance. [En savoir plus](#renseigner-lieu-de-naissance)&nbsp;;
+                  - {:.fr-text--sm .fr-mb-0} Option 2 : Nom de la commune de naissance et code du département de naissance. Pour cette option, la date de naissance est obligatoire. [En savoir plus](#renseigner-lieu-de-naissance).
 
 
-        <span class="fr-text--xs">
-        <sup>\*</sup> Obligatoire | <sup>\**</sup> Obligatoire pour l'option 2 du lieu de naissance.
-        </span>
         <span class="fr-text--xs fr-m-0">
-        <sup>1</sup> Fournir plusieurs prénoms permet de limiter les risques d'homonymie mais un seul prénom peut fonctionner. Attention, l'usager doit compléter chaque prénom dans un champ distinct.
+        <sup>1</sup> Obligatoire<br>
+        <sup>2</sup> Obligatoire pour l'option 2 du lieu de naissance.<br>
+        <sup>3</sup> Fournir plusieurs prénoms permet de limiter les risques d'homonymie mais un seul prénom peut fonctionner. Attention, l'usager doit compléter chaque prénom dans un champ distinct.
         </span>
     data:
       description: |+
@@ -82,6 +78,9 @@ fiche:
           - **Lieu de naissance**.
 
           Si ces trois informations sont correctement fournies, le particulier peut être identifié même si les autres paramètres comportent des erreurs. En revanche, si ces informations ne sont pas renseignées ou sont erronées, **le risque de recevoir une réponse 404** _(dossier allocataire absent)_ **augmente significativement**.
+
+          {:.fr-highlight}
+          > **Il est donc fortement recommandé de renseigner le lieu de naissance** afin de maximiser les chances d'identification du particulier.
       - q: "Qu'est-ce qu'une complémentaire santé solidaire ?"
         a: |+
           La complémentaire santé solidaire est une **aide versée par l'assurance maladie sous conditions de ressources et de résidence**. Elle prend en charge la part des dépenses de santé qui ne sont pas remboursées par la sécurité sociale et permet d'accéder à d'autres avantages.
@@ -95,20 +94,20 @@ fiche:
           **En savoir plus sur les conditions d'accès** : [complementaire-sante-solidaire.gouv.fr](https://www.complementaire-sante-solidaire.gouv.fr/complementairesantesolidaire.php){:target="_blank"}.
       - q: <a name="renseigner-lieu-de-naissance"></a> Appel avec l'identité pivot, comment renseigner le lieu de naissance ?
         a: |+
-         Lorsque l'API est appelée avec l'identité pivot, pour identifier correctement le particulier, le système d'information a besoin de récupérer le lieu de naissance du particulier.
+         Lorsque l'API est appelée avec l'identité pivot, le lieu de naissance est [fortement recommandé](#poids-parametres-identification) pour identifier correctement le particulier.
 
-          - **Pour les particuliers nés en France**: le code COG pays `99100` est obigatoire. La commune de naissance est également obligatoire et peut-être renseignée via deux options différentes&nbsp;:
+          - **Pour les particuliers nés en France**: le code COG pays `99100` doit être renseigné. La commune de naissance peut être renseignée via deux options différentes&nbsp;:
 
               - *Option 1 : L'API est appelée avec le code COG commune lui-même*. Pour aider les usagers à renseigner leur code COG, consultez la publication suivante :
                 {:.fr-icon-arrow-right-line .fr-link--icon-right}
                 [✒️ **Aider les usagers à renseigner leur lieu de naissance par code COG** - Lire la publication du 08/11/2023](https://particulier.api.gouv.fr/blog/parametre-lieu-naissance-code-cog){:target="_blank"}
 
               - *Option 2 : L'API est appelée avec le nom de la commune de naissance et le code du département de naissance*. La date de naissance est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG.
-          
-          - **Pour les particuliers nés à l'étranger**: le code COG pays est obigatoire.
+
+          - **Pour les particuliers nés à l'étranger**: le code COG pays doit être renseigné.
 
           {:.fr-highlight}
-          > **Le code COG du pays de naissance est obligatoire pour tous les appels.** Pour simplifier le parcours des usagers, évitez de demander aux particuliers nés en France de saisir leur pays de naissance, puisque vous pouvez le paramétrer directement -code COG pays France `99100`-, dès qu'un particuloer renseigne les informations de sa commune de naissance (forcément en France).
+          > **Le code COG du pays de naissance est obligatoire pour tous les appels.** Pour simplifier le parcours des usagers, évitez de demander aux particuliers nés en France de saisir leur pays de naissance, puisque vous pouvez le paramétrer directement -code COG pays France `99100`-, dès qu'un particulier renseigne les informations de sa commune de naissance (forcément en France).
 
     historique: |+
       **Ce que change le passage à la V.3 d'API Particulier:**

--- a/commons/endpoints/api_particulier/cnav_prime_activite.yml
+++ b/commons/endpoints/api_particulier/cnav_prime_activite.yml
@@ -33,21 +33,17 @@ fiche:
         **Avec les données d'identité** : 
           
           {:.fr-mb-0}
-          - Nom de naissance<sup>\*</sup>, nom d'usage, prénoms<sup>1</sup>, sexe<sup>\*</sup>, date de naissance de l'allocataire<sup>\**</sup>&nbsp;;
-          - Lieu de naissance&nbsp;: 
-              - *Si le lieu de naissance est en France,* la commune de naissance est obligatoire, elle peut être saisie de deux façons différentes :
-                  - {:.fr-text--sm .fr-mb-0} Option 1 : Code COG de la commune de naissance<sup>\*</sup>. [En savoir plus](#renseigner-lieu-de-naissance)&nbsp;;
-                  - {:.fr-text--sm .fr-mb-0} Option 2 : Nom de la commune de naissance<sup>\*</sup> et code du département de naissance<sup>\*</sup>. Pour cette option, la date de naissance est obligatoire. [En savoir plus](#renseigner-lieu-de-naissance).
-                  
-                Pour chacune des deux options ci-dessus, le code COG de la France `99100`<sup>\*</sup> doit également être renseigné en paramètre d'appel. Vous n'avez pas besoin de le demander à l'usager, il peut être déduit de la commune de naissance.
-              - *Si le lieu de naissance est à l'étranger&nbsp;:* code COG du pays de naissance<sup>\*</sup>.
+          - Nom de naissance<sup>1</sup>, nom d'usage, prénoms<sup>3</sup>, sexe<sup>1</sup>, date de naissance de l'allocataire<sup>2</sup>, code COG du pays de naissance<sup>1</sup>&nbsp;;
+          - Commune de naissance _([fortement recommandé](#poids-parametres-identification))_&nbsp;:
+              - *Si le lieu de naissance est en France,* la commune de naissance peut être saisie de deux façons différentes :
+                  - {:.fr-text--sm .fr-mb-0} Option 1 : Code COG de la commune de naissance. [En savoir plus](#renseigner-lieu-de-naissance)&nbsp;;
+                  - {:.fr-text--sm .fr-mb-0} Option 2 : Nom de la commune de naissance et code du département de naissance. Pour cette option, la date de naissance est obligatoire. [En savoir plus](#renseigner-lieu-de-naissance).
 
 
-        <span class="fr-text--xs">
-        <sup>\*</sup> Obligatoire | <sup>\**</sup> Obligatoire pour l'option 2 du lieu de naissance.
-        </span>
         <span class="fr-text--xs fr-m-0">
-        <sup>1</sup> Fournir plusieurs prénoms permet de limiter les risques d'homonymie mais un seul prénom peut fonctionner. Attention, l'usager doit compléter chaque prénom dans un champ distinct.
+        <sup>1</sup> Obligatoire<br>
+        <sup>2</sup> Obligatoire pour l'option 2 du lieu de naissance.<br>
+        <sup>3</sup> Fournir plusieurs prénoms permet de limiter les risques d'homonymie mais un seul prénom peut fonctionner. Attention, l'usager doit compléter chaque prénom dans un champ distinct.
         </span>
     data:
       description: |+
@@ -76,22 +72,25 @@ fiche:
           - **Lieu de naissance**.
 
           Si ces trois informations sont correctement fournies, le particulier peut être identifié même si les autres paramètres comportent des erreurs. En revanche, si ces informations ne sont pas renseignées ou sont erronées, **le risque de recevoir une réponse 404** _(dossier allocataire absent)_ **augmente significativement**.
+
+          {:.fr-highlight}
+          > **Il est donc fortement recommandé de renseigner le lieu de naissance** afin de maximiser les chances d'identification du particulier.
       - q: <a name="renseigner-lieu-de-naissance"></a> Appel avec l'identité pivot, comment renseigner le lieu de naissance ?
         a: |+
-         Lorsque l'API est appelée avec l'identité pivot, pour identifier correctement le particulier, le système d'information a besoin de récupérer le lieu de naissance du particulier.
+         Lorsque l'API est appelée avec l'identité pivot, le lieu de naissance est [fortement recommandé](#poids-parametres-identification) pour identifier correctement le particulier.
 
-          - **Pour les particuliers nés en France**: le code COG pays `99100` est obigatoire. La commune de naissance est également obligatoire et peut-être renseignée via deux options différentes&nbsp;:
+          - **Pour les particuliers nés en France**: le code COG pays `99100` doit être renseigné. La commune de naissance peut être renseignée via deux options différentes&nbsp;:
 
               - *Option 1 : L'API est appelée avec le code COG commune lui-même*. Pour aider les usagers à renseigner leur code COG, consultez la publication suivante :
                 {:.fr-icon-arrow-right-line .fr-link--icon-right}
                 [✒️ **Aider les usagers à renseigner leur lieu de naissance par code COG** - Lire la publication du 08/11/2023](https://particulier.api.gouv.fr/blog/parametre-lieu-naissance-code-cog){:target="_blank"}
 
               - *Option 2 : L'API est appelée avec le nom de la commune de naissance et le code du département de naissance*. La date de naissance est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG.
-          
-          - **Pour les particuliers nés à l'étranger**: le code COG pays est obigatoire.
+
+          - **Pour les particuliers nés à l'étranger**: le code COG pays doit être renseigné.
 
           {:.fr-highlight}
-          > **Le code COG du pays de naissance est obligatoire pour tous les appels.** Pour simplifier le parcours des usagers, évitez de demander aux particuliers nés en France de saisir leur pays de naissance, puisque vous pouvez le paramétrer directement -code COG pays France `99100`-, dès qu'un particuloer renseigne les informations de sa commune de naissance (forcément en France).
+          > **Le code COG du pays de naissance est obligatoire pour tous les appels.** Pour simplifier le parcours des usagers, évitez de demander aux particuliers nés en France de saisir leur pays de naissance, puisque vous pouvez le paramétrer directement -code COG pays France `99100`-, dès qu'un particulier renseigne les informations de sa commune de naissance (forcément en France).
 
     historique: |+
       **Ce que change le passage à la V.3 d'API Particulier:**

--- a/commons/endpoints/api_particulier/cnav_revenu_solidarite_active.yml
+++ b/commons/endpoints/api_particulier/cnav_revenu_solidarite_active.yml
@@ -33,16 +33,15 @@ fiche:
         **Avec les données d'identité** : 
           
           {:.fr-mb-0}
-          - Nom de naissance<sup>\*</sup>, nom d'usage, prénoms<sup>1</sup>, sexe<sup>\*</sup>, date de naissance de l'allocataire<sup>\**</sup>, code COG du pays de naissance<sup>\*</sup>.
-          - Commune de naissance qui peut être renseignée de deux façons différentes :
-              - {:.fr-text--sm .fr-mb-0} Option 1 : Code COG<sup>\*</sup> de la commune de naissance si le lieu de naissance est en France. [En savoir plus](#renseigner-lieu-de-naissance)&nbsp;;
-              - {:.fr-text--sm .fr-mb-0} Option 2 : Nom<sup>\*</sup> de la commune de naissance et code<sup>\*</sup> du département de naissance. Pour cette option, la date de naissance est obligatoire. [En savoir plus](#renseigner-lieu-de-naissance).
+          - Nom de naissance<sup>1</sup>, nom d'usage, prénoms<sup>3</sup>, sexe<sup>1</sup>, date de naissance de l'allocataire<sup>2</sup>, code COG du pays de naissance<sup>1</sup>&nbsp;;
+          - Commune de naissance _([fortement recommandé](#poids-parametres-identification))_&nbsp;: peut être renseignée de deux façons différentes :
+              - {:.fr-text--sm .fr-mb-0} Option 1 : Code COG de la commune de naissance si le lieu de naissance est en France. [En savoir plus](#renseigner-lieu-de-naissance)&nbsp;;
+              - {:.fr-text--sm .fr-mb-0} Option 2 : Nom de la commune de naissance et code du département de naissance. Pour cette option, la date de naissance est obligatoire. [En savoir plus](#renseigner-lieu-de-naissance).
 
-        <span class="fr-text--xs">
-        <sup>\*</sup> Obligatoire | <sup>\**</sup> Obligatoire pour l'option 2 du lieu de naissance.
-        </span>
         <span class="fr-text--xs fr-m-0">
-        <sup>1</sup> Fournir plusieurs prénoms permet de limiter les risques d'homonymie mais un seul prénom peut fonctionner. Attention, l'usager doit compléter chaque prénom dans un champ distinct.
+        <sup>1</sup> Obligatoire<br>
+        <sup>2</sup> Obligatoire pour l'option 2 du lieu de naissance.<br>
+        <sup>3</sup> Fournir plusieurs prénoms permet de limiter les risques d'homonymie mais un seul prénom peut fonctionner. Attention, l'usager doit compléter chaque prénom dans un champ distinct.
         </span>
     data:
       description: |+
@@ -71,24 +70,27 @@ fiche:
           - **Lieu de naissance**.
 
           Si ces trois informations sont correctement fournies, le particulier peut être identifié même si les autres paramètres comportent des erreurs. En revanche, si ces informations ne sont pas renseignées ou sont erronées, **le risque de recevoir une réponse 404** _(dossier allocataire absent)_ **augmente significativement**.
+
+          {:.fr-highlight}
+          > **Il est donc fortement recommandé de renseigner le lieu de naissance** afin de maximiser les chances d'identification du particulier.
       - q: <a name="renseigner-lieu-de-naissance"></a> Appel avec l'identité pivot, comment renseigner le lieu de naissance ?
         a: |+
-          Lorsque l'API est appelée avec l'identité pivot, pour identifier correctement le particulier, le système d'information a besoin de récupérer le code COG du lieu de naissance de l'usager.
-          
+          Lorsque l'API est appelée avec l'identité pivot, le lieu de naissance est [fortement recommandé](#poids-parametres-identification) pour identifier correctement le particulier.
+
           La déduction du code COG peut être obtenue via deux options différentes :
-            
+
           **Option 1 : L'API est appelée avec le code COG lui-même**
 
           Cette option est à privilégier car elle couvre l'ensemble des usagers, y compris ceux nés à l'étranger et ceux nés dans un pays étranger autrefois rattaché à la France.
-          
+
           Toutefois, cette option nécessite de disposer du code COG de la commune ou du pays de naissance. Pour aider les usagers à renseigner leur code COG, consultez la publication suivante :
 
           {:.fr-icon-arrow-right-line .fr-link--icon-right}
           [✒️ **Aider les usagers à renseigner leur lieu de naissance par code COG** - Lire la publication du 08/11/2023](https://particulier.api.gouv.fr/blog/parametre-lieu-naissance-code-cog){:target="_blank"}
 
-          **Option 2 : L'API est appelée avec le nom de la commune de naissance et code* du département de naissance**
+          **Option 2 : L'API est appelée avec le nom de la commune de naissance et le code du département de naissance**
 
-          Cette option à pour objectif de faciliter vos développements, mais elle n'est pas exhaustive puisque les usagers nés à l'étranger ne pourront pas être identifiés. 
+          Cette option a pour objectif de faciliter vos développements, mais elle n'est pas exhaustive puisque les usagers nés à l'étranger ne pourront pas être identifiés.
 
           Avec cette option, vous pouvez appeler l'API avec le nom de la commune de naissance et le code du département de naissance. La date de naissance est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG.
     historique: |+

--- a/commons/swagger/openapi-particulierv2.yaml
+++ b/commons/swagger/openapi-particulierv2.yaml
@@ -139,9 +139,8 @@ paths:
           example: '08480'
         description: Code Insee à 5 chiffres du lieu de naissance de la personne.
           Ne pas remplir si la personne est née à l'étranger ou si présence de jeton
-          FranceConnect. En l'absence de jeton FranceConnect et du triplet (nomCommuneNaissance,
-          anneeDateDeNaissance, codeInseeDepartementNaissance), le champ est obligatoire
-          si la personne est née en France
+          FranceConnect. Fortement recommandé pour les personnes nées en France afin
+          de maximiser les chances d'identification.
         required: false
       - name: codePaysLieuDeNaissance
         in: query
@@ -170,9 +169,9 @@ paths:
           type: string
           minLength: 1
           example: Gennevilliers
-        description: Nom de la commune de naissance. En l'absence de jeton FranceConnect
-          et du codeInseeLieuDeNaissance, ce paramètre est obligatoire si la personne
-          est née en France
+        description: Nom de la commune de naissance. Fortement recommandé pour les
+          personnes nées en France. Alternative au codeInseeLieuDeNaissance, à utiliser
+          avec codeInseeDepartementNaissance et la date de naissance complète.
         required: false
       - name: codeInseeDepartementNaissance
         in: query
@@ -181,9 +180,9 @@ paths:
           minLength: 2
           maxLength: 3
           example: '92'
-        description: Code INSEE du département de naissance. En l'absence de jeton
-          FranceConnect et du codeInseeLieuDeNaissance, ce paramètre est obligatoire
-          si la personne est née en France
+        description: Code INSEE du département de naissance. Fortement recommandé
+          pour les personnes nées en France. À utiliser avec nomCommuneNaissance et
+          la date de naissance complète.
         required: false
       - name: recipient
         in: query
@@ -444,9 +443,8 @@ paths:
           example: '08480'
         description: Code Insee à 5 chiffres du lieu de naissance de la personne.
           Ne pas remplir si la personne est née à l'étranger ou si présence de jeton
-          FranceConnect. En l'absence de jeton FranceConnect et du triplet (nomCommuneNaissance,
-          anneeDateDeNaissance, codeInseeDepartementNaissance), le champ est obligatoire
-          si la personne est née en France
+          FranceConnect. Fortement recommandé pour les personnes nées en France afin
+          de maximiser les chances d'identification.
         required: false
       - name: codePaysLieuDeNaissance
         in: query
@@ -475,9 +473,9 @@ paths:
           type: string
           minLength: 1
           example: Gennevilliers
-        description: Nom de la commune de naissance. En l'absence de jeton FranceConnect
-          et du codeInseeLieuDeNaissance, ce paramètre est obligatoire si la personne
-          est née en France
+        description: Nom de la commune de naissance. Fortement recommandé pour les
+          personnes nées en France. Alternative au codeInseeLieuDeNaissance, à utiliser
+          avec codeInseeDepartementNaissance et la date de naissance complète.
         required: false
       - name: codeInseeDepartementNaissance
         in: query
@@ -486,9 +484,9 @@ paths:
           minLength: 2
           maxLength: 3
           example: '92'
-        description: Code INSEE du département de naissance. En l'absence de jeton
-          FranceConnect et du codeInseeLieuDeNaissance, ce paramètre est obligatoire
-          si la personne est née en France
+        description: Code INSEE du département de naissance. Fortement recommandé
+          pour les personnes nées en France. À utiliser avec nomCommuneNaissance et
+          la date de naissance complète.
         required: false
       security:
       - franceConnectToken: []
@@ -747,9 +745,8 @@ paths:
           example: '08480'
         description: Code Insee à 5 chiffres du lieu de naissance de la personne.
           Ne pas remplir si la personne est née à l'étranger ou si présence de jeton
-          FranceConnect. En l'absence de jeton FranceConnect et du triplet (nomCommuneNaissance,
-          anneeDateDeNaissance, codeInseeDepartementNaissance), le champ est obligatoire
-          si la personne est née en France
+          FranceConnect. Fortement recommandé pour les personnes nées en France afin
+          de maximiser les chances d'identification.
         required: false
       - name: codePaysLieuDeNaissance
         in: query
@@ -778,9 +775,9 @@ paths:
           type: string
           minLength: 1
           example: Gennevilliers
-        description: Nom de la commune de naissance. En l'absence de jeton FranceConnect
-          et du codeInseeLieuDeNaissance, ce paramètre est obligatoire si la personne
-          est née en France
+        description: Nom de la commune de naissance. Fortement recommandé pour les
+          personnes nées en France. Alternative au codeInseeLieuDeNaissance, à utiliser
+          avec codeInseeDepartementNaissance et la date de naissance complète.
         required: false
       - name: codeInseeDepartementNaissance
         in: query
@@ -789,9 +786,9 @@ paths:
           minLength: 2
           maxLength: 3
           example: '92'
-        description: Code INSEE du département de naissance. En l'absence de jeton
-          FranceConnect et du codeInseeLieuDeNaissance, ce paramètre est obligatoire
-          si la personne est née en France
+        description: Code INSEE du département de naissance. Fortement recommandé
+          pour les personnes nées en France. À utiliser avec nomCommuneNaissance et
+          la date de naissance complète.
         required: false
       security:
       - franceConnectToken: []
@@ -1061,9 +1058,8 @@ paths:
           example: '08480'
         description: Code Insee à 5 chiffres du lieu de naissance de la personne.
           Ne pas remplir si la personne est née à l'étranger ou si présence de jeton
-          FranceConnect. En l'absence de jeton FranceConnect et du triplet (nomCommuneNaissance,
-          anneeDateDeNaissance, codeInseeDepartementNaissance), le champ est obligatoire
-          si la personne est née en France
+          FranceConnect. Fortement recommandé pour les personnes nées en France afin
+          de maximiser les chances d'identification.
         required: false
       - name: codePaysLieuDeNaissance
         in: query
@@ -1092,9 +1088,9 @@ paths:
           type: string
           minLength: 1
           example: Gennevilliers
-        description: Nom de la commune de naissance. En l'absence de jeton FranceConnect
-          et du codeInseeLieuDeNaissance, ce paramètre est obligatoire si la personne
-          est née en France
+        description: Nom de la commune de naissance. Fortement recommandé pour les
+          personnes nées en France. Alternative au codeInseeLieuDeNaissance, à utiliser
+          avec codeInseeDepartementNaissance et la date de naissance complète.
         required: false
       - name: codeInseeDepartementNaissance
         in: query
@@ -1103,9 +1099,9 @@ paths:
           minLength: 2
           maxLength: 3
           example: '92'
-        description: Code INSEE du département de naissance. En l'absence de jeton
-          FranceConnect et du codeInseeLieuDeNaissance, ce paramètre est obligatoire
-          si la personne est née en France
+        description: Code INSEE du département de naissance. Fortement recommandé
+          pour les personnes nées en France. À utiliser avec nomCommuneNaissance et
+          la date de naissance complète.
         required: false
       security:
       - franceConnectToken: []
@@ -1372,9 +1368,8 @@ paths:
           example: '08480'
         description: Code Insee à 5 chiffres du lieu de naissance de la personne.
           Ne pas remplir si la personne est née à l'étranger ou si présence de jeton
-          FranceConnect. En l'absence de jeton FranceConnect et du triplet (nomCommuneNaissance,
-          anneeDateDeNaissance, codeInseeDepartementNaissance), le champ est obligatoire
-          si la personne est née en France
+          FranceConnect. Fortement recommandé pour les personnes nées en France afin
+          de maximiser les chances d'identification.
         required: false
       - name: codePaysLieuDeNaissance
         in: query
@@ -1403,9 +1398,9 @@ paths:
           type: string
           minLength: 1
           example: Gennevilliers
-        description: Nom de la commune de naissance. En l'absence de jeton FranceConnect
-          et du codeInseeLieuDeNaissance, ce paramètre est obligatoire si la personne
-          est née en France
+        description: Nom de la commune de naissance. Fortement recommandé pour les
+          personnes nées en France. Alternative au codeInseeLieuDeNaissance, à utiliser
+          avec codeInseeDepartementNaissance et la date de naissance complète.
         required: false
       - name: codeInseeDepartementNaissance
         in: query
@@ -1414,9 +1409,9 @@ paths:
           minLength: 2
           maxLength: 3
           example: '92'
-        description: Code INSEE du département de naissance. En l'absence de jeton
-          FranceConnect et du codeInseeLieuDeNaissance, ce paramètre est obligatoire
-          si la personne est née en France
+        description: Code INSEE du département de naissance. Fortement recommandé
+          pour les personnes nées en France. À utiliser avec nomCommuneNaissance et
+          la date de naissance complète.
         required: false
       - name: annee
         in: query
@@ -1928,9 +1923,8 @@ paths:
           example: '08480'
         description: Code Insee à 5 chiffres du lieu de naissance de la personne.
           Ne pas remplir si la personne est née à l'étranger ou si présence de jeton
-          FranceConnect. En l'absence de jeton FranceConnect et du triplet (nomCommuneNaissance,
-          anneeDateDeNaissance, codeInseeDepartementNaissance), le champ est obligatoire
-          si la personne est née en France
+          FranceConnect. Fortement recommandé pour les personnes nées en France afin
+          de maximiser les chances d'identification.
         required: false
       - name: codePaysLieuDeNaissance
         in: query
@@ -1959,9 +1953,9 @@ paths:
           type: string
           minLength: 1
           example: Gennevilliers
-        description: Nom de la commune de naissance. En l'absence de jeton FranceConnect
-          et du codeInseeLieuDeNaissance, ce paramètre est obligatoire si la personne
-          est née en France
+        description: Nom de la commune de naissance. Fortement recommandé pour les
+          personnes nées en France. Alternative au codeInseeLieuDeNaissance, à utiliser
+          avec codeInseeDepartementNaissance et la date de naissance complète.
         required: false
       - name: codeInseeDepartementNaissance
         in: query
@@ -1970,9 +1964,9 @@ paths:
           minLength: 2
           maxLength: 3
           example: '92'
-        description: Code INSEE du département de naissance. En l'absence de jeton
-          FranceConnect et du codeInseeLieuDeNaissance, ce paramètre est obligatoire
-          si la personne est née en France
+        description: Code INSEE du département de naissance. Fortement recommandé
+          pour les personnes nées en France. À utiliser avec nomCommuneNaissance et
+          la date de naissance complète.
         required: false
       security:
       - franceConnectToken: []

--- a/siade/app/interactors/cnav/validate_code_cog_insee_commune_naissance_or_transcogage_params.rb
+++ b/siade/app/interactors/cnav/validate_code_cog_insee_commune_naissance_or_transcogage_params.rb
@@ -11,12 +11,10 @@ class CNAV::ValidateCodeCogINSEECommuneNaissanceOrTranscogageParams < ValidatePa
   private
 
   def call_validator
-    if code_cog_insee_commune_naissance? || !france?
+    if code_cog_insee_commune_naissance?
       CNAV::ValidateCodeCogINSEECommuneNaissance.call(params: context.params)
     elsif transcogage_params?
       INSEE::CommuneINSEECode::ValidateParams.call(params: context.params)
-    else
-      invalid_param!(:birth_place)
     end
   end
 
@@ -26,13 +24,5 @@ class CNAV::ValidateCodeCogINSEECommuneNaissanceOrTranscogageParams < ValidatePa
 
   def transcogage_params?
     %i[nom_commune_naissance annee_date_naissance code_cog_insee_departement_naissance].all? { |key| context.params[key].present? }
-  end
-
-  def france?
-    code_cog_insee_pays_naissance == '99100'
-  end
-
-  def code_cog_insee_pays_naissance
-    param(:code_cog_insee_pays_naissance).to_s
   end
 end

--- a/siade/spec/controllers/api_particulier/v3_and_more/cnav/abstract_civility_controller_spec.rb
+++ b/siade/spec/controllers/api_particulier/v3_and_more/cnav/abstract_civility_controller_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe APIParticulier::V3AndMore::CNAV::AbstractCivilityController do
       end
     end
 
-    context 'with missing required param for transcogage (departement naissance)' do
+    context 'with missing departement naissance (commune params are optional)' do
       let(:params) do
         {
           recipient:,
@@ -94,10 +94,10 @@ RSpec.describe APIParticulier::V3AndMore::CNAV::AbstractCivilityController do
         }
       end
 
-      it 'returns 422' do
+      it 'returns 200' do
         subject
 
-        expect(response).to have_http_status(:unprocessable_content)
+        expect(response).to have_http_status(:ok)
       end
     end
   end

--- a/siade/spec/interactors/cnav/validate_code_cog_insee_commune_naissance_or_transcogage_params_spec.rb
+++ b/siade/spec/interactors/cnav/validate_code_cog_insee_commune_naissance_or_transcogage_params_spec.rb
@@ -4,8 +4,14 @@ RSpec.describe CNAV::ValidateCodeCogINSEECommuneNaissanceOrTranscogageParams, ty
   describe 'with code insee lieu de naissance' do
     let(:params) { { code_cog_insee_commune_naissance:, code_cog_insee_pays_naissance: '99100' } }
 
-    context 'when it is not valid' do
+    context 'when it is not provided' do
       let(:code_cog_insee_commune_naissance) { nil }
+
+      it { is_expected.to be_a_success }
+    end
+
+    context 'when it is provided but invalid' do
+      let(:code_cog_insee_commune_naissance) { 'invalid' }
 
       it { is_expected.to be_a_failure }
 
@@ -48,17 +54,13 @@ RSpec.describe CNAV::ValidateCodeCogINSEECommuneNaissanceOrTranscogageParams, ty
     describe 'when in france' do
       let(:params) { { code_cog_insee_pays_naissance: '99100' } }
 
-      it { is_expected.to be_a_failure }
-
-      its(:errors) { is_expected.to include(instance_of(UnprocessableEntityError)) }
+      it { is_expected.to be_a_success }
     end
 
     describe 'when not in france' do
       let(:params) { { code_cog_insee_pays_naissance: '99345' } }
 
       it { is_expected.to be_a_success }
-
-      its(:errors) { is_expected.to be_empty }
     end
   end
 end

--- a/siade/spec/organizers/cnav/quotient_familial_v2/validate_params_spec.rb
+++ b/siade/spec/organizers/cnav/quotient_familial_v2/validate_params_spec.rb
@@ -101,9 +101,9 @@ RSpec.describe CNAV::QuotientFamilialV2::ValidateParams, type: :validate_params 
       let(:code_cog_insee_commune_naissance) { nil }
       let(:code_cog_insee_pays_naissance) { '99100' }
 
-      it { is_expected.to be_a_failure }
+      it { is_expected.to be_a_success }
 
-      its(:errors) { is_expected.to include(instance_of(UnprocessableEntityError)) }
+      its(:errors) { is_expected.to be_empty }
     end
 
     describe 'with empty params for lieu de naissance and not in france' do

--- a/siade/spec/organizers/cnav/validate_params_spec.rb
+++ b/siade/spec/organizers/cnav/validate_params_spec.rb
@@ -94,9 +94,9 @@ RSpec.describe CNAV::ValidateParams, type: :validate_params do
       let(:code_cog_insee_commune_naissance) { nil }
       let(:code_cog_insee_pays_naissance) { '99100' }
 
-      it { is_expected.to be_a_failure }
+      it { is_expected.to be_a_success }
 
-      its(:errors) { is_expected.to include(instance_of(UnprocessableEntityError)) }
+      its(:errors) { is_expected.to be_empty }
     end
 
     describe 'with empty params for lieu de naissance and not in france' do

--- a/site/config/changelogs.yml
+++ b/site/config/changelogs.yml
@@ -1,3 +1,9 @@
+- date: 2026-05-12
+  scope: api_particulier
+  title: "Endpoints CNAV : paramètres de lieu de naissance désormais fortement recommandés"
+  description: |
+    Sur l'ensemble des endpoints CNAV appelés avec l'identité pivot ([AAH](<%= endpoint_path(uid: 'cnav/allocation_adulte_handicape') %>), [ASF](<%= endpoint_path(uid: 'cnav/allocation_soutien_familial') %>), [RSA](<%= endpoint_path(uid: 'cnav/revenu_solidarite_active') %>), [prime d'activité](<%= endpoint_path(uid: 'cnav/prime_activite') %>), [C2S](<%= endpoint_path(uid: 'cnav/complementaire_sante_solidaire') %>), [AEEH](<%= endpoint_path(uid: 'cnav/aeeh') %>)), **seul le code COG du pays de naissance reste obligatoire**. Les paramètres de commune de naissance (code COG commune, nom de commune et code département) deviennent fortement recommandés afin de maximiser les chances d'identification du particulier. Une FAQ dédiée à l'algorithme d'identification est ajoutée sur chaque fiche.
+
 - date: 2026-05-05
   scope: both
   title: "SDKs officiels : Ruby disponible"


### PR DESCRIPTION
The CNAV data provider only requires the country COG code as mandatory birth place parameter. Our API was requiring either the commune COG code or the transcogage triplet (commune name + department + birth year) on top of the country code for French-born persons.

Simplify by making commune-related params strongly recommended instead of mandatory:
- Relax ValidateCodeCogINSEECommuneNaissanceOrTranscogageParams to accept calls without commune info (validates format only if provided)
- Update all 6 CNAV endpoint docs: country COG code listed as mandatory param, commune section labeled "fortement recommandé" with link to identification algorithm FAQ
- Add FAQ highlight box explaining parameter weights (birth name, birth year, birth place carry the most weight in identification)
- Add poids-parametres-identification FAQ to AEEH endpoint (was missing)
- Fix typos in existing FAQ entries (obigatoire, particuloer, "à pour")
- Update OpenAPI v2 parameter descriptions accordingly
- Add changelog entry