### PR TITLE
Add global provider dashboard at /admin/providers/all

### DIFF
--- a/site/app/controllers/admin/provider_dashboards_controller.rb
+++ b/site/app/controllers/admin/provider_dashboards_controller.rb
@@ -21,7 +21,7 @@ class Admin::ProviderDashboardsController < AdminController
   private
 
   def load_provider
-    @provider = provider_klass.find(params[:id])
+    @provider = params[:id] == 'all' ? Provider::All.new(namespace) : provider_klass.find(params[:id])
   end
 
   def provider_klass

--- a/site/app/forms/provider/dashboard_filter.rb
+++ b/site/app/forms/provider/dashboard_filter.rb
@@ -72,7 +72,10 @@ class Provider::DashboardFilter
   end
 
   def provider_endpoints
-    @provider_endpoints ||= endpoint_klass.all.select { |endpoint| endpoint.provider_uids.to_a.include?(provider.uid) }
+    @provider_endpoints ||= begin
+      all = endpoint_klass.all
+      provider.uid == 'all' ? all : all.select { |endpoint| endpoint.provider_uids.to_a.include?(provider.uid) }
+    end
   end
 
   private

--- a/site/app/models/provider/all.rb
+++ b/site/app/models/provider/all.rb
@@ -1,0 +1,20 @@
+class Provider::All
+  attr_reader :api
+
+  def initialize(api)
+    @api = api.to_s
+  end
+
+  def uid = 'all'
+  def name = 'Tous les fournisseurs'
+  def scopes = provider_klass.all.flat_map(&:scopes).uniq
+  def routes_or_uid_to_match = nil
+
+  def all_provider? = true
+
+  private
+
+  def provider_klass
+    Kernel.const_get("API#{api.classify}::Provider")
+  end
+end

--- a/site/app/queries/provider/dashboard_query.rb
+++ b/site/app/queries/provider/dashboard_query.rb
@@ -178,6 +178,8 @@ class Provider::DashboardQuery # rubocop:disable Metrics/ClassLength
 
   attr_reader :provider, :filter
 
+  def all_provider? = provider.uid == 'all'
+
   ENDPOINT_METRIC_COLUMNS = { # rubocop:disable Lint/UselessConstantScoping
     total: 'appels_totaux',
     unique: 'appels_uniques',
@@ -203,17 +205,26 @@ class Provider::DashboardQuery # rubocop:disable Metrics/ClassLength
 
   def match_routes(relation, column = nil)
     api_col = column || "#{relation.klass.table_name}.api"
-    return restrict_by_provider_uid(relation, api_col) if requested_controllers.nil?
+    return relation if requested_controllers.nil?
     return relation.where('1 = 0') if requested_controllers.empty?
 
     relation.where("#{api_col} = ANY(ARRAY[?]::text[])", requested_controllers)
   end
 
   def requested_controllers
+    @requested_controllers ||= compute_requested_controllers
+  end
+
+  def compute_requested_controllers
+    return all_provider_controllers if all_provider?
     return nil if !filter.routes_submitted? && provider_controllers.empty?
     return provider_controllers unless filter.routes_submitted?
 
-    @requested_controllers ||= filter.routes & provider_controllers
+    filter.routes & provider_controllers
+  end
+
+  def all_provider_controllers
+    filter.routes_submitted? ? filter.routes : provider_controllers
   end
 
   def restrict_by_provider_uid(relation, api_col)

--- a/site/app/views/admin/provider_dashboards/index.html.erb
+++ b/site/app/views/admin/provider_dashboards/index.html.erb
@@ -2,6 +2,10 @@
   <div class="fr-col-12">
     <h1>Tableaux de bords des fournisseurs</h1>
 
+    <p>
+      <%= link_to "Tableau de bord global (tous les fournisseurs)", admin_provider_dashboard_path('all'), class: "fr-btn fr-btn--lg" %>
+    </p>
+
     <div class="fr-table">
       <table>
         <caption>Liste des fournisseurs</caption>

--- a/site/spec/features/admin/provider_dashboards_spec.rb
+++ b/site/spec/features/admin/provider_dashboards_spec.rb
@@ -27,4 +27,22 @@ RSpec.describe 'Admin: provider dashboards', app: :api_entreprise do
       expect(page).to have_text('Date de début')
     end
   end
+
+  describe 'all providers page' do
+    it 'renders the global dashboard with all endpoints' do
+      visit admin_provider_dashboard_path('all')
+
+      expect(page).to have_css('h1', text: 'Tous les fournisseurs')
+      expect(page).to have_css('form')
+      expect(page).to have_text('Date de début')
+    end
+
+    it 'is accessible from the index page' do
+      visit admin_provider_dashboards_path
+
+      click_link 'Tableau de bord global (tous les fournisseurs)'
+
+      expect(page).to have_css('h1', text: 'Tous les fournisseurs')
+    end
+  end
 end


### PR DESCRIPTION
Treat 'all' as a regular provider id: /admin/providers/all reuses the existing show action and section routes with no route duplication.

Provider::All duck-types a provider, returning all endpoints for the current namespace. DashboardFilter and DashboardQuery are adapted to skip per-provider filtering when uid is 'all', while still scoping data to the namespace's controllers (no cross-API data leak).

<img width="2754" height="850" alt="screenshot-2026-05-12--17-55-11--000726" src="https://github.com/user-attachments/assets/7efac62b-b687-457d-aa73-938797ec92fb" />
<img width="2668" height="1534" alt="screenshot-2026-05-12--17-55-06--000725" src="https://github.com/user-attachments/assets/e00bc472-4155-47d7-a19e-026bb1054155" />
