### PR TITLE
Aggregate legacy endpoint stats under their current version in provider dashboard

### DIFF
--- a/site/app/forms/provider/dashboard_filter.rb
+++ b/site/app/forms/provider/dashboard_filter.rb
@@ -65,10 +65,17 @@ class Provider::DashboardFilter
 
   def endpoint_options
     @endpoint_options ||= provider_endpoints
-      .reject(&:deprecated?)
       .filter_map { |endpoint| [endpoint.controller, endpoint.title] if endpoint.controller.present? }
       .uniq(&:first)
       .sort_by(&:second)
+  end
+
+  def controllers_with_legacy
+    @controllers_with_legacy ||= provider_endpoints.each_with_object({}) do |endpoint, map|
+      next if endpoint.controller.blank?
+
+      map[endpoint.controller] = [endpoint.controller, *legacy_controllers(endpoint)].uniq
+    end
   end
 
   def provider_endpoints
@@ -79,6 +86,14 @@ class Provider::DashboardFilter
   end
 
   private
+
+  def legacy_controllers(endpoint)
+    endpoint.old_endpoints.filter_map do |old|
+      next old.controller if old.controller.present? && old.controller != 'Inline'
+
+      nil
+    end
+  end
 
   def endpoint_klass
     Kernel.const_get("API#{api.to_s.classify}::Endpoint")

--- a/site/app/queries/provider/dashboard_query.rb
+++ b/site/app/queries/provider/dashboard_query.rb
@@ -220,11 +220,15 @@ class Provider::DashboardQuery # rubocop:disable Metrics/ClassLength
     return nil if !filter.routes_submitted? && provider_controllers.empty?
     return provider_controllers unless filter.routes_submitted?
 
-    filter.routes & provider_controllers
+    expand_routes(filter.routes) & provider_controllers
   end
 
   def all_provider_controllers
-    filter.routes_submitted? ? filter.routes : provider_controllers
+    filter.routes_submitted? ? expand_routes(filter.routes) : provider_controllers
+  end
+
+  def expand_routes(routes)
+    routes.flat_map { |r| filter.controllers_with_legacy.fetch(r, [r]) }.uniq
   end
 
   def restrict_by_provider_uid(relation, api_col)
@@ -250,7 +254,7 @@ class Provider::DashboardQuery # rubocop:disable Metrics/ClassLength
   end
 
   def provider_controllers
-    @provider_controllers ||= filter.provider_endpoints.filter_map(&:controller).uniq
+    @provider_controllers ||= filter.controllers_with_legacy.values.flatten.uniq
   end
 
   def date_trunc_sql
@@ -262,10 +266,14 @@ class Provider::DashboardQuery # rubocop:disable Metrics/ClassLength
   end
 
   def endpoint_titles
-    @endpoint_titles ||= filter.provider_endpoints
-      .filter_map { |e| [e.controller, e.title] if e.controller.present? }
-      .uniq(&:first)
-      .to_h
+    @endpoint_titles ||= build_endpoint_titles
+  end
+
+  def build_endpoint_titles
+    filter.controllers_with_legacy.each_with_object({}) do |(controller, all_controllers), map|
+      title = filter.provider_endpoints.find { |e| e.controller == controller }&.title || controller
+      all_controllers.each { |c| map[c] ||= title }
+    end
   end
 
   def habilitation_scope_clause

--- a/site/spec/queries/provider/dashboard_query_spec.rb
+++ b/site/spec/queries/provider/dashboard_query_spec.rb
@@ -187,6 +187,29 @@ RSpec.describe Provider::DashboardQuery do
     end
   end
 
+  describe 'legacy endpoint aggregation' do
+    let(:provider) { APIParticulier::Provider.find('cnav') }
+    let(:filter) { Provider::DashboardFilter.new(provider, 'particulier') }
+    let(:current_qf) { 'api_particulier/v3_and_more/cnav/quotient_familial_with_civility' }
+    let(:legacy_qf) { 'api_particulier/v2/cnav/quotient_familial_v2' }
+
+    before do
+      create(:access_log, controller: current_qf, status: '200', api_version: 'v3', cached: false, duration: '100')
+      create(:access_log, controller: legacy_qf, status: '200', api_version: 'v2', cached: false, duration: '200')
+    end
+
+    it 'includes v2 calls when filtering on the v3 controller' do
+      narrow = Provider::DashboardFilter.new(provider, 'particulier', routes: [current_qf])
+      expect(described_class.new(provider, narrow).total_calls).to eq(2)
+    end
+
+    it 'labels v2 calls with the v3 endpoint title' do
+      rows = query.per_endpoint
+      titles = rows.pluck(:endpoint)
+      expect(titles.uniq.count { |t| t.include?('Quotient familial') }).to eq(1)
+    end
+  end
+
   describe 'excluded controllers' do
     it 'ignores ping/uptime traffic' do
       create(:access_log, controller: 'uptime', status: '200', api_version: 'v3', cached: false, duration: '10')


### PR DESCRIPTION
When filtering by a v3 endpoint (e.g. Quotient familial CAF & MSA), the dashboard now also includes traffic from deprecated v2 controllers by walking the old_endpoint_uids chain. Stats and graph labels are grouped under the current endpoint title instead of showing separate entries for each API version.