### PR TITLE
Fix API Particulier changelog mailer using API Entreprise URL helpers

### DIFF
--- a/site/app/views/api_particulier/changelog_mailer/_block_unsubscribe_changelog.html.mjml
+++ b/site/app/views/api_particulier/changelog_mailer/_block_unsubscribe_changelog.html.mjml
@@ -3,7 +3,7 @@
     <mj-text mj-class="secondary-link">
       <p>
         Vous recevez cet email car vous êtes inscrit à la newsletter hebdomadaire des nouveautés d'API Particulier.
-        <a target="_blank" href="<%= changelog_unsubscribe_token_url(token: @subscription.unsubscribe_token) %>">
+        <a target="_blank" href="<%= api_particulier_changelog_unsubscribe_token_url(token: @subscription.unsubscribe_token) %>">
           Se désinscrire
         </a>
       </p>

--- a/site/app/views/api_particulier/changelog_mailer/weekly.html.mjml
+++ b/site/app/views/api_particulier/changelog_mailer/weekly.html.mjml
@@ -32,7 +32,7 @@
 <% end %>
 <mj-section mj-class="section-block">
   <mj-column>
-    <mj-button href="<%= changelogs_url %>">
+    <mj-button href="<%= api_particulier_changelogs_url %>">
       Voir toutes les nouveautés
     </mj-button>
   </mj-column>


### PR DESCRIPTION
The changelog mailer templates for API Particulier used non-prefixed route helpers (changelogs_url, changelog_unsubscribe_token_url) which resolve to the API Entreprise routes. Replace with the correctly namespaced api_particulier_* variants, matching the pattern used by all other API Particulier mailers (authorization_request, newsletter).