### PR TITLE
Add payload API Part cnous, aah, aeeh with civility for FranceConnect citizen

### DIFF
--- a/mocks/payloads/api_particulier_v3_cnav_allocation_adulte_handicape_with_civility/200-usager-base-france_connect.yml
+++ b/mocks/payloads/api_particulier_v3_cnav_allocation_adulte_handicape_with_civility/200-usager-base-france_connect.yml
@@ -1,0 +1,27 @@
+---
+description:
+  ## Identité connue de la base de test de France Connect
+
+  Ce cas permet de tester un appel à partir notamment des données de l'identité
+  pivot France Connect.
+
+params:
+  nomNaissance: 'MERCIER'
+  prenoms:
+  - 'PIERRE'
+  anneeDateNaissance: 1969
+  moisDateNaissance: 3
+  jourDateNaissance: 17
+  codeCogInseeCommuneNaissance: '95277'
+  codeCogInseePaysNaissance: '99100'
+  sexeEtatCivil: 'M'
+status: 200
+payload: |-
+  {
+    "data": {
+      "est_beneficiaire": true,
+      "date_debut_droit": "2022-11-29"
+    },
+    "links": {},
+    "meta": {}
+  }

--- a/mocks/payloads/api_particulier_v3_cnav_allocation_enfant_handicape_with_civility/200-usager-base-france_connect.yml
+++ b/mocks/payloads/api_particulier_v3_cnav_allocation_enfant_handicape_with_civility/200-usager-base-france_connect.yml
@@ -1,0 +1,27 @@
+---
+description:
+  ## Identité connue de la base de test de France Connect
+
+  Ce cas permet de tester un appel à partir notamment des données de l'identité
+  pivot France Connect.
+
+params:
+  nomNaissance: 'MERCIER'
+  prenoms:
+  - 'PIERRE'
+  anneeDateNaissance: 1969
+  moisDateNaissance: 3
+  jourDateNaissance: 17
+  codeCogInseeCommuneNaissance: '95277'
+  codeCogInseePaysNaissance: '99100'
+  sexeEtatCivil: 'M'
+status: 200
+payload: |-
+  {
+    "data": {
+      "status": "allocataire",
+      "date_debut_droit": "2023-06-15"
+    },
+    "links": {},
+    "meta": {}
+  }

--- a/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_civility/200-usager-base-france_connect.yml
+++ b/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_civility/200-usager-base-france_connect.yml
@@ -1,0 +1,51 @@
+---
+description:
+  ## Identité connue de la base de test de France Connect
+
+  Ce cas permet de tester un appel à partir notamment des données de l'identité
+  pivot France Connect.
+
+params:
+  nomNaissance: 'MERCIER'
+  prenoms:
+    - 'PIERRE'
+  anneeDateNaissance: 1969
+  moisDateNaissance: 3
+  jourDateNaissance: 17
+  codeCogInseeCommuneNaissance: '95277'
+  sexeEtatCivil: 'M'
+status: 200
+payload: |-
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": false,
+        "est_radie": true,
+        "date_radiation": "1990-07-01"
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "1989-09-01",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Evry",
+        "nom_etablissement": "ENSIIE"
+      },
+      "echelon_bourse": {
+        "echelon": "5",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "pierre.mercier@mail.fr",
+      "identite": {
+        "nom": "MERCIER",
+        "prenoms": [
+          "PIERRE"
+        ],
+        "date_naissance": "1969-03-17",
+        "nom_commune_naissance": "Gonesse",
+        "sexe": "M"
+      }
+    },
+    "links": {},
+    "meta": {}
+  }


### PR DESCRIPTION
Ces nouvelles payloads permettent notamment de tester directement des appels à partir des données de l'identité pivot France Connect de leur base citizen.