### PR TITLE
Site: Editor delegations page — UUID, scopes & creation date columns

### DIFF
--- a/site/app/helpers/scope_helper.rb
+++ b/site/app/helpers/scope_helper.rb
@@ -8,11 +8,11 @@ module ScopeHelper
     scopes_tree
   end
 
-  private
-
   def humanize_scope(scope, api)
     I18n.t("api_#{api}.tokens.token.scope.#{scope}.label", default: scope.humanize)
   end
+
+  private
 
   def build_scopes_parts(scopes_tree, splitted_scope) # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
     if splitted_scope.size > 2

--- a/site/app/views/editor/delegations/_scopes_cell.html.erb
+++ b/site/app/views/editor/delegations/_scopes_cell.html.erb
@@ -1,0 +1,9 @@
+<% if scopes.any? %>
+  <ul class="delegation-scopes fr-text--sm">
+    <% scopes.each do |scope| %>
+      <li><%= humanize_scope(scope, api).split('||').last.strip %></li>
+    <% end %>
+  </ul>
+<% else %>
+  <span class="fr-text--sm fr-text-mention--grey"><%= t('editor.delegations.index.no_scopes') %></span>
+<% end %>

--- a/site/app/views/editor/delegations/index.html.erb
+++ b/site/app/views/editor/delegations/index.html.erb
@@ -62,6 +62,7 @@
               <th scope="col"><%= t('.table.organization') %></th>
               <th scope="col"><%= t('.table.demandeur') %></th>
               <th scope="col"><%= t('.table.status') %></th>
+              <th scope="col"><%= t('.table.scopes') %></th>
             </tr>
           </thead>
           <tbody>
@@ -99,6 +100,17 @@
                     <p class="fr-badge fr-badge--pink-tuile"><%= t('.status_revoked') %></p>
                   <% else %>
                     <p class="fr-badge fr-badge--green-emeraude"><%= t('.status_active') %></p>
+                  <% end %>
+                </td>
+                <td>
+                  <% if ar.scopes.any? %>
+                    <ul class="delegation-scopes fr-text--sm">
+                      <% ar.scopes.each do |scope| %>
+                        <li><%= humanize_scope(scope, ar.api).split('||').last.strip %></li>
+                      <% end %>
+                    </ul>
+                  <% else %>
+                    <span class="fr-text--sm fr-text-mention--grey"><%= t('.no_scopes') %></span>
                   <% end %>
                 </td>
               </tr>

--- a/site/app/views/editor/delegations/index.html.erb
+++ b/site/app/views/editor/delegations/index.html.erb
@@ -104,15 +104,7 @@
                   <% end %>
                 </td>
                 <td>
-                  <% if ar.scopes.any? %>
-                    <ul class="delegation-scopes fr-text--sm">
-                      <% ar.scopes.each do |scope| %>
-                        <li><%= humanize_scope(scope, ar.api).split('||').last.strip %></li>
-                      <% end %>
-                    </ul>
-                  <% else %>
-                    <span class="fr-text--sm fr-text-mention--grey"><%= t('.no_scopes') %></span>
-                  <% end %>
+                  <%= render 'scopes_cell', scopes: ar.scopes, api: ar.api %>
                 </td>
                 <td class="delegation-created-at">
                   <%= delegation.created_at.strftime('%d/%m/%Y') %>

--- a/site/app/views/editor/delegations/index.html.erb
+++ b/site/app/views/editor/delegations/index.html.erb
@@ -56,6 +56,7 @@
           </caption>
           <thead>
             <tr>
+              <th scope="col"><%= t('.table.delegation_id') %></th>
               <th scope="col"><%= t('.table.datapass_id') %></th>
               <th scope="col"><%= t('.table.intitule') %></th>
               <th scope="col"><%= t('.table.organization') %></th>
@@ -67,6 +68,20 @@
             <% @delegations.each do |delegation| %>
               <% ar = delegation.authorization_request %>
               <tr id="<%= dom_id(delegation) %>" class="delegation">
+                <td>
+                  <div class="copy-token" data-controller="clipboard" data-clipboard-alert-message-value="<%= t('.copy_alert') %>">
+                    <code class="fr-text--sm"><%= delegation.id %></code>
+                    <input class="fr-input" type="text" readonly
+                           data-clipboard-target="source"
+                           value="<%= delegation.id %>"
+                           style="position: absolute; left: -9999px" />
+                    <button class="fr-btn fr-btn--sm fr-icon-clipboard-fill fr-btn--icon-right"
+                            type="button"
+                            data-action="click->clipboard#copy">
+                      <%= t('.table.copy_delegation_id') %>
+                    </button>
+                  </div>
+                </td>
                 <td>
                   <%= link_to "DataPass ##{ar.external_id}", "#{datapass_v2_base_url(ar.api)}/public/demandes/#{ar.public_id}", target: '_blank' %>
                 </td>

--- a/site/app/views/editor/delegations/index.html.erb
+++ b/site/app/views/editor/delegations/index.html.erb
@@ -63,6 +63,7 @@
               <th scope="col"><%= t('.table.demandeur') %></th>
               <th scope="col"><%= t('.table.status') %></th>
               <th scope="col"><%= t('.table.scopes') %></th>
+              <th scope="col"><%= t('.table.created_at') %></th>
             </tr>
           </thead>
           <tbody>
@@ -112,6 +113,9 @@
                   <% else %>
                     <span class="fr-text--sm fr-text-mention--grey"><%= t('.no_scopes') %></span>
                   <% end %>
+                </td>
+                <td class="delegation-created-at">
+                  <%= delegation.created_at.strftime('%d/%m/%Y') %>
                 </td>
               </tr>
             <% end %>

--- a/site/config/locales/fr.yml
+++ b/site/config/locales/fr.yml
@@ -527,6 +527,7 @@ fr:
           demandeur: Demandeur
           status: Statut
           scopes: Scopes disponibles
+          created_at: Date de création
         copy_alert: Identifiant copié
         no_scopes: Aucun scope
         status_active: Actif

--- a/site/config/locales/fr.yml
+++ b/site/config/locales/fr.yml
@@ -519,11 +519,14 @@ fr:
       index:
         title: Délégations
         table:
+          delegation_id: Identifiant de délégation
+          copy_delegation_id: Copier l'identifiant
           datapass_id: DataPass ID
           intitule: Intitulé
           organization: Organisation
           demandeur: Demandeur
           status: Statut
+        copy_alert: Identifiant copié
         status_active: Actif
         status_revoked: Révoqué
         editor_tokens_title: Jetons de délégation

--- a/site/config/locales/fr.yml
+++ b/site/config/locales/fr.yml
@@ -526,7 +526,9 @@ fr:
           organization: Organisation
           demandeur: Demandeur
           status: Statut
+          scopes: Scopes disponibles
         copy_alert: Identifiant copié
+        no_scopes: Aucun scope
         status_active: Actif
         status_revoked: Révoqué
         editor_tokens_title: Jetons de délégation

--- a/site/spec/features/editor/delegations_spec.rb
+++ b/site/spec/features/editor/delegations_spec.rb
@@ -42,9 +42,9 @@ RSpec.describe 'Editor: delegations', app: :api_entreprise do
           expect(page).to have_button("Copier l'identifiant")
           expect(page).to have_css(
             'input[data-clipboard-target="source"]',
-            visible: false
+            visible: :all
           )
-          expect(find('input[data-clipboard-target="source"]', visible: false).value)
+          expect(find('input[data-clipboard-target="source"]', visible: :all).value)
             .to eq(active_delegation.id)
         end
       end

--- a/site/spec/features/editor/delegations_spec.rb
+++ b/site/spec/features/editor/delegations_spec.rb
@@ -10,11 +10,14 @@ RSpec.describe 'Editor: delegations', app: :api_entreprise do
       let(:editor) { create(:editor, :delegable) }
       let!(:active_delegation) do
         create(:editor_delegation, editor:,
-          authorization_request: create(:authorization_request, :validated, :with_demandeur, api: 'entreprise'))
+          authorization_request: create(:authorization_request, :validated, :with_demandeur,
+            api: 'entreprise',
+            scopes: %w[unites_legales_etablissements_insee associations]))
       end
       let!(:revoked_delegation) do
         create(:editor_delegation, editor:, revoked_at: 1.day.ago,
-          authorization_request: create(:authorization_request, :validated, :with_demandeur, api: 'entreprise'))
+          authorization_request: create(:authorization_request, :validated, :with_demandeur,
+            api: 'entreprise', scopes: []))
       end
 
       it 'displays the delegations tab in header' do
@@ -43,6 +46,25 @@ RSpec.describe 'Editor: delegations', app: :api_entreprise do
           )
           expect(find('input[data-clipboard-target="source"]', visible: false).value)
             .to eq(active_delegation.id)
+        end
+      end
+
+      it 'displays humanized scopes per delegation, with a fallback when empty' do
+        visit editor_delegations_path
+
+        within "##{dom_id(active_delegation)}" do
+          expect(page).to have_css(
+            '.delegation-scopes li',
+            text: 'API Données unités légales et établissements dont les non diffusibles'
+          )
+          expect(page).to have_css(
+            '.delegation-scopes li',
+            text: 'API Données ouvertes association'
+          )
+        end
+
+        within "##{dom_id(revoked_delegation)}" do
+          expect(page).to have_text('Aucun scope')
         end
       end
     end

--- a/site/spec/features/editor/delegations_spec.rb
+++ b/site/spec/features/editor/delegations_spec.rb
@@ -67,6 +67,16 @@ RSpec.describe 'Editor: delegations', app: :api_entreprise do
           expect(page).to have_text('Aucun scope')
         end
       end
+
+      it 'displays the creation date for each delegation' do
+        active_delegation.update!(created_at: Time.zone.local(2026, 3, 14, 12))
+
+        visit editor_delegations_path
+
+        within "##{dom_id(active_delegation)}" do
+          expect(page).to have_css('.delegation-created-at', text: '14/03/2026')
+        end
+      end
     end
 
     context 'when delegations are not enabled' do

--- a/site/spec/features/editor/delegations_spec.rb
+++ b/site/spec/features/editor/delegations_spec.rb
@@ -30,6 +30,21 @@ RSpec.describe 'Editor: delegations', app: :api_entreprise do
         expect(page).to have_css('.fr-badge--green-emeraude', text: 'Actif')
         expect(page).to have_css('.fr-badge--pink-tuile', text: 'Révoqué')
       end
+
+      it 'displays the delegation UUID with a copy button per row' do
+        visit editor_delegations_path
+
+        within "##{dom_id(active_delegation)}" do
+          expect(page).to have_text(active_delegation.id)
+          expect(page).to have_button("Copier l'identifiant")
+          expect(page).to have_css(
+            'input[data-clipboard-target="source"]',
+            visible: false
+          )
+          expect(find('input[data-clipboard-target="source"]', visible: false).value)
+            .to eq(active_delegation.id)
+        end
+      end
     end
 
     context 'when delegations are not enabled' do

--- a/site/spec/helpers_spec/scope_helper_spec.rb
+++ b/site/spec/helpers_spec/scope_helper_spec.rb
@@ -3,6 +3,18 @@ require 'rails_helper'
 RSpec.describe ScopeHelper do
   include described_class
 
+  describe '#humanize_scope' do
+    it 'returns the I18n label for a known scope' do
+      expect(humanize_scope('unites_legales_etablissements_insee', 'entreprise'))
+        .to eq('INSEE || API Données unités légales et établissements dont les non diffusibles')
+    end
+
+    it 'falls back to scope.humanize when no I18n label is defined' do
+      expect(humanize_scope('totally_unknown_scope', 'entreprise'))
+        .to eq('Totally unknown scope')
+    end
+  end
+
   describe '#build_scopes' do
     it 'returns correct tree structure for cnaf_quotient_familial scope' do
       scopes = ['cnaf_quotient_familial']


### PR DESCRIPTION
## Summary

- Surface `delegation_id` (UUID) with a DSFR copy button — the value editors pass via `X-Delegation-Id`, central piece for integration.
- List humanized scopes per delegation (with an « Aucun scope » fallback), so editors can pick the right delegation per call.
- Add an explicit DD/MM/YYYY creation date column.
- `ScopeHelper#humanize_scope` is made public so the view can render scope labels directly.

Out of scope per the latest challenge (2026-05-21) — moved to dedicated issues:

- Filters / sort / detail page (UI2.A / UI2.B / UI2.C).
- Banner / link to the D1 developer docs — deferred until D1 (API-6652) ships.
- Editor-side « révoquer » action — abandoned (handled by client via T13 or admin via UI7).

Linear: https://linear.app/pole-api/issue/API-6636

## Test plan

- [x] `bundle exec rspec spec/features/editor/delegations_spec.rb spec/helpers_spec/scope_helper_spec.rb` — 11 examples, 0 failures
- [x] `bundle exec rubocop` on touched files — clean
- [ ] Manual UI check on `editeur@yopmail.com` / `/editeur/delegations`: copy button works, scopes display, date renders, 7-column table doesn't overflow on narrow screens (drop `fr-table--layout-fixed` if it does)