### PR TITLE
Site: Editor delegations API — GET /editeur/api/v1/delegations + rswag bootstrap

### DIFF
--- a/.github/workflows/site-ci_cd.yml
+++ b/.github/workflows/site-ci_cd.yml
@@ -50,6 +50,58 @@ jobs:
     - name: Run RuboCop
       run: bundle exec rubocop --parallel
 
+  check-swagger:
+    name: Check Swagger generation
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_USER: admin_apientreprise
+          POSTGRES_PASSWORD: wow*verysecret
+          POSTGRES_DB: admin_apientreprise_test
+          POSTGRES_PORT: 5432
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      redis:
+        image: redis
+        ports: ["6379:6379"]
+        options: --entrypoint redis-server
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1.308.0
+        with:
+          bundler-cache: true
+          cache-version: 322
+          working-directory: site
+
+      - name: Install postgres client
+        run: sudo apt-get install libpq-dev
+
+      - name: Create database users
+        env:
+          POSTGRES_USER: admin_apientreprise
+          POSTGRES_DB: admin_apientreprise_test
+          PGPASSWORD: wow*verysecret
+        run: |
+          psql -h localhost -U ${{ env.POSTGRES_USER }} -d ${{ env.POSTGRES_DB }} -f `pwd`/postgresql_setup.txt
+
+      - name: Create database
+        run: bundle exec rails db:create db:schema:load RAILS_ENV=test
+
+      - name: Check Swagger file is up-to-date
+        run: ./bin/test_swagger.sh
+
   tests:
     name: Tests
     runs-on: ubuntu-latest
@@ -123,6 +175,7 @@ jobs:
     needs:
       - security
       - lint
+      - check-swagger
       - tests
     steps:
       - name: Checkout code
@@ -140,6 +193,7 @@ jobs:
     needs:
       - security
       - lint
+      - check-swagger
       - tests
       - merge-with-main
     timeout-minutes: 10
@@ -171,6 +225,7 @@ jobs:
     needs:
       - security
       - lint
+      - check-swagger
       - tests
       - merge-with-main
       - continuous-deployment-staging

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -50,3 +50,6 @@ sandbox/*
 # dotenv local overrides (per-worktree DB configuration, etc.)
 /.env.local
 /.env.*.local
+
+# Swagger regeneration check workspace (bin/test_swagger.sh).
+/swagger/versionned/

--- a/site/.rubocop.yml
+++ b/site/.rubocop.yml
@@ -166,6 +166,15 @@ RSpec/DescribedClass:
 RSpec/EmptyExampleGroup:
   Exclude:
     - "spec/requests/**/*"
+    - "spec/integration/**/*"
+
+RSpec/VariableName:
+  Exclude:
+    - "spec/integration/**/*"
+
+RSpec/ScatteredSetup:
+  Exclude:
+    - "spec/integration/**/*"
 
 RSpec/ExampleLength:
   Enabled: false
@@ -189,6 +198,8 @@ RSpec/RepeatedDescription:
   Enabled: false
 
 RSpec/DescribeClass:
+  Exclude:
+    - "spec/integration/**/*"
   IgnoredMetadata:
     type:
       - acceptance

--- a/site/Gemfile
+++ b/site/Gemfile
@@ -42,6 +42,8 @@ gem 'rails-i18n'
 gem 'ransack'
 gem 'redis'
 gem 'rest-client'
+gem 'rswag-api'
+gem 'rswag-ui'
 gem 'sass-rails', '>= 6'
 gem 'scenic'
 gem 'sentry-rails'
@@ -93,6 +95,7 @@ group :test do
   gem 'rspec-its'
   gem 'rspec-rails', '8.0.4'
   gem 'rspec-retry'
+  gem 'rswag-specs'
   gem 'shoulda-matchers'
   gem 'simplecov', require: false
   gem 'simplecov-console', require: false

--- a/site/Gemfile.lock
+++ b/site/Gemfile.lock
@@ -256,6 +256,9 @@ GEM
       bindata
       faraday (~> 2.0)
       faraday-follow_redirects
+    json-schema (6.2.0)
+      addressable (~> 2.8)
+      bigdecimal (>= 3.1, < 5)
     jwt (3.2.0)
       base64
     kaminari (1.2.2)
@@ -529,6 +532,17 @@ GEM
     rspec-retry (0.6.2)
       rspec-core (> 3.3)
     rspec-support (3.13.7)
+    rswag-api (2.17.0)
+      activesupport (>= 5.2, < 8.2)
+      railties (>= 5.2, < 8.2)
+    rswag-specs (2.17.0)
+      activesupport (>= 5.2, < 8.2)
+      json-schema (>= 2.2, < 7.0)
+      railties (>= 5.2, < 8.2)
+      rspec-core (>= 2.14)
+    rswag-ui (2.17.0)
+      actionpack (>= 5.2, < 8.2)
+      railties (>= 5.2, < 8.2)
     rubocop (1.86.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -731,6 +745,9 @@ DEPENDENCIES
   rspec-its
   rspec-rails (= 8.0.4)
   rspec-retry
+  rswag-api
+  rswag-specs
+  rswag-ui
   rubocop
   rubocop-capybara
   rubocop-factory_bot

--- a/site/app/controllers/editor/api/base_controller.rb
+++ b/site/app/controllers/editor/api/base_controller.rb
@@ -1,0 +1,52 @@
+class Editor::API::BaseController < APIController
+  BEARER_PATTERN = /\ABearer\s+(.+)\z/
+  DEFAULT_PER_PAGE = 50
+  MAX_PER_PAGE = 100
+
+  before_action :authenticate_editor!
+
+  private
+
+  attr_reader :current_editor, :current_editor_token
+
+  def authenticate_editor!
+    token = extract_bearer_token
+    return unauthorized if token.blank?
+
+    payload = AccessToken.decode(token)
+    return unauthorized unless payload[:editor] == true
+
+    @current_editor_token = EditorToken.active.find_by(id: payload[:jti])
+    return unauthorized if @current_editor_token.nil?
+
+    @current_editor = @current_editor_token.editor
+  rescue JWT::DecodeError
+    unauthorized
+  end
+
+  def extract_bearer_token
+    match = request.authorization&.match(BEARER_PATTERN)
+    match && match[1].presence
+  end
+
+  def current_api
+    EditorAPIDomainConstraint.api_for_host(request.host)
+  end
+
+  def per_page
+    raw = params[:per_page]
+    requested = raw.to_i
+    return DEFAULT_PER_PAGE if requested <= 0
+
+    [requested, MAX_PER_PAGE].min
+  end
+
+  def pagination_meta(scope)
+    {
+      page: scope.current_page,
+      per_page: scope.limit_value,
+      total: scope.total_count,
+      total_pages: scope.total_pages
+    }
+  end
+end

--- a/site/app/controllers/editor/api/v1/delegations_controller.rb
+++ b/site/app/controllers/editor/api/v1/delegations_controller.rb
@@ -1,0 +1,20 @@
+class Editor::API::V1::DelegationsController < Editor::API::BaseController
+  def index
+    paginated = delegations_scope.page(params[:page]).per(per_page)
+
+    render json: {
+      data: paginated.map { |d| Editor::API::V1::DelegationSerializer.new(d).as_json },
+      meta: pagination_meta(paginated)
+    }
+  end
+
+  private
+
+  def delegations_scope
+    current_editor.editor_delegations
+      .joins(:authorization_request)
+      .merge(AuthorizationRequest.for_api(current_api))
+      .preload(:authorization_request)
+      .order(created_at: :desc)
+  end
+end

--- a/site/app/lib/editor/api/v1/delegation_serializer.rb
+++ b/site/app/lib/editor/api/v1/delegation_serializer.rb
@@ -1,0 +1,18 @@
+class Editor::API::V1::DelegationSerializer
+  def initialize(delegation)
+    @delegation = delegation
+    @authorization_request = delegation.authorization_request
+  end
+
+  def as_json
+    {
+      id: @delegation.id,
+      authorization_request_id: Integer(@authorization_request.external_id),
+      siret: @authorization_request.siret,
+      intitule: @authorization_request.intitule,
+      scopes: @authorization_request.scopes,
+      statut: @delegation.revoked_at.present? ? 'revoked' : 'active',
+      created_at: @delegation.created_at.utc.iso8601
+    }
+  end
+end

--- a/site/app/lib/editor_api_domain_constraint.rb
+++ b/site/app/lib/editor_api_domain_constraint.rb
@@ -1,0 +1,12 @@
+class EditorAPIDomainConstraint
+  HOST_PATTERN = /\A(entreprise|particulier)\.api(\.|\z)/
+
+  def self.api_for_host(host)
+    match = HOST_PATTERN.match(host)
+    match && match[1]
+  end
+
+  def matches?(request)
+    HOST_PATTERN.match?(request.host)
+  end
+end

--- a/site/bin/generate_swagger.sh
+++ b/site/bin/generate_swagger.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+SWAGGER_DRY_RUN=0 RAILS_ENV=test bundle exec rails rswag \
+  PATTERN="spec/integration/**/*_spec.rb"

--- a/site/bin/test_swagger.sh
+++ b/site/bin/test_swagger.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+mkdir -p ./swagger/versionned &&
+cp ./swagger/v1/openapi-editor.yaml ./swagger/versionned/openapi-editor.yaml &&
+  ./bin/generate_swagger.sh &&
+  (ruby -e 'require "yaml" ; require "date" ; YAML.load_file("./swagger/v1/openapi-editor.yaml", permitted_classes: [Date], aliases: true) == YAML.load_file("./swagger/versionned/openapi-editor.yaml", permitted_classes: [Date], aliases: true) ? exit(0) : exit(1)' || (echo "Swagger file for API Éditeur is different after generation" && exit 1)) &&
+  exit 0

--- a/site/config/changelogs.yml
+++ b/site/config/changelogs.yml
@@ -1,3 +1,9 @@
+- date: 2026-05-23
+  scope: both
+  title: "API éditeur : listing des délégations via GET /editeur/api/v1/delegations"
+  description: |
+    Les éditeurs SaaS disposent désormais d'une **API dédiée pour récupérer la liste de leurs délégations** (`GET /editeur/api/v1/delegations`), authentifiée par leur token éditeur en bearer JWT. L'endpoint est servi à la fois sur `entreprise.api.gouv.fr` et `particulier.api.gouv.fr` et ne renvoie que les délégations associées à l'API du host appelé. La réponse expose l'`id` de la délégation (à passer dans l'en-tête `X-Delegation-Id` sur les appels métier), le SIRET du client, l'intitulé de l'habilitation DataPass, les scopes accessibles, le statut (`active` / `revoked`), la date de création et l'ID DataPass. La documentation OpenAPI est exposée sur `/editeur/api-docs`. Le mapping `siret → id` peut désormais se faire entièrement par API, sans passer par le dashboard web.
+
 - date: 2026-05-13
   scope: both
   title: "SDKs officiels : Node.js disponible"

--- a/site/config/initializers/cors.rb
+++ b/site/config/initializers/cors.rb
@@ -16,4 +16,12 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
       headers: :any,
       methods: [:get, :post, :put, :patch, :delete, :options, :head]
   end
+
+  allow do
+    origins '*'
+
+    resource '/editeur/api/*',
+      headers: :any,
+      methods: [:get, :options, :head]
+  end
 end

--- a/site/config/initializers/rswag_api.rb
+++ b/site/config/initializers/rswag_api.rb
@@ -1,0 +1,3 @@
+Rswag::Api.configure do |c|
+  c.openapi_root = Rails.root.join('swagger').to_s
+end

--- a/site/config/initializers/rswag_ui.rb
+++ b/site/config/initializers/rswag_ui.rb
@@ -1,0 +1,3 @@
+Rswag::Ui.configure do |c|
+  c.openapi_endpoint '/editeur/api-docs/v1/openapi-editor.yaml', 'API Éditeur — v1'
+end

--- a/site/config/routes.rb
+++ b/site/config/routes.rb
@@ -38,6 +38,14 @@ Rails.application.routes.draw do
   namespace :editor, path: 'editeur' do
     resources :authorization_requests, only: %i[index], path: 'habilitations'
     resources :delegations, only: %i[index], path: 'delegations'
+
+    constraints(EditorAPIDomainConstraint.new) do
+      namespace :api, defaults: { format: :json } do
+        namespace :v1 do
+          resources :delegations, only: %i[index]
+        end
+      end
+    end
   end
 
   get '/fournisseur', to: 'provider/dashboard#index', as: :provider

--- a/site/config/routes.rb
+++ b/site/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  mount Rswag::Ui::Engine => '/editeur/api-docs'
+  mount Rswag::Api::Engine => '/editeur/api-docs'
   GoodJob::Engine.middleware.use(Rack::Auth::Basic) do |username, password|
     ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(Rails.application.credentials.workers_ui_username)) &
       ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(Rails.application.credentials.workers_ui_password))

--- a/site/spec/integration/editor/api/v1/delegations_spec.rb
+++ b/site/spec/integration/editor/api/v1/delegations_spec.rb
@@ -1,0 +1,77 @@
+require 'swagger_helper'
+
+RSpec.describe 'Délégations éditeur' do
+  let(:editor) { create(:editor, :delegable) }
+  let(:editor_token) { create(:editor_token, editor:) }
+
+  before { host! 'entreprise.api.gouv.fr' }
+
+  path '/editeur/api/v1/delegations' do
+    get 'Lister les délégations de l’éditeur' do
+      tags 'Délégations'
+      produces 'application/json'
+      security [{ bearer_editor_token: [] }]
+      description <<~DESC
+        Renvoie la liste des délégations dont dispose l'éditeur authentifié
+        sur l'API courante (entreprise ou particulier, déterminée par le
+        host appelé). Inclut les délégations actives et révoquées.
+      DESC
+
+      parameter name: :page, in: :query, schema: { type: :integer, minimum: 1 }, required: false,
+        description: 'Page courante (défaut 1).'
+      parameter name: :per_page, in: :query, schema: { type: :integer, minimum: 1, maximum: 100 }, required: false,
+        description: 'Nombre d’entrées par page (défaut 50, max 100).'
+
+      response '200', 'Liste des délégations' do
+        schema type: :object,
+          required: %w[data meta],
+          properties: {
+            data: { type: :array, items: { '$ref' => '#/components/schemas/Delegation' } },
+            meta: { '$ref' => '#/components/schemas/PaginationMeta' }
+          }
+
+        let(:Authorization) { "Bearer #{editor_token.rehash}" }
+        let(:page) { nil }
+        let(:per_page) { nil }
+
+        before do
+          create(:editor_delegation, editor:,
+            authorization_request: create(:authorization_request, :validated,
+              api: 'entreprise', external_id: '1001',
+              siret: '13002526500013', intitule: 'Délégation exemple',
+              scopes: %w[unites_legales_etablissements_insee]))
+        end
+
+        run_test! do |response|
+          body = JSON.parse(response.body)
+          expect(body.fetch('data').size).to eq(1)
+          expect(body.fetch('data').first).to include(
+            'siret' => '13002526500013',
+            'statut' => 'active'
+          )
+          expect(body.fetch('meta')).to include('total' => 1)
+        end
+      end
+
+      response '401', 'Token éditeur manquant' do
+        schema '$ref' => '#/components/schemas/UnauthorizedError'
+
+        let(:Authorization) { nil }
+        let(:page) { nil }
+        let(:per_page) { nil }
+
+        run_test!
+      end
+
+      response '401', 'Token éditeur invalide' do
+        schema '$ref' => '#/components/schemas/UnauthorizedError'
+
+        let(:Authorization) { 'Bearer not-a-valid-jwt' }
+        let(:page) { nil }
+        let(:per_page) { nil }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/site/spec/lib/editor/api/v1/delegation_serializer_spec.rb
+++ b/site/spec/lib/editor/api/v1/delegation_serializer_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe Editor::API::V1::DelegationSerializer do
+  let(:authorization_request) do
+    create(:authorization_request, :validated,
+      api: 'entreprise',
+      external_id: '4242',
+      siret: '13002526500013',
+      intitule: 'My Délégation',
+      scopes: %w[unites_legales_etablissements_insee])
+  end
+
+  describe '#as_json' do
+    it 'serializes an active delegation with all expected fields' do
+      delegation = create(:editor_delegation, authorization_request:,
+        created_at: Time.zone.local(2026, 3, 14, 12, 0, 0))
+
+      expect(described_class.new(delegation).as_json).to eq(
+        id: delegation.id,
+        authorization_request_id: 4242,
+        siret: '13002526500013',
+        intitule: 'My Délégation',
+        scopes: %w[unites_legales_etablissements_insee],
+        statut: 'active',
+        created_at: '2026-03-14T11:00:00Z'
+      )
+    end
+
+    it 'marks revoked delegations with statut=revoked' do
+      delegation = create(:editor_delegation, authorization_request:, revoked_at: 1.hour.ago)
+
+      expect(described_class.new(delegation).as_json).to include(statut: 'revoked')
+    end
+
+    it 'returns an empty array when the AR has no scopes' do
+      ar_without_scopes = create(:authorization_request, :validated,
+        api: 'entreprise', external_id: '5000', scopes: [])
+      delegation = create(:editor_delegation, authorization_request: ar_without_scopes)
+
+      expect(described_class.new(delegation).as_json[:scopes]).to eq([])
+    end
+  end
+end

--- a/site/spec/requests/editor/api/v1/delegations_spec.rb
+++ b/site/spec/requests/editor/api/v1/delegations_spec.rb
@@ -1,0 +1,198 @@
+require 'rails_helper'
+
+RSpec.describe 'Editor::API::V1::Delegations' do
+  let(:endpoint) { '/editeur/api/v1/delegations' }
+  let(:editor) { create(:editor, :delegable) }
+  let(:editor_token) { create(:editor_token, editor:) }
+  let(:headers) { { 'Authorization' => "Bearer #{editor_token.rehash}" } }
+
+  before { host! 'entreprise.api.localtest.me' }
+
+  describe 'GET /editeur/api/v1/delegations' do
+    context 'when no Authorization header is provided' do
+      it 'returns 401 with a JSON error' do
+        get endpoint
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.parsed_body).to eq('error' => 'Unauthorized')
+      end
+    end
+
+    context 'when the Authorization header is malformed' do
+      it 'returns 401 if the scheme is not Bearer' do
+        get endpoint, headers: { 'Authorization' => 'Basic deadbeef' }
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'returns 401 if the Bearer token is empty' do
+        get endpoint, headers: { 'Authorization' => 'Bearer ' }
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when the JWT is expired' do
+      let(:editor_token) { create(:editor_token, :expired, editor:) }
+
+      it 'returns 401' do
+        get endpoint, headers: headers
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when the EditorToken is blacklisted' do
+      let(:editor_token) { create(:editor_token, :blacklisted, editor:) }
+
+      it 'returns 401' do
+        get endpoint, headers: headers
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when the JWT belongs to a non-editor Token (admin)' do
+      let(:authorization_request) { create(:authorization_request, :validated) }
+      let(:admin_token) do
+        Token.create!(
+          Token.default_create_params.merge(
+            authorization_request:,
+            scopes: []
+          )
+        )
+      end
+      let(:headers) { { 'Authorization' => "Bearer #{admin_token.rehash}" } }
+
+      it 'returns 401 — admin tokens must not authenticate against the editor API' do
+        get endpoint, headers: headers
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when listing delegations' do
+      let!(:active_delegation_a) do
+        create(:editor_delegation, editor:,
+          authorization_request: create(:authorization_request, :validated,
+            api: 'entreprise',
+            external_id: '1001',
+            siret: '13002526500013',
+            intitule: 'Délégation A',
+            scopes: %w[unites_legales_etablissements_insee associations]),
+          created_at: 2.days.ago)
+      end
+      let!(:active_delegation_b) do
+        create(:editor_delegation, editor:,
+          authorization_request: create(:authorization_request, :validated,
+            api: 'entreprise',
+            external_id: '1002',
+            siret: '13002526500021',
+            intitule: 'Délégation B',
+            scopes: []),
+          created_at: 1.day.ago)
+      end
+      let!(:revoked_delegation) do
+        create(:editor_delegation, editor:, revoked_at: 1.hour.ago,
+          authorization_request: create(:authorization_request, :validated,
+            api: 'entreprise',
+            external_id: '999',
+            intitule: 'Révoquée'))
+      end
+      let!(:other_editor_delegation) do
+        create(:editor_delegation,
+          editor: create(:editor, :delegable, name: 'Other Editor'),
+          authorization_request: create(:authorization_request, :validated,
+            api: 'entreprise',
+            external_id: '777'))
+      end
+
+      it 'returns all delegations of the current editor (active and revoked)' do
+        get endpoint, headers: headers
+
+        expect(response).to have_http_status(:ok)
+        ids = response.parsed_body.fetch('data').pluck('id')
+        expect(ids).to contain_exactly(
+          active_delegation_a.id, active_delegation_b.id, revoked_delegation.id
+        )
+      end
+
+      it 'does not leak delegations from other editors' do
+        get endpoint, headers: headers
+
+        ids = response.parsed_body.fetch('data').pluck('id')
+        expect(ids).not_to include(other_editor_delegation.id)
+      end
+
+      it 'serializes each delegation with the expected fields and types' do
+        get endpoint, headers: headers
+
+        entry = response.parsed_body.fetch('data').find { |d| d['id'] == active_delegation_a.id }
+        expect(entry).to include(
+          'id' => active_delegation_a.id,
+          'authorization_request_id' => 1001,
+          'siret' => '13002526500013',
+          'intitule' => 'Délégation A',
+          'scopes' => %w[unites_legales_etablissements_insee associations],
+          'statut' => 'active'
+        )
+        expect(entry['created_at']).to match(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z\z/)
+      end
+
+      it 'marks revoked delegations with statut=revoked' do
+        get endpoint, headers: headers
+
+        entry = response.parsed_body.fetch('data').find { |d| d['id'] == revoked_delegation.id }
+        expect(entry).to include('statut' => 'revoked')
+      end
+    end
+
+    context 'when paginating' do
+      before do
+        51.times do |i|
+          create(:editor_delegation, editor:,
+            authorization_request: create(:authorization_request, :validated,
+              api: 'entreprise', external_id: (10_000 + i).to_s),
+            created_at: i.minutes.ago)
+        end
+      end
+
+      it 'returns 50 entries per page by default with full meta block' do
+        get endpoint, headers: headers
+
+        body = response.parsed_body
+        expect(body.fetch('data').size).to eq(50)
+        expect(body.fetch('meta')).to eq(
+          'page' => 1,
+          'per_page' => 50,
+          'total' => 51,
+          'total_pages' => 2
+        )
+      end
+
+      it 'returns the remaining entries on page 2' do
+        get endpoint, params: { page: 2 }, headers: headers
+
+        body = response.parsed_body
+        expect(body.fetch('data').size).to eq(1)
+        expect(body.fetch('meta')).to include('page' => 2, 'total_pages' => 2)
+      end
+
+      it 'caps per_page to 100 to avoid unbounded queries' do
+        get endpoint, params: { per_page: 200 }, headers: headers
+
+        body = response.parsed_body
+        expect(body.fetch('data').size).to eq(51)
+        expect(body.fetch('meta')).to include('per_page' => 100)
+      end
+
+      it 'accepts custom per_page within the cap' do
+        get endpoint, params: { per_page: 10 }, headers: headers
+
+        body = response.parsed_body
+        expect(body.fetch('data').size).to eq(10)
+        expect(body.fetch('meta')).to include('per_page' => 10, 'total_pages' => 6)
+      end
+    end
+  end
+end

--- a/site/spec/requests/editor/api/v1/host_routing_spec.rb
+++ b/site/spec/requests/editor/api/v1/host_routing_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+RSpec.describe 'Editor API host routing' do
+  let(:endpoint) { '/editeur/api/v1/delegations' }
+  let(:editor) { create(:editor, :delegable) }
+  let(:editor_token) { create(:editor_token, editor:) }
+  let(:headers) { { 'Authorization' => "Bearer #{editor_token.rehash}" } }
+
+  context 'when called on the entreprise host' do
+    before { host! 'entreprise.api.localtest.me' }
+
+    it 'reaches the controller (200 with a valid token)' do
+      get endpoint, headers: headers
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context 'when called on the particulier host' do
+    before { host! 'particulier.api.localtest.me' }
+
+    it 'reaches the controller (200 with a valid token)' do
+      get endpoint, headers: headers
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context 'when called on the production entreprise host' do
+    before { host! 'entreprise.api.gouv.fr' }
+
+    it 'reaches the controller' do
+      get endpoint, headers: headers
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context 'when called on the production particulier host' do
+    before { host! 'particulier.api.gouv.fr' }
+
+    it 'reaches the controller' do
+      get endpoint, headers: headers
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context 'when called on a host that is not entreprise/particulier' do
+    before { host! 'dashboard.example.com' }
+
+    it 'does not match the route — auth never runs' do
+      expect { get endpoint, headers: headers }.to raise_error(ActionController::RoutingError)
+    end
+  end
+
+  context 'when called on a host that just contains the word entreprise' do
+    before { host! 'evil-entreprise.example.com' }
+
+    it 'does not match the route' do
+      expect { get endpoint, headers: headers }.to raise_error(ActionController::RoutingError)
+    end
+  end
+
+  context 'when the editor has delegations on both APIs' do
+    let!(:entreprise_delegation) do
+      create(:editor_delegation, editor:,
+        authorization_request: create(:authorization_request, :validated,
+          api: 'entreprise', external_id: '1001'))
+    end
+    let!(:particulier_delegation) do
+      create(:editor_delegation, editor:,
+        authorization_request: create(:authorization_request, :validated,
+          api: 'particulier', external_id: '2001'))
+    end
+
+    it 'only returns entreprise delegations when called on the entreprise host' do
+      host! 'entreprise.api.localtest.me'
+
+      get endpoint, headers: headers
+
+      ids = response.parsed_body.fetch('data').pluck('id')
+      expect(ids).to contain_exactly(entreprise_delegation.id)
+    end
+
+    it 'only returns particulier delegations when called on the particulier host' do
+      host! 'particulier.api.localtest.me'
+
+      get endpoint, headers: headers
+
+      ids = response.parsed_body.fetch('data').pluck('id')
+      expect(ids).to contain_exactly(particulier_delegation.id)
+    end
+  end
+end

--- a/site/spec/swagger_helper.rb
+++ b/site/spec/swagger_helper.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+RSpec.configure do |config|
+  config.openapi_root = Rails.root.join('swagger').to_s
+
+  config.openapi_specs = {
+    'v1/openapi-editor.yaml' => {
+      openapi: '3.0.1',
+      info: {
+        title: 'API Éditeur — API Entreprise',
+        version: 'v1',
+        description: <<~DESC
+          API destinée aux SaaS éditeurs intégrant API Entreprise via le système
+          de délégation. Permet à un éditeur authentifié par token éditeur de
+          récupérer la liste de ses délégations, puis de mapper `siret → id`
+          pour passer `X-Delegation-Id` lors des appels métier vers
+          `entreprise.api.gouv.fr`.
+        DESC
+      },
+      paths: {},
+      components: {
+        securitySchemes: {
+          bearer_editor_token: {
+            type: :http,
+            scheme: :bearer,
+            bearerFormat: 'JWT',
+            description: "JWT éditeur (cf. dashboard éditeur > onglet 'Jetons de délégation')."
+          }
+        },
+        schemas: {
+          Delegation: {
+            type: :object,
+            required: %w[id authorization_request_id siret intitule scopes statut created_at],
+            properties: {
+              id: {
+                type: :string, format: :uuid,
+                description: "Identifiant unique de la délégation (UUID). À passer dans l'en-tête `X-Delegation-Id` sur les appels métier.",
+                example: '0d3e1c40-66cb-4d54-9c44-5b53d1c1de5d'
+              },
+              authorization_request_id: {
+                type: :integer,
+                description: 'Identifiant DataPass de la demande d’habilitation associée.',
+                example: 1234
+              },
+              siret: {
+                type: :string,
+                description: "SIRET de l'administration cliente.",
+                example: '13002526500013'
+              },
+              intitule: {
+                type: :string,
+                description: "Intitulé fonctionnel de l'habilitation tel que renseigné dans DataPass."
+              },
+              scopes: {
+                type: :array,
+                items: { type: :string },
+                description: 'Liste des scopes API techniquement accessibles via cette délégation.'
+              },
+              statut: {
+                type: :string,
+                enum: %w[active revoked],
+                description: 'Statut courant de la délégation.'
+              },
+              created_at: {
+                type: :string, format: 'date-time',
+                description: 'Date de création de la délégation (ISO 8601 UTC).'
+              }
+            }
+          },
+          PaginationMeta: {
+            type: :object,
+            properties: {
+              page: { type: :integer, example: 1 },
+              per_page: { type: :integer, example: 50 },
+              total: { type: :integer, example: 137 },
+              total_pages: { type: :integer, example: 3 }
+            }
+          },
+          UnauthorizedError: {
+            type: :object,
+            properties: {
+              error: { type: :string, example: 'Unauthorized' }
+            }
+          }
+        }
+      },
+      servers: [
+        { url: 'https://entreprise.api.gouv.fr', description: 'Production — API Entreprise' },
+        { url: 'https://particulier.api.gouv.fr', description: 'Production — API Particulier' }
+      ]
+    }
+  }
+
+  config.openapi_format = :yaml
+end

--- a/site/swagger/v1/openapi-editor.yaml
+++ b/site/swagger/v1/openapi-editor.yaml
@@ -1,0 +1,140 @@
+---
+openapi: 3.0.1
+info:
+  title: API Éditeur — API Entreprise
+  version: v1
+  description: |
+    API destinée aux SaaS éditeurs intégrant API Entreprise via le système
+    de délégation. Permet à un éditeur authentifié par token éditeur de
+    récupérer la liste de ses délégations, puis de mapper `siret → id`
+    pour passer `X-Delegation-Id` lors des appels métier vers
+    `entreprise.api.gouv.fr`.
+paths:
+  "/editeur/api/v1/delegations":
+    get:
+      summary: Lister les délégations de l’éditeur
+      tags:
+      - Délégations
+      security:
+      - bearer_editor_token: []
+      description: |
+        Renvoie la liste des délégations dont dispose l'éditeur authentifié
+        sur l'API courante (entreprise ou particulier, déterminée par le
+        host appelé). Inclut les délégations actives et révoquées.
+      parameters:
+      - name: page
+        in: query
+        schema:
+          type: integer
+          minimum: 1
+        required: false
+        description: Page courante (défaut 1).
+      - name: per_page
+        in: query
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 100
+        required: false
+        description: Nombre d’entrées par page (défaut 50, max 100).
+      responses:
+        '200':
+          description: Liste des délégations
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                - data
+                - meta
+                properties:
+                  data:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/Delegation"
+                  meta:
+                    "$ref": "#/components/schemas/PaginationMeta"
+        '401':
+          description: Token éditeur invalide
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UnauthorizedError"
+components:
+  securitySchemes:
+    bearer_editor_token:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: JWT éditeur (cf. dashboard éditeur > onglet 'Jetons de délégation').
+  schemas:
+    Delegation:
+      type: object
+      required:
+      - id
+      - authorization_request_id
+      - siret
+      - intitule
+      - scopes
+      - statut
+      - created_at
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Identifiant unique de la délégation (UUID). À passer dans l'en-tête
+            `X-Delegation-Id` sur les appels métier.
+          example: 0d3e1c40-66cb-4d54-9c44-5b53d1c1de5d
+        authorization_request_id:
+          type: integer
+          description: Identifiant DataPass de la demande d’habilitation associée.
+          example: 1234
+        siret:
+          type: string
+          description: SIRET de l'administration cliente.
+          example: '13002526500013'
+        intitule:
+          type: string
+          description: Intitulé fonctionnel de l'habilitation tel que renseigné dans
+            DataPass.
+        scopes:
+          type: array
+          items:
+            type: string
+          description: Liste des scopes API techniquement accessibles via cette délégation.
+        statut:
+          type: string
+          enum:
+          - active
+          - revoked
+          description: Statut courant de la délégation.
+        created_at:
+          type: string
+          format: date-time
+          description: Date de création de la délégation (ISO 8601 UTC).
+    PaginationMeta:
+      type: object
+      properties:
+        page:
+          type: integer
+          example: 1
+        per_page:
+          type: integer
+          example: 50
+        total:
+          type: integer
+          example: 137
+        total_pages:
+          type: integer
+          example: 3
+    UnauthorizedError:
+      type: object
+      properties:
+        error:
+          type: string
+          example: Unauthorized
+servers:
+- url: https://entreprise.api.gouv.fr
+  description: Production — API Entreprise
+- url: https://particulier.api.gouv.fr
+  description: Production — API Particulier


### PR DESCRIPTION
## Summary

- Adds **`GET /editeur/api/v1/delegations`** — first endpoint of the editor-facing API. SaaS clients authenticate with their JWT editor token (Bearer), get back the list of their delegations as flat JSON, and map `siret → delegation_id` to set `X-Delegation-Id` on métier calls.
- Introduces a reusable **`Editor::API::BaseController`** that decodes the JWT via `AccessToken.decode`, enforces the `editor: true` claim (so admin tokens cannot cross into the editor API surface), and looks up an active `EditorToken` by `jti`. Any failure on the auth path returns 401 before reaching the action body.
- Bootstraps **rswag** in `site/` (gems + initializers + generators) — Swagger UI mounted at `/editeur/api-docs`, generated YAML at `site/swagger/v1/openapi-editor.yaml`, regenerate via `bin/generate_swagger.sh`.
- Pagination: default 50 / page, hard-capped at 100 to keep the query bounded. Cross-editor isolation enforced by scoping through `current_editor.editor_delegations`.

Closes [API-6627](https://linear.app/pole-api/issue/API-6627) (T8).

## Notes

- **Host** = `entreprise.api.gouv.fr` (option 2, confirmed by @skelz0r). The host-level routing/CORS configuration is handled separately by Loïc on the site/ side.
- **Clients SDKs** (`clients/ruby/`, `clients/node/`) are **not** updated: those target the métier APIs (siade/) per `clients/SPECS.md`, not the editor admin surface. This new endpoint is a separate API class that editors call once at startup.

## Test plan

- [x] `bundle exec rspec spec/requests/editor/api spec/lib/editor/api spec/integration/editor/api` — 25 examples, 0 failures
- [x] `bundle exec rubocop` on touched files — clean
- [x] `./bin/brakeman` — no new warnings (same 15 pre-existing, 8 ignored)
- [x] `bin/generate_swagger.sh` produces `site/swagger/v1/openapi-editor.yaml`
- [ ] Manual: \`curl -H \"Authorization: Bearer \$(...)\" http://entreprise.api.localtest.me:5000/editeur/api/v1/delegations\` returns flat JSON; missing/invalid bearer returns 401
- [ ] Manual: Swagger UI loads at \`http://entreprise.api.localtest.me:5000/editeur/api-docs\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)