### PR TITLE
Add FC citizen civility payloads for CNOUS, AAH and AEEH

### DIFF
--- a/mocks/payloads/api_entreprise_v3_insee_successions/README.md
+++ b/mocks/payloads/api_entreprise_v3_insee_successions/README.md
@@ -86,7 +86,7 @@
       {
         "title": "Privilèges insuffisants",
         "detail": "Votre token est valide mais vos privilèges sont insuffisants. Listez vos privilèges sur /v2/privileges",
-        "code": "0100"
+        "code": "00100"
       }
     ]
   }
@@ -183,7 +183,10 @@
       {
         "title": "Erreur inconnue du fournisseur de données",
         "detail": "La réponse retournée par le fournisseur de données est invalide et inconnue de notre service. L'équipe technique a été notifiée de cette erreur pour investigation.",
-        "code": "01999"
+        "code": "01999",
+        "meta": {
+          "provider": "INSEE"
+        }
       }
     ]
   }
@@ -230,7 +233,10 @@
       {
         "title": "Service non disponible",
         "detail": "Service du fournisseur de données temporairement indisponible ou en maintenance.",
-        "code": "01001"
+        "code": "01001",
+        "meta": {
+          "provider": "INSEE"
+        }
       }
     ]
   }

--- a/mocks/payloads/api_entreprise_v3_insee_successions/summary.csv
+++ b/mocks/payloads/api_entreprise_v3_insee_successions/summary.csv
@@ -26,7 +26,7 @@ Reponse 403,INSEE Liens de successions - Exemple 403,"{""siret"":""3268222162525
     {
       ""title"": ""Privilèges insuffisants"",
       ""detail"": ""Votre token est valide mais vos privilèges sont insuffisants. Listez vos privilèges sur /v2/privileges"",
-      ""code"": ""0100""
+      ""code"": ""00100""
     }
   ]
 }"
@@ -47,7 +47,10 @@ Reponse 502,INSEE Liens de successions - Exemple 502,"{""siret"":""6122962873473
     {
       ""title"": ""Erreur inconnue du fournisseur de données"",
       ""detail"": ""La réponse retournée par le fournisseur de données est invalide et inconnue de notre service. L'équipe technique a été notifiée de cette erreur pour investigation."",
-      ""code"": ""01999""
+      ""code"": ""01999"",
+      ""meta"": {
+        ""provider"": ""INSEE""
+      }
     }
   ]
 }"
@@ -56,7 +59,10 @@ Réponse 504,INSEE Liens de successions - Exemple 504,"{""siret"":""391977701009
     {
       ""title"": ""Service non disponible"",
       ""detail"": ""Service du fournisseur de données temporairement indisponible ou en maintenance."",
-      ""code"": ""01001""
+      ""code"": ""01001"",
+      ""meta"": {
+        ""provider"": ""INSEE""
+      }
     }
   ]
 }"

--- a/mocks/payloads/api_particulier_v3_cnav_allocation_adulte_handicape_with_civility/200-usager-base-france_connect.yml
+++ b/mocks/payloads/api_particulier_v3_cnav_allocation_adulte_handicape_with_civility/200-usager-base-france_connect.yml
@@ -1,0 +1,27 @@
+---
+description:
+  ## Identité connue de la base de test de France Connect
+
+  Ce cas permet de tester un appel à partir notamment des données de l'identité
+  pivot France Connect.
+
+params:
+  nomNaissance: 'MERCIER'
+  prenoms:
+  - 'PIERRE'
+  anneeDateNaissance: 1969
+  moisDateNaissance: 3
+  jourDateNaissance: 17
+  codeCogInseeCommuneNaissance: '95277'
+  codeCogInseePaysNaissance: '99100'
+  sexeEtatCivil: 'M'
+status: 200
+payload: |-
+  {
+    "data": {
+      "est_beneficiaire": true,
+      "date_debut_droit": "2022-11-29"
+    },
+    "links": {},
+    "meta": {}
+  }

--- a/mocks/payloads/api_particulier_v3_cnav_allocation_adulte_handicape_with_civility/README.md
+++ b/mocks/payloads/api_particulier_v3_cnav_allocation_adulte_handicape_with_civility/README.md
@@ -1,4 +1,57 @@
 # [Identité] Statut allocation adulte handicapé (AAH)
+* [200-usager-base-france_connect.yml](200-usager-base-france_connect.yml)
+
+  Status `200`
+
+  Ce cas permet de tester un appel à partir notamment des données de l'identité pivot France Connect.
+
+  <details><summary>Paramètres</summary>
+  <p>
+
+  ```json
+  {
+    "nomNaissance": "MERCIER",
+    "prenoms": [
+      "PIERRE"
+    ],
+    "anneeDateNaissance": 1969,
+    "moisDateNaissance": 3,
+    "jourDateNaissance": 17,
+    "codeCogInseeCommuneNaissance": "95277",
+    "codeCogInseePaysNaissance": "99100",
+    "sexeEtatCivil": "M"
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Réponse API</summary>
+  <p>
+
+  ```json
+  {
+    "data": {
+      "est_beneficiaire": true,
+      "date_debut_droit": "2022-11-29"
+    },
+    "links": {},
+    "meta": {}
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Commande cURL</summary>
+  <p>
+
+  ```bash
+  curl -H "Authorization: Bearer $token_france_connect" --url "https://staging.particulier.api.gouv.fr/v3/dss/allocation_adulte_handicape/identite?recipient=13002526500013"
+  ```
+
+  </p>
+  </details>
 * [200_beneficiaire.yaml](200_beneficiaire.yaml)
 
   Status `200`

--- a/mocks/payloads/api_particulier_v3_cnav_allocation_adulte_handicape_with_civility/summary.csv
+++ b/mocks/payloads/api_particulier_v3_cnav_allocation_adulte_handicape_with_civility/summary.csv
@@ -1,4 +1,12 @@
 Titre,Description,Paramètres,Status,Réponse
+,Ce cas permet de tester un appel à partir notamment des données de l'identité pivot France Connect.,"{""nomNaissance"":""MERCIER"",""prenoms"":[""PIERRE""],""anneeDateNaissance"":1969,""moisDateNaissance"":3,""jourDateNaissance"":17,""codeCogInseeCommuneNaissance"":""95277"",""codeCogInseePaysNaissance"":""99100"",""sexeEtatCivil"":""M""}",200,"{
+  ""data"": {
+    ""est_beneficiaire"": true,
+    ""date_debut_droit"": ""2022-11-29""
+  },
+  ""links"": {},
+  ""meta"": {}
+}"
 ,## Bénéficiaire,"{""nomUsage"":""DUPONT"",""nomNaissance"":""MARTIN"",""prenoms"":[""PIERRE"",""RICHARD""],""anneeDateNaissance"":1987,""moisDateNaissance"":12,""jourDateNaissance"":1,""codeCogInseeCommuneNaissance"":""08480"",""codeCogInseePaysNaissance"":""99100"",""sexeEtatCivil"":""M""}",200,"{
   ""data"": {
     ""est_beneficiaire"": true,

--- a/mocks/payloads/api_particulier_v3_cnav_allocation_enfant_handicape_with_civility/200-usager-base-france_connect.yml
+++ b/mocks/payloads/api_particulier_v3_cnav_allocation_enfant_handicape_with_civility/200-usager-base-france_connect.yml
@@ -1,0 +1,27 @@
+---
+description:
+  ## Identité connue de la base de test de France Connect
+
+  Ce cas permet de tester un appel à partir notamment des données de l'identité
+  pivot France Connect.
+
+params:
+  nomNaissance: 'MERCIER'
+  prenoms:
+  - 'PIERRE'
+  anneeDateNaissance: 1969
+  moisDateNaissance: 3
+  jourDateNaissance: 17
+  codeCogInseeCommuneNaissance: '95277'
+  codeCogInseePaysNaissance: '99100'
+  sexeEtatCivil: 'M'
+status: 200
+payload: |-
+  {
+    "data": {
+      "status": "allocataire",
+      "date_debut_droit": "2023-06-15"
+    },
+    "links": {},
+    "meta": {}
+  }

--- a/mocks/payloads/api_particulier_v3_cnav_allocation_enfant_handicape_with_civility/README.md
+++ b/mocks/payloads/api_particulier_v3_cnav_allocation_enfant_handicape_with_civility/README.md
@@ -1,4 +1,57 @@
 # [Identité] Statut allocation d'éducation de l'enfant handicapé (AEEH)
+* [200-usager-base-france_connect.yml](200-usager-base-france_connect.yml)
+
+  Status `200`
+
+  Ce cas permet de tester un appel à partir notamment des données de l'identité pivot France Connect.
+
+  <details><summary>Paramètres</summary>
+  <p>
+
+  ```json
+  {
+    "nomNaissance": "MERCIER",
+    "prenoms": [
+      "PIERRE"
+    ],
+    "anneeDateNaissance": 1969,
+    "moisDateNaissance": 3,
+    "jourDateNaissance": 17,
+    "codeCogInseeCommuneNaissance": "95277",
+    "codeCogInseePaysNaissance": "99100",
+    "sexeEtatCivil": "M"
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Réponse API</summary>
+  <p>
+
+  ```json
+  {
+    "data": {
+      "status": "allocataire",
+      "date_debut_droit": "2023-06-15"
+    },
+    "links": {},
+    "meta": {}
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Commande cURL</summary>
+  <p>
+
+  ```bash
+  curl -H "Authorization: Bearer $token_france_connect" --url "https://staging.particulier.api.gouv.fr/v3/dss/allocation_enfant_handicape/identite?recipient=13002526500013"
+  ```
+
+  </p>
+  </details>
 * [200_beneficiaire.yaml](200_beneficiaire.yaml)
 
   Status `200`

--- a/mocks/payloads/api_particulier_v3_cnav_allocation_enfant_handicape_with_civility/summary.csv
+++ b/mocks/payloads/api_particulier_v3_cnav_allocation_enfant_handicape_with_civility/summary.csv
@@ -1,4 +1,12 @@
 Titre,Description,Paramètres,Status,Réponse
+,Ce cas permet de tester un appel à partir notamment des données de l'identité pivot France Connect.,"{""nomNaissance"":""MERCIER"",""prenoms"":[""PIERRE""],""anneeDateNaissance"":1969,""moisDateNaissance"":3,""jourDateNaissance"":17,""codeCogInseeCommuneNaissance"":""95277"",""codeCogInseePaysNaissance"":""99100"",""sexeEtatCivil"":""M""}",200,"{
+  ""data"": {
+    ""status"": ""allocataire"",
+    ""date_debut_droit"": ""2023-06-15""
+  },
+  ""links"": {},
+  ""meta"": {}
+}"
 ,## Bénéficiaire,"{""nomNaissance"":""DUPONT"",""prenoms"":[""PIERRE""],""anneeDateNaissance"":2015,""moisDateNaissance"":3,""jourDateNaissance"":12,""codeCogInseeCommuneNaissance"":""75112"",""codeCogInseePaysNaissance"":""99100"",""sexeEtatCivil"":""M""}",200,"{
   ""data"": {
     ""status"": ""allocataire"",

--- a/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_civility/200-usager-base-france_connect.yml
+++ b/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_civility/200-usager-base-france_connect.yml
@@ -1,0 +1,51 @@
+---
+description:
+  ## Identité connue de la base de test de France Connect
+
+  Ce cas permet de tester un appel à partir notamment des données de l'identité
+  pivot France Connect.
+
+params:
+  nomNaissance: 'MERCIER'
+  prenoms:
+    - 'PIERRE'
+  anneeDateNaissance: 1969
+  moisDateNaissance: 3
+  jourDateNaissance: 17
+  codeCogInseeCommuneNaissance: '95277'
+  sexeEtatCivil: 'M'
+status: 200
+payload: |-
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": false,
+        "est_radie": true,
+        "date_radiation": "1990-07-01"
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "1989-09-01",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Evry",
+        "nom_etablissement": "ENSIIE"
+      },
+      "echelon_bourse": {
+        "echelon": "5",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "pierre.mercier@mail.fr",
+      "identite": {
+        "nom": "MERCIER",
+        "prenoms": [
+          "PIERRE"
+        ],
+        "date_naissance": "1969-03-17",
+        "nom_commune_naissance": "Gonesse",
+        "sexe": "M"
+      }
+    },
+    "links": {},
+    "meta": {}
+  }

--- a/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_civility/README.md
+++ b/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_civility/README.md
@@ -1,4 +1,81 @@
 # [Identité] Statut étudiant boursier
+* [200-usager-base-france_connect.yml](200-usager-base-france_connect.yml)
+
+  Status `200`
+
+  Ce cas permet de tester un appel à partir notamment des données de l'identité pivot France Connect.
+
+  <details><summary>Paramètres</summary>
+  <p>
+
+  ```json
+  {
+    "nomNaissance": "MERCIER",
+    "prenoms": [
+      "PIERRE"
+    ],
+    "anneeDateNaissance": 1969,
+    "moisDateNaissance": 3,
+    "jourDateNaissance": 17,
+    "codeCogInseeCommuneNaissance": "95277",
+    "sexeEtatCivil": "M"
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Réponse API</summary>
+  <p>
+
+  ```json
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": false,
+        "est_radie": true,
+        "date_radiation": "1990-07-01"
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "1989-09-01",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Evry",
+        "nom_etablissement": "ENSIIE"
+      },
+      "echelon_bourse": {
+        "echelon": "5",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "pierre.mercier@mail.fr",
+      "identite": {
+        "nom": "MERCIER",
+        "prenoms": [
+          "PIERRE"
+        ],
+        "date_naissance": "1969-03-17",
+        "nom_commune_naissance": "Gonesse",
+        "sexe": "M"
+      }
+    },
+    "links": {},
+    "meta": {}
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Commande cURL</summary>
+  <p>
+
+  ```bash
+  curl -H "Authorization: Bearer $token_france_connect" --url "https://staging.particulier.api.gouv.fr/v4/cnous/etudiant_boursier/identite?recipient=13002526500013"
+  ```
+
+  </p>
+  </details>
 * [200_boursier.yaml](200_boursier.yaml)
 
   Status `200`

--- a/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_civility/summary.csv
+++ b/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_civility/summary.csv
@@ -1,4 +1,37 @@
 Titre,Description,Paramètres,Status,Réponse
+,Ce cas permet de tester un appel à partir notamment des données de l'identité pivot France Connect.,"{""nomNaissance"":""MERCIER"",""prenoms"":[""PIERRE""],""anneeDateNaissance"":1969,""moisDateNaissance"":3,""jourDateNaissance"":17,""codeCogInseeCommuneNaissance"":""95277"",""sexeEtatCivil"":""M""}",200,"{
+  ""data"": {
+    ""statut_boursier"": {
+      ""est_boursier"": false,
+      ""est_radie"": true,
+      ""date_radiation"": ""1990-07-01""
+    },
+    ""periode_versement_bourse"": {
+      ""date_rentree"": ""1989-09-01"",
+      ""duree"": 12
+    },
+    ""etablissement_etudes"": {
+      ""nom_commune"": ""Evry"",
+      ""nom_etablissement"": ""ENSIIE""
+    },
+    ""echelon_bourse"": {
+      ""echelon"": ""5"",
+      ""echelon_bourse_regionale_provisoire"": false
+    },
+    ""email"": ""pierre.mercier@mail.fr"",
+    ""identite"": {
+      ""nom"": ""MERCIER"",
+      ""prenoms"": [
+        ""PIERRE""
+      ],
+      ""date_naissance"": ""1969-03-17"",
+      ""nom_commune_naissance"": ""Gonesse"",
+      ""sexe"": ""M""
+    }
+  },
+  ""links"": {},
+  ""meta"": {}
+}"
 ,Boursier échelon 5,"{""nomNaissance"":""Pagnol"",""prenoms"":[""Marcel""],""anneeDateNaissance"":1998,""moisDateNaissance"":7,""jourDateNaissance"":12,""codeCogInseeCommuneNaissance"":""75000"",""sexeEtatCivil"":""M""}",200,"{
   ""data"": {
     ""statut_boursier"": {


### PR DESCRIPTION
## Summary

- Add FranceConnect citizen payloads with civility for API Particulier v4 CNOUS (étudiant boursier)
- Add FranceConnect citizen payloads with civility for API Particulier v3 AAH (allocation adulte handicapé)
- Add FranceConnect citizen payloads with civility for API Particulier v3 AEEH (allocation enfant handicapé)
- Regenerate mocks README and summary.csv for the new payloads

## Auteur original

@Benoit-MINT

## Test plan

- [ ] Vérifier que les payloads sont bien servis par le mock server
- [ ] Vérifier que les README générés sont cohérents avec les fichiers YAML