### PR TITLE
FIX FranceConnect endpoint with missing FranceConnect token and classic token

### DIFF
--- a/commons/swagger/openapi-particulier.yaml
+++ b/commons/swagger/openapi-particulier.yaml
@@ -106,6 +106,64 @@ paths:
                     Listez vos privilèges sur /api/introspect
               schema:
                 "$ref": "#/components/schemas/Error"
+        '401':
+          description: Non autorisé
+          content:
+            application/json:
+              examples:
+                missing_france_connect_access_token_error:
+                  value:
+                    errors:
+                    - code: '50004'
+                      title: Accès non autorisé
+                      detail: 'Le jeton d''accès FranceConnect est manquant. Cet endpoint
+                        requiert un jeton d''accès FranceConnect transmis via l''en-tête
+                        Authorization: Bearer.'
+                      source:
+                      meta: {}
+                  summary: Accès non autorisé
+                  description: 'Le jeton d''accès FranceConnect est manquant. Cet
+                    endpoint requiert un jeton d''accès FranceConnect transmis via
+                    l''en-tête Authorization: Bearer.'
+                invalid_token_error:
+                  value:
+                    errors:
+                    - code: '00101'
+                      title: Interdit
+                      detail: Votre token n'est pas valide ou n'est pas renseigné
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Interdit
+                  description: Votre token n'est pas valide ou n'est pas renseigné
+                expired_token_error:
+                  value:
+                    errors:
+                    - code: '00103'
+                      title: Jeton expiré
+                      detail: Votre token est expiré. Vous devez refaire une demande
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Jeton expiré
+                  description: Votre token est expiré. Vous devez refaire une demande
+                blacklisted_token_error:
+                  value:
+                    errors:
+                    - code: '00105'
+                      title: Jeton sur liste noire
+                      detail: 'Votre jeton est sur liste noire, celui-ci a certainement
+                        été divulgué sur un canal non-sécurisé. Vous pouvez trouver
+                        un jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Jeton sur liste noire
+                  description: 'Votre jeton est sur liste noire, celui-ci a certainement
+                    été divulgué sur un canal non-sécurisé. Vous pouvez trouver un
+                    jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
+              schema:
+                "$ref": "#/components/schemas/Error"
         '200':
           description: Identité trouvée
           headers:
@@ -626,50 +684,6 @@ paths:
                     sont pas connus, ou ne comportent aucune information pour cet
                     appel. Veuillez vérifier que votre recherche est couverte par
                     le périmètre de l'API.
-              schema:
-                "$ref": "#/components/schemas/Error"
-        '401':
-          description: Non autorisé
-          content:
-            application/json:
-              examples:
-                invalid_token_error:
-                  value:
-                    errors:
-                    - code: '00101'
-                      title: Interdit
-                      detail: Votre token n'est pas valide ou n'est pas renseigné
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Interdit
-                  description: Votre token n'est pas valide ou n'est pas renseigné
-                expired_token_error:
-                  value:
-                    errors:
-                    - code: '00103'
-                      title: Jeton expiré
-                      detail: Votre token est expiré. Vous devez refaire une demande
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Jeton expiré
-                  description: Votre token est expiré. Vous devez refaire une demande
-                blacklisted_token_error:
-                  value:
-                    errors:
-                    - code: '00105'
-                      title: Jeton sur liste noire
-                      detail: 'Votre jeton est sur liste noire, celui-ci a certainement
-                        été divulgué sur un canal non-sécurisé. Vous pouvez trouver
-                        un jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Jeton sur liste noire
-                  description: 'Votre jeton est sur liste noire, celui-ci a certainement
-                    été divulgué sur un canal non-sécurisé. Vous pouvez trouver un
-                    jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
               schema:
                 "$ref": "#/components/schemas/Error"
         '409':
@@ -1332,6 +1346,64 @@ paths:
                     Listez vos privilèges sur /api/introspect
               schema:
                 "$ref": "#/components/schemas/Error"
+        '401':
+          description: Non autorisé
+          content:
+            application/json:
+              examples:
+                missing_france_connect_access_token_error:
+                  value:
+                    errors:
+                    - code: '50004'
+                      title: Accès non autorisé
+                      detail: 'Le jeton d''accès FranceConnect est manquant. Cet endpoint
+                        requiert un jeton d''accès FranceConnect transmis via l''en-tête
+                        Authorization: Bearer.'
+                      source:
+                      meta: {}
+                  summary: Accès non autorisé
+                  description: 'Le jeton d''accès FranceConnect est manquant. Cet
+                    endpoint requiert un jeton d''accès FranceConnect transmis via
+                    l''en-tête Authorization: Bearer.'
+                invalid_token_error:
+                  value:
+                    errors:
+                    - code: '00101'
+                      title: Interdit
+                      detail: Votre token n'est pas valide ou n'est pas renseigné
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Interdit
+                  description: Votre token n'est pas valide ou n'est pas renseigné
+                expired_token_error:
+                  value:
+                    errors:
+                    - code: '00103'
+                      title: Jeton expiré
+                      detail: Votre token est expiré. Vous devez refaire une demande
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Jeton expiré
+                  description: Votre token est expiré. Vous devez refaire une demande
+                blacklisted_token_error:
+                  value:
+                    errors:
+                    - code: '00105'
+                      title: Jeton sur liste noire
+                      detail: 'Votre jeton est sur liste noire, celui-ci a certainement
+                        été divulgué sur un canal non-sécurisé. Vous pouvez trouver
+                        un jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Jeton sur liste noire
+                  description: 'Votre jeton est sur liste noire, celui-ci a certainement
+                    été divulgué sur un canal non-sécurisé. Vous pouvez trouver un
+                    jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
+              schema:
+                "$ref": "#/components/schemas/Error"
         '200':
           description: Dossier trouvé
           headers:
@@ -1461,50 +1533,6 @@ paths:
                   summary: Erreur inattendue
                   description: Une erreur inattendue est survenue lors de la collecte
                     des données
-              schema:
-                "$ref": "#/components/schemas/Error"
-        '401':
-          description: Non autorisé
-          content:
-            application/json:
-              examples:
-                invalid_token_error:
-                  value:
-                    errors:
-                    - code: '00101'
-                      title: Interdit
-                      detail: Votre token n'est pas valide ou n'est pas renseigné
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Interdit
-                  description: Votre token n'est pas valide ou n'est pas renseigné
-                expired_token_error:
-                  value:
-                    errors:
-                    - code: '00103'
-                      title: Jeton expiré
-                      detail: Votre token est expiré. Vous devez refaire une demande
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Jeton expiré
-                  description: Votre token est expiré. Vous devez refaire une demande
-                blacklisted_token_error:
-                  value:
-                    errors:
-                    - code: '00105'
-                      title: Jeton sur liste noire
-                      detail: 'Votre jeton est sur liste noire, celui-ci a certainement
-                        été divulgué sur un canal non-sécurisé. Vous pouvez trouver
-                        un jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Jeton sur liste noire
-                  description: 'Votre jeton est sur liste noire, celui-ci a certainement
-                    été divulgué sur un canal non-sécurisé. Vous pouvez trouver un
-                    jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
               schema:
                 "$ref": "#/components/schemas/Error"
         '409':
@@ -2167,6 +2195,64 @@ paths:
                     Listez vos privilèges sur /api/introspect
               schema:
                 "$ref": "#/components/schemas/Error"
+        '401':
+          description: Non autorisé
+          content:
+            application/json:
+              examples:
+                missing_france_connect_access_token_error:
+                  value:
+                    errors:
+                    - code: '50004'
+                      title: Accès non autorisé
+                      detail: 'Le jeton d''accès FranceConnect est manquant. Cet endpoint
+                        requiert un jeton d''accès FranceConnect transmis via l''en-tête
+                        Authorization: Bearer.'
+                      source:
+                      meta: {}
+                  summary: Accès non autorisé
+                  description: 'Le jeton d''accès FranceConnect est manquant. Cet
+                    endpoint requiert un jeton d''accès FranceConnect transmis via
+                    l''en-tête Authorization: Bearer.'
+                invalid_token_error:
+                  value:
+                    errors:
+                    - code: '00101'
+                      title: Interdit
+                      detail: Votre token n'est pas valide ou n'est pas renseigné
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Interdit
+                  description: Votre token n'est pas valide ou n'est pas renseigné
+                expired_token_error:
+                  value:
+                    errors:
+                    - code: '00103'
+                      title: Jeton expiré
+                      detail: Votre token est expiré. Vous devez refaire une demande
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Jeton expiré
+                  description: Votre token est expiré. Vous devez refaire une demande
+                blacklisted_token_error:
+                  value:
+                    errors:
+                    - code: '00105'
+                      title: Jeton sur liste noire
+                      detail: 'Votre jeton est sur liste noire, celui-ci a certainement
+                        été divulgué sur un canal non-sécurisé. Vous pouvez trouver
+                        un jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Jeton sur liste noire
+                  description: 'Votre jeton est sur liste noire, celui-ci a certainement
+                    été divulgué sur un canal non-sécurisé. Vous pouvez trouver un
+                    jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
+              schema:
+                "$ref": "#/components/schemas/Error"
         '200':
           description: Dossier trouvé
           headers:
@@ -2309,50 +2395,6 @@ paths:
                   summary: Erreur inattendue
                   description: Une erreur inattendue est survenue lors de la collecte
                     des données
-              schema:
-                "$ref": "#/components/schemas/Error"
-        '401':
-          description: Non autorisé
-          content:
-            application/json:
-              examples:
-                invalid_token_error:
-                  value:
-                    errors:
-                    - code: '00101'
-                      title: Interdit
-                      detail: Votre token n'est pas valide ou n'est pas renseigné
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Interdit
-                  description: Votre token n'est pas valide ou n'est pas renseigné
-                expired_token_error:
-                  value:
-                    errors:
-                    - code: '00103'
-                      title: Jeton expiré
-                      detail: Votre token est expiré. Vous devez refaire une demande
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Jeton expiré
-                  description: Votre token est expiré. Vous devez refaire une demande
-                blacklisted_token_error:
-                  value:
-                    errors:
-                    - code: '00105'
-                      title: Jeton sur liste noire
-                      detail: 'Votre jeton est sur liste noire, celui-ci a certainement
-                        été divulgué sur un canal non-sécurisé. Vous pouvez trouver
-                        un jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Jeton sur liste noire
-                  description: 'Votre jeton est sur liste noire, celui-ci a certainement
-                    été divulgué sur un canal non-sécurisé. Vous pouvez trouver un
-                    jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
               schema:
                 "$ref": "#/components/schemas/Error"
         '409':
@@ -3000,6 +3042,64 @@ paths:
                     Listez vos privilèges sur /api/introspect
               schema:
                 "$ref": "#/components/schemas/Error"
+        '401':
+          description: Non autorisé
+          content:
+            application/json:
+              examples:
+                missing_france_connect_access_token_error:
+                  value:
+                    errors:
+                    - code: '50004'
+                      title: Accès non autorisé
+                      detail: 'Le jeton d''accès FranceConnect est manquant. Cet endpoint
+                        requiert un jeton d''accès FranceConnect transmis via l''en-tête
+                        Authorization: Bearer.'
+                      source:
+                      meta: {}
+                  summary: Accès non autorisé
+                  description: 'Le jeton d''accès FranceConnect est manquant. Cet
+                    endpoint requiert un jeton d''accès FranceConnect transmis via
+                    l''en-tête Authorization: Bearer.'
+                invalid_token_error:
+                  value:
+                    errors:
+                    - code: '00101'
+                      title: Interdit
+                      detail: Votre token n'est pas valide ou n'est pas renseigné
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Interdit
+                  description: Votre token n'est pas valide ou n'est pas renseigné
+                expired_token_error:
+                  value:
+                    errors:
+                    - code: '00103'
+                      title: Jeton expiré
+                      detail: Votre token est expiré. Vous devez refaire une demande
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Jeton expiré
+                  description: Votre token est expiré. Vous devez refaire une demande
+                blacklisted_token_error:
+                  value:
+                    errors:
+                    - code: '00105'
+                      title: Jeton sur liste noire
+                      detail: 'Votre jeton est sur liste noire, celui-ci a certainement
+                        été divulgué sur un canal non-sécurisé. Vous pouvez trouver
+                        un jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Jeton sur liste noire
+                  description: 'Votre jeton est sur liste noire, celui-ci a certainement
+                    été divulgué sur un canal non-sécurisé. Vous pouvez trouver un
+                    jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
+              schema:
+                "$ref": "#/components/schemas/Error"
         '200':
           description: Dossier trouvé
           headers:
@@ -3130,50 +3230,6 @@ paths:
                   summary: Erreur inattendue
                   description: Une erreur inattendue est survenue lors de la collecte
                     des données
-              schema:
-                "$ref": "#/components/schemas/Error"
-        '401':
-          description: Non autorisé
-          content:
-            application/json:
-              examples:
-                invalid_token_error:
-                  value:
-                    errors:
-                    - code: '00101'
-                      title: Interdit
-                      detail: Votre token n'est pas valide ou n'est pas renseigné
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Interdit
-                  description: Votre token n'est pas valide ou n'est pas renseigné
-                expired_token_error:
-                  value:
-                    errors:
-                    - code: '00103'
-                      title: Jeton expiré
-                      detail: Votre token est expiré. Vous devez refaire une demande
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Jeton expiré
-                  description: Votre token est expiré. Vous devez refaire une demande
-                blacklisted_token_error:
-                  value:
-                    errors:
-                    - code: '00105'
-                      title: Jeton sur liste noire
-                      detail: 'Votre jeton est sur liste noire, celui-ci a certainement
-                        été divulgué sur un canal non-sécurisé. Vous pouvez trouver
-                        un jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Jeton sur liste noire
-                  description: 'Votre jeton est sur liste noire, celui-ci a certainement
-                    été divulgué sur un canal non-sécurisé. Vous pouvez trouver un
-                    jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
               schema:
                 "$ref": "#/components/schemas/Error"
         '409':
@@ -3844,6 +3900,64 @@ paths:
                     Listez vos privilèges sur /api/introspect
               schema:
                 "$ref": "#/components/schemas/Error"
+        '401':
+          description: Non autorisé
+          content:
+            application/json:
+              examples:
+                missing_france_connect_access_token_error:
+                  value:
+                    errors:
+                    - code: '50004'
+                      title: Accès non autorisé
+                      detail: 'Le jeton d''accès FranceConnect est manquant. Cet endpoint
+                        requiert un jeton d''accès FranceConnect transmis via l''en-tête
+                        Authorization: Bearer.'
+                      source:
+                      meta: {}
+                  summary: Accès non autorisé
+                  description: 'Le jeton d''accès FranceConnect est manquant. Cet
+                    endpoint requiert un jeton d''accès FranceConnect transmis via
+                    l''en-tête Authorization: Bearer.'
+                invalid_token_error:
+                  value:
+                    errors:
+                    - code: '00101'
+                      title: Interdit
+                      detail: Votre token n'est pas valide ou n'est pas renseigné
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Interdit
+                  description: Votre token n'est pas valide ou n'est pas renseigné
+                expired_token_error:
+                  value:
+                    errors:
+                    - code: '00103'
+                      title: Jeton expiré
+                      detail: Votre token est expiré. Vous devez refaire une demande
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Jeton expiré
+                  description: Votre token est expiré. Vous devez refaire une demande
+                blacklisted_token_error:
+                  value:
+                    errors:
+                    - code: '00105'
+                      title: Jeton sur liste noire
+                      detail: 'Votre jeton est sur liste noire, celui-ci a certainement
+                        été divulgué sur un canal non-sécurisé. Vous pouvez trouver
+                        un jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Jeton sur liste noire
+                  description: 'Votre jeton est sur liste noire, celui-ci a certainement
+                    été divulgué sur un canal non-sécurisé. Vous pouvez trouver un
+                    jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
+              schema:
+                "$ref": "#/components/schemas/Error"
         '200':
           description: Dossier trouvé
           headers:
@@ -3993,50 +4107,6 @@ paths:
                   summary: Erreur inattendue
                   description: Une erreur inattendue est survenue lors de la collecte
                     des données
-              schema:
-                "$ref": "#/components/schemas/Error"
-        '401':
-          description: Non autorisé
-          content:
-            application/json:
-              examples:
-                invalid_token_error:
-                  value:
-                    errors:
-                    - code: '00101'
-                      title: Interdit
-                      detail: Votre token n'est pas valide ou n'est pas renseigné
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Interdit
-                  description: Votre token n'est pas valide ou n'est pas renseigné
-                expired_token_error:
-                  value:
-                    errors:
-                    - code: '00103'
-                      title: Jeton expiré
-                      detail: Votre token est expiré. Vous devez refaire une demande
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Jeton expiré
-                  description: Votre token est expiré. Vous devez refaire une demande
-                blacklisted_token_error:
-                  value:
-                    errors:
-                    - code: '00105'
-                      title: Jeton sur liste noire
-                      detail: 'Votre jeton est sur liste noire, celui-ci a certainement
-                        été divulgué sur un canal non-sécurisé. Vous pouvez trouver
-                        un jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Jeton sur liste noire
-                  description: 'Votre jeton est sur liste noire, celui-ci a certainement
-                    été divulgué sur un canal non-sécurisé. Vous pouvez trouver un
-                    jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
               schema:
                 "$ref": "#/components/schemas/Error"
         '409':
@@ -4846,6 +4916,64 @@ paths:
                     Listez vos privilèges sur /api/introspect
               schema:
                 "$ref": "#/components/schemas/Error"
+        '401':
+          description: Non autorisé
+          content:
+            application/json:
+              examples:
+                missing_france_connect_access_token_error:
+                  value:
+                    errors:
+                    - code: '50004'
+                      title: Accès non autorisé
+                      detail: 'Le jeton d''accès FranceConnect est manquant. Cet endpoint
+                        requiert un jeton d''accès FranceConnect transmis via l''en-tête
+                        Authorization: Bearer.'
+                      source:
+                      meta: {}
+                  summary: Accès non autorisé
+                  description: 'Le jeton d''accès FranceConnect est manquant. Cet
+                    endpoint requiert un jeton d''accès FranceConnect transmis via
+                    l''en-tête Authorization: Bearer.'
+                invalid_token_error:
+                  value:
+                    errors:
+                    - code: '00101'
+                      title: Interdit
+                      detail: Votre token n'est pas valide ou n'est pas renseigné
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Interdit
+                  description: Votre token n'est pas valide ou n'est pas renseigné
+                expired_token_error:
+                  value:
+                    errors:
+                    - code: '00103'
+                      title: Jeton expiré
+                      detail: Votre token est expiré. Vous devez refaire une demande
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Jeton expiré
+                  description: Votre token est expiré. Vous devez refaire une demande
+                blacklisted_token_error:
+                  value:
+                    errors:
+                    - code: '00105'
+                      title: Jeton sur liste noire
+                      detail: 'Votre jeton est sur liste noire, celui-ci a certainement
+                        été divulgué sur un canal non-sécurisé. Vous pouvez trouver
+                        un jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Jeton sur liste noire
+                  description: 'Votre jeton est sur liste noire, celui-ci a certainement
+                    été divulgué sur un canal non-sécurisé. Vous pouvez trouver un
+                    jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
+              schema:
+                "$ref": "#/components/schemas/Error"
         '200':
           description: Dossier trouvé
           headers:
@@ -5105,50 +5233,6 @@ paths:
                         provider: CNAV
                   summary: Entité non trouvée
                   description: Dossier allocataire inexistant.
-              schema:
-                "$ref": "#/components/schemas/Error"
-        '401':
-          description: Non autorisé
-          content:
-            application/json:
-              examples:
-                invalid_token_error:
-                  value:
-                    errors:
-                    - code: '00101'
-                      title: Interdit
-                      detail: Votre token n'est pas valide ou n'est pas renseigné
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Interdit
-                  description: Votre token n'est pas valide ou n'est pas renseigné
-                expired_token_error:
-                  value:
-                    errors:
-                    - code: '00103'
-                      title: Jeton expiré
-                      detail: Votre token est expiré. Vous devez refaire une demande
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Jeton expiré
-                  description: Votre token est expiré. Vous devez refaire une demande
-                blacklisted_token_error:
-                  value:
-                    errors:
-                    - code: '00105'
-                      title: Jeton sur liste noire
-                      detail: 'Votre jeton est sur liste noire, celui-ci a certainement
-                        été divulgué sur un canal non-sécurisé. Vous pouvez trouver
-                        un jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Jeton sur liste noire
-                  description: 'Votre jeton est sur liste noire, celui-ci a certainement
-                    été divulgué sur un canal non-sécurisé. Vous pouvez trouver un
-                    jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
               schema:
                 "$ref": "#/components/schemas/Error"
         '409':
@@ -5822,6 +5906,64 @@ paths:
                     Listez vos privilèges sur /api/introspect
               schema:
                 "$ref": "#/components/schemas/Error"
+        '401':
+          description: Non autorisé
+          content:
+            application/json:
+              examples:
+                missing_france_connect_access_token_error:
+                  value:
+                    errors:
+                    - code: '50004'
+                      title: Accès non autorisé
+                      detail: 'Le jeton d''accès FranceConnect est manquant. Cet endpoint
+                        requiert un jeton d''accès FranceConnect transmis via l''en-tête
+                        Authorization: Bearer.'
+                      source:
+                      meta: {}
+                  summary: Accès non autorisé
+                  description: 'Le jeton d''accès FranceConnect est manquant. Cet
+                    endpoint requiert un jeton d''accès FranceConnect transmis via
+                    l''en-tête Authorization: Bearer.'
+                invalid_token_error:
+                  value:
+                    errors:
+                    - code: '00101'
+                      title: Interdit
+                      detail: Votre token n'est pas valide ou n'est pas renseigné
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Interdit
+                  description: Votre token n'est pas valide ou n'est pas renseigné
+                expired_token_error:
+                  value:
+                    errors:
+                    - code: '00103'
+                      title: Jeton expiré
+                      detail: Votre token est expiré. Vous devez refaire une demande
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Jeton expiré
+                  description: Votre token est expiré. Vous devez refaire une demande
+                blacklisted_token_error:
+                  value:
+                    errors:
+                    - code: '00105'
+                      title: Jeton sur liste noire
+                      detail: 'Votre jeton est sur liste noire, celui-ci a certainement
+                        été divulgué sur un canal non-sécurisé. Vous pouvez trouver
+                        un jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Jeton sur liste noire
+                  description: 'Votre jeton est sur liste noire, celui-ci a certainement
+                    été divulgué sur un canal non-sécurisé. Vous pouvez trouver un
+                    jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
+              schema:
+                "$ref": "#/components/schemas/Error"
         '200':
           description: Dossier trouvé
           headers:
@@ -6110,50 +6252,6 @@ paths:
                   summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
                   description: 'Erreur de fournisseur de donnée : Trop de requêtes
                     effectuées, veuillez réessayer plus tard.'
-              schema:
-                "$ref": "#/components/schemas/Error"
-        '401':
-          description: Non autorisé
-          content:
-            application/json:
-              examples:
-                invalid_token_error:
-                  value:
-                    errors:
-                    - code: '00101'
-                      title: Interdit
-                      detail: Votre token n'est pas valide ou n'est pas renseigné
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Interdit
-                  description: Votre token n'est pas valide ou n'est pas renseigné
-                expired_token_error:
-                  value:
-                    errors:
-                    - code: '00103'
-                      title: Jeton expiré
-                      detail: Votre token est expiré. Vous devez refaire une demande
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Jeton expiré
-                  description: Votre token est expiré. Vous devez refaire une demande
-                blacklisted_token_error:
-                  value:
-                    errors:
-                    - code: '00105'
-                      title: Jeton sur liste noire
-                      detail: 'Votre jeton est sur liste noire, celui-ci a certainement
-                        été divulgué sur un canal non-sécurisé. Vous pouvez trouver
-                        un jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Jeton sur liste noire
-                  description: 'Votre jeton est sur liste noire, celui-ci a certainement
-                    été divulgué sur un canal non-sécurisé. Vous pouvez trouver un
-                    jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
               schema:
                 "$ref": "#/components/schemas/Error"
         '409':
@@ -7067,6 +7165,64 @@ paths:
                     Listez vos privilèges sur /api/introspect
               schema:
                 "$ref": "#/components/schemas/Error"
+        '401':
+          description: Non autorisé
+          content:
+            application/json:
+              examples:
+                missing_france_connect_access_token_error:
+                  value:
+                    errors:
+                    - code: '50004'
+                      title: Accès non autorisé
+                      detail: 'Le jeton d''accès FranceConnect est manquant. Cet endpoint
+                        requiert un jeton d''accès FranceConnect transmis via l''en-tête
+                        Authorization: Bearer.'
+                      source:
+                      meta: {}
+                  summary: Accès non autorisé
+                  description: 'Le jeton d''accès FranceConnect est manquant. Cet
+                    endpoint requiert un jeton d''accès FranceConnect transmis via
+                    l''en-tête Authorization: Bearer.'
+                invalid_token_error:
+                  value:
+                    errors:
+                    - code: '00101'
+                      title: Interdit
+                      detail: Votre token n'est pas valide ou n'est pas renseigné
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Interdit
+                  description: Votre token n'est pas valide ou n'est pas renseigné
+                expired_token_error:
+                  value:
+                    errors:
+                    - code: '00103'
+                      title: Jeton expiré
+                      detail: Votre token est expiré. Vous devez refaire une demande
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Jeton expiré
+                  description: Votre token est expiré. Vous devez refaire une demande
+                blacklisted_token_error:
+                  value:
+                    errors:
+                    - code: '00105'
+                      title: Jeton sur liste noire
+                      detail: 'Votre jeton est sur liste noire, celui-ci a certainement
+                        été divulgué sur un canal non-sécurisé. Vous pouvez trouver
+                        un jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Jeton sur liste noire
+                  description: 'Votre jeton est sur liste noire, celui-ci a certainement
+                    été divulgué sur un canal non-sécurisé. Vous pouvez trouver un
+                    jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
+              schema:
+                "$ref": "#/components/schemas/Error"
         '200':
           description: Dossier trouvé
           headers:
@@ -7427,50 +7583,6 @@ paths:
                   summary: Erreur inattendue
                   description: Une erreur inattendue est survenue lors de la collecte
                     des données
-              schema:
-                "$ref": "#/components/schemas/Error"
-        '401':
-          description: Non autorisé
-          content:
-            application/json:
-              examples:
-                invalid_token_error:
-                  value:
-                    errors:
-                    - code: '00101'
-                      title: Interdit
-                      detail: Votre token n'est pas valide ou n'est pas renseigné
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Interdit
-                  description: Votre token n'est pas valide ou n'est pas renseigné
-                expired_token_error:
-                  value:
-                    errors:
-                    - code: '00103'
-                      title: Jeton expiré
-                      detail: Votre token est expiré. Vous devez refaire une demande
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Jeton expiré
-                  description: Votre token est expiré. Vous devez refaire une demande
-                blacklisted_token_error:
-                  value:
-                    errors:
-                    - code: '00105'
-                      title: Jeton sur liste noire
-                      detail: 'Votre jeton est sur liste noire, celui-ci a certainement
-                        été divulgué sur un canal non-sécurisé. Vous pouvez trouver
-                        un jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Jeton sur liste noire
-                  description: 'Votre jeton est sur liste noire, celui-ci a certainement
-                    été divulgué sur un canal non-sécurisé. Vous pouvez trouver un
-                    jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
               schema:
                 "$ref": "#/components/schemas/Error"
         '409':
@@ -8127,6 +8239,64 @@ paths:
                     Listez vos privilèges sur /api/introspect
               schema:
                 "$ref": "#/components/schemas/Error"
+        '401':
+          description: Non autorisé
+          content:
+            application/json:
+              examples:
+                missing_france_connect_access_token_error:
+                  value:
+                    errors:
+                    - code: '50004'
+                      title: Accès non autorisé
+                      detail: 'Le jeton d''accès FranceConnect est manquant. Cet endpoint
+                        requiert un jeton d''accès FranceConnect transmis via l''en-tête
+                        Authorization: Bearer.'
+                      source:
+                      meta: {}
+                  summary: Accès non autorisé
+                  description: 'Le jeton d''accès FranceConnect est manquant. Cet
+                    endpoint requiert un jeton d''accès FranceConnect transmis via
+                    l''en-tête Authorization: Bearer.'
+                invalid_token_error:
+                  value:
+                    errors:
+                    - code: '00101'
+                      title: Interdit
+                      detail: Votre token n'est pas valide ou n'est pas renseigné
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Interdit
+                  description: Votre token n'est pas valide ou n'est pas renseigné
+                expired_token_error:
+                  value:
+                    errors:
+                    - code: '00103'
+                      title: Jeton expiré
+                      detail: Votre token est expiré. Vous devez refaire une demande
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Jeton expiré
+                  description: Votre token est expiré. Vous devez refaire une demande
+                blacklisted_token_error:
+                  value:
+                    errors:
+                    - code: '00105'
+                      title: Jeton sur liste noire
+                      detail: 'Votre jeton est sur liste noire, celui-ci a certainement
+                        été divulgué sur un canal non-sécurisé. Vous pouvez trouver
+                        un jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Jeton sur liste noire
+                  description: 'Votre jeton est sur liste noire, celui-ci a certainement
+                    été divulgué sur un canal non-sécurisé. Vous pouvez trouver un
+                    jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
+              schema:
+                "$ref": "#/components/schemas/Error"
         '200':
           description: Dossier trouvé
           headers:
@@ -8266,50 +8436,6 @@ paths:
                   summary: Erreur inattendue
                   description: Une erreur inattendue est survenue lors de la collecte
                     des données
-              schema:
-                "$ref": "#/components/schemas/Error"
-        '401':
-          description: Non autorisé
-          content:
-            application/json:
-              examples:
-                invalid_token_error:
-                  value:
-                    errors:
-                    - code: '00101'
-                      title: Interdit
-                      detail: Votre token n'est pas valide ou n'est pas renseigné
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Interdit
-                  description: Votre token n'est pas valide ou n'est pas renseigné
-                expired_token_error:
-                  value:
-                    errors:
-                    - code: '00103'
-                      title: Jeton expiré
-                      detail: Votre token est expiré. Vous devez refaire une demande
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Jeton expiré
-                  description: Votre token est expiré. Vous devez refaire une demande
-                blacklisted_token_error:
-                  value:
-                    errors:
-                    - code: '00105'
-                      title: Jeton sur liste noire
-                      detail: 'Votre jeton est sur liste noire, celui-ci a certainement
-                        été divulgué sur un canal non-sécurisé. Vous pouvez trouver
-                        un jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Jeton sur liste noire
-                  description: 'Votre jeton est sur liste noire, celui-ci a certainement
-                    été divulgué sur un canal non-sécurisé. Vous pouvez trouver un
-                    jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
               schema:
                 "$ref": "#/components/schemas/Error"
         '409':
@@ -8979,6 +9105,64 @@ paths:
                     Listez vos privilèges sur /api/introspect
               schema:
                 "$ref": "#/components/schemas/Error"
+        '401':
+          description: Non autorisé
+          content:
+            application/json:
+              examples:
+                missing_france_connect_access_token_error:
+                  value:
+                    errors:
+                    - code: '50004'
+                      title: Accès non autorisé
+                      detail: 'Le jeton d''accès FranceConnect est manquant. Cet endpoint
+                        requiert un jeton d''accès FranceConnect transmis via l''en-tête
+                        Authorization: Bearer.'
+                      source:
+                      meta: {}
+                  summary: Accès non autorisé
+                  description: 'Le jeton d''accès FranceConnect est manquant. Cet
+                    endpoint requiert un jeton d''accès FranceConnect transmis via
+                    l''en-tête Authorization: Bearer.'
+                invalid_token_error:
+                  value:
+                    errors:
+                    - code: '00101'
+                      title: Interdit
+                      detail: Votre token n'est pas valide ou n'est pas renseigné
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Interdit
+                  description: Votre token n'est pas valide ou n'est pas renseigné
+                expired_token_error:
+                  value:
+                    errors:
+                    - code: '00103'
+                      title: Jeton expiré
+                      detail: Votre token est expiré. Vous devez refaire une demande
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Jeton expiré
+                  description: Votre token est expiré. Vous devez refaire une demande
+                blacklisted_token_error:
+                  value:
+                    errors:
+                    - code: '00105'
+                      title: Jeton sur liste noire
+                      detail: 'Votre jeton est sur liste noire, celui-ci a certainement
+                        été divulgué sur un canal non-sécurisé. Vous pouvez trouver
+                        un jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Jeton sur liste noire
+                  description: 'Votre jeton est sur liste noire, celui-ci a certainement
+                    été divulgué sur un canal non-sécurisé. Vous pouvez trouver un
+                    jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
+              schema:
+                "$ref": "#/components/schemas/Error"
         '200':
           description: Étudiant identifié
           x-operationId: api_particulier_v3_cnous_etudiant_boursier_with_france_connect
@@ -9139,50 +9323,6 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
-              schema:
-                "$ref": "#/components/schemas/Error"
-        '401':
-          description: Non autorisé
-          content:
-            application/json:
-              examples:
-                invalid_token_error:
-                  value:
-                    errors:
-                    - code: '00101'
-                      title: Interdit
-                      detail: Votre token n'est pas valide ou n'est pas renseigné
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Interdit
-                  description: Votre token n'est pas valide ou n'est pas renseigné
-                expired_token_error:
-                  value:
-                    errors:
-                    - code: '00103'
-                      title: Jeton expiré
-                      detail: Votre token est expiré. Vous devez refaire une demande
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Jeton expiré
-                  description: Votre token est expiré. Vous devez refaire une demande
-                blacklisted_token_error:
-                  value:
-                    errors:
-                    - code: '00105'
-                      title: Jeton sur liste noire
-                      detail: 'Votre jeton est sur liste noire, celui-ci a certainement
-                        été divulgué sur un canal non-sécurisé. Vous pouvez trouver
-                        un jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Jeton sur liste noire
-                  description: 'Votre jeton est sur liste noire, celui-ci a certainement
-                    été divulgué sur un canal non-sécurisé. Vous pouvez trouver un
-                    jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
               schema:
                 "$ref": "#/components/schemas/Error"
         '409':
@@ -11331,6 +11471,64 @@ paths:
                     Listez vos privilèges sur /api/introspect
               schema:
                 "$ref": "#/components/schemas/Error"
+        '401':
+          description: Non autorisé
+          content:
+            application/json:
+              examples:
+                missing_france_connect_access_token_error:
+                  value:
+                    errors:
+                    - code: '50004'
+                      title: Accès non autorisé
+                      detail: 'Le jeton d''accès FranceConnect est manquant. Cet endpoint
+                        requiert un jeton d''accès FranceConnect transmis via l''en-tête
+                        Authorization: Bearer.'
+                      source:
+                      meta: {}
+                  summary: Accès non autorisé
+                  description: 'Le jeton d''accès FranceConnect est manquant. Cet
+                    endpoint requiert un jeton d''accès FranceConnect transmis via
+                    l''en-tête Authorization: Bearer.'
+                invalid_token_error:
+                  value:
+                    errors:
+                    - code: '00101'
+                      title: Interdit
+                      detail: Votre token n'est pas valide ou n'est pas renseigné
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Interdit
+                  description: Votre token n'est pas valide ou n'est pas renseigné
+                expired_token_error:
+                  value:
+                    errors:
+                    - code: '00103'
+                      title: Jeton expiré
+                      detail: Votre token est expiré. Vous devez refaire une demande
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Jeton expiré
+                  description: Votre token est expiré. Vous devez refaire une demande
+                blacklisted_token_error:
+                  value:
+                    errors:
+                    - code: '00105'
+                      title: Jeton sur liste noire
+                      detail: 'Votre jeton est sur liste noire, celui-ci a certainement
+                        été divulgué sur un canal non-sécurisé. Vous pouvez trouver
+                        un jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Jeton sur liste noire
+                  description: 'Votre jeton est sur liste noire, celui-ci a certainement
+                    été divulgué sur un canal non-sécurisé. Vous pouvez trouver un
+                    jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
+              schema:
+                "$ref": "#/components/schemas/Error"
         '200':
           description: Identité trouvée
           headers:
@@ -11416,50 +11614,6 @@ paths:
                     sont pas connus, ou ne comportent aucune information pour cet
                     appel. Veuillez vérifier que votre recherche est couverte par
                     le périmètre de l'API.
-              schema:
-                "$ref": "#/components/schemas/Error"
-        '401':
-          description: Non autorisé
-          content:
-            application/json:
-              examples:
-                invalid_token_error:
-                  value:
-                    errors:
-                    - code: '00101'
-                      title: Interdit
-                      detail: Votre token n'est pas valide ou n'est pas renseigné
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Interdit
-                  description: Votre token n'est pas valide ou n'est pas renseigné
-                expired_token_error:
-                  value:
-                    errors:
-                    - code: '00103'
-                      title: Jeton expiré
-                      detail: Votre token est expiré. Vous devez refaire une demande
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Jeton expiré
-                  description: Votre token est expiré. Vous devez refaire une demande
-                blacklisted_token_error:
-                  value:
-                    errors:
-                    - code: '00105'
-                      title: Jeton sur liste noire
-                      detail: 'Votre jeton est sur liste noire, celui-ci a certainement
-                        été divulgué sur un canal non-sécurisé. Vous pouvez trouver
-                        un jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Jeton sur liste noire
-                  description: 'Votre jeton est sur liste noire, celui-ci a certainement
-                    été divulgué sur un canal non-sécurisé. Vous pouvez trouver un
-                    jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
               schema:
                 "$ref": "#/components/schemas/Error"
         '409':
@@ -13053,6 +13207,64 @@ paths:
                     Listez vos privilèges sur /api/introspect
               schema:
                 "$ref": "#/components/schemas/Error"
+        '401':
+          description: Non autorisé
+          content:
+            application/json:
+              examples:
+                missing_france_connect_access_token_error:
+                  value:
+                    errors:
+                    - code: '50004'
+                      title: Accès non autorisé
+                      detail: 'Le jeton d''accès FranceConnect est manquant. Cet endpoint
+                        requiert un jeton d''accès FranceConnect transmis via l''en-tête
+                        Authorization: Bearer.'
+                      source:
+                      meta: {}
+                  summary: Accès non autorisé
+                  description: 'Le jeton d''accès FranceConnect est manquant. Cet
+                    endpoint requiert un jeton d''accès FranceConnect transmis via
+                    l''en-tête Authorization: Bearer.'
+                invalid_token_error:
+                  value:
+                    errors:
+                    - code: '00101'
+                      title: Interdit
+                      detail: Votre token n'est pas valide ou n'est pas renseigné
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Interdit
+                  description: Votre token n'est pas valide ou n'est pas renseigné
+                expired_token_error:
+                  value:
+                    errors:
+                    - code: '00103'
+                      title: Jeton expiré
+                      detail: Votre token est expiré. Vous devez refaire une demande
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Jeton expiré
+                  description: Votre token est expiré. Vous devez refaire une demande
+                blacklisted_token_error:
+                  value:
+                    errors:
+                    - code: '00105'
+                      title: Jeton sur liste noire
+                      detail: 'Votre jeton est sur liste noire, celui-ci a certainement
+                        été divulgué sur un canal non-sécurisé. Vous pouvez trouver
+                        un jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Jeton sur liste noire
+                  description: 'Votre jeton est sur liste noire, celui-ci a certainement
+                    été divulgué sur un canal non-sécurisé. Vous pouvez trouver un
+                    jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
+              schema:
+                "$ref": "#/components/schemas/Error"
         '200':
           description: Identité trouvée
           headers:
@@ -13240,50 +13452,6 @@ paths:
                     sont pas connus, ou ne comportent aucune information pour cet
                     appel. Veuillez vérifier que votre recherche est couverte par
                     le périmètre de l'API.
-              schema:
-                "$ref": "#/components/schemas/Error"
-        '401':
-          description: Non autorisé
-          content:
-            application/json:
-              examples:
-                invalid_token_error:
-                  value:
-                    errors:
-                    - code: '00101'
-                      title: Interdit
-                      detail: Votre token n'est pas valide ou n'est pas renseigné
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Interdit
-                  description: Votre token n'est pas valide ou n'est pas renseigné
-                expired_token_error:
-                  value:
-                    errors:
-                    - code: '00103'
-                      title: Jeton expiré
-                      detail: Votre token est expiré. Vous devez refaire une demande
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Jeton expiré
-                  description: Votre token est expiré. Vous devez refaire une demande
-                blacklisted_token_error:
-                  value:
-                    errors:
-                    - code: '00105'
-                      title: Jeton sur liste noire
-                      detail: 'Votre jeton est sur liste noire, celui-ci a certainement
-                        été divulgué sur un canal non-sécurisé. Vous pouvez trouver
-                        un jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Jeton sur liste noire
-                  description: 'Votre jeton est sur liste noire, celui-ci a certainement
-                    été divulgué sur un canal non-sécurisé. Vous pouvez trouver un
-                    jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
               schema:
                 "$ref": "#/components/schemas/Error"
         '409':
@@ -15887,6 +16055,64 @@ paths:
                     Listez vos privilèges sur /api/introspect
               schema:
                 "$ref": "#/components/schemas/Error"
+        '401':
+          description: Non autorisé
+          content:
+            application/json:
+              examples:
+                missing_france_connect_access_token_error:
+                  value:
+                    errors:
+                    - code: '50004'
+                      title: Accès non autorisé
+                      detail: 'Le jeton d''accès FranceConnect est manquant. Cet endpoint
+                        requiert un jeton d''accès FranceConnect transmis via l''en-tête
+                        Authorization: Bearer.'
+                      source:
+                      meta: {}
+                  summary: Accès non autorisé
+                  description: 'Le jeton d''accès FranceConnect est manquant. Cet
+                    endpoint requiert un jeton d''accès FranceConnect transmis via
+                    l''en-tête Authorization: Bearer.'
+                invalid_token_error:
+                  value:
+                    errors:
+                    - code: '00101'
+                      title: Interdit
+                      detail: Votre token n'est pas valide ou n'est pas renseigné
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Interdit
+                  description: Votre token n'est pas valide ou n'est pas renseigné
+                expired_token_error:
+                  value:
+                    errors:
+                    - code: '00103'
+                      title: Jeton expiré
+                      detail: Votre token est expiré. Vous devez refaire une demande
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Jeton expiré
+                  description: Votre token est expiré. Vous devez refaire une demande
+                blacklisted_token_error:
+                  value:
+                    errors:
+                    - code: '00105'
+                      title: Jeton sur liste noire
+                      detail: 'Votre jeton est sur liste noire, celui-ci a certainement
+                        été divulgué sur un canal non-sécurisé. Vous pouvez trouver
+                        un jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Jeton sur liste noire
+                  description: 'Votre jeton est sur liste noire, celui-ci a certainement
+                    été divulgué sur un canal non-sécurisé. Vous pouvez trouver un
+                    jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
+              schema:
+                "$ref": "#/components/schemas/Error"
         '200':
           description: Étudiant identifié
           x-operationId: api_particulier_v3_mesri_statut_etudiant_with_france_connect
@@ -16045,50 +16271,6 @@ paths:
                         provider: MESRI
                   summary: Entité non trouvée
                   description: Aucun étudiant n'a pu être trouvé.
-              schema:
-                "$ref": "#/components/schemas/Error"
-        '401':
-          description: Non autorisé
-          content:
-            application/json:
-              examples:
-                invalid_token_error:
-                  value:
-                    errors:
-                    - code: '00101'
-                      title: Interdit
-                      detail: Votre token n'est pas valide ou n'est pas renseigné
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Interdit
-                  description: Votre token n'est pas valide ou n'est pas renseigné
-                expired_token_error:
-                  value:
-                    errors:
-                    - code: '00103'
-                      title: Jeton expiré
-                      detail: Votre token est expiré. Vous devez refaire une demande
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Jeton expiré
-                  description: Votre token est expiré. Vous devez refaire une demande
-                blacklisted_token_error:
-                  value:
-                    errors:
-                    - code: '00105'
-                      title: Jeton sur liste noire
-                      detail: 'Votre jeton est sur liste noire, celui-ci a certainement
-                        été divulgué sur un canal non-sécurisé. Vous pouvez trouver
-                        un jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Jeton sur liste noire
-                  description: 'Votre jeton est sur liste noire, celui-ci a certainement
-                    été divulgué sur un canal non-sécurisé. Vous pouvez trouver un
-                    jeton valide sur votre espace personnel: https://particulier.api.gouv.fr/compte'
               schema:
                 "$ref": "#/components/schemas/Error"
         '409':

--- a/siade/app/controllers/api_particulier/v3_and_more/ants/extrait_immatriculation_vehicule_with_france_connect_controller.rb
+++ b/siade/app/controllers/api_particulier/v3_and_more/ants/extrait_immatriculation_vehicule_with_france_connect_controller.rb
@@ -1,5 +1,5 @@
 class APIParticulier::V3AndMore::ANTS::ExtraitImmatriculationVehiculeWithFranceConnectController < APIParticulier::V3AndMore::BaseController
-  include APIParticulier::FranceConnectable
+  include APIParticulier::RequiresFranceConnect
   include APIParticulier::CivilityParameters
 
   def show

--- a/siade/app/controllers/api_particulier/v3_and_more/cnav/abstract_france_connect_controller.rb
+++ b/siade/app/controllers/api_particulier/v3_and_more/cnav/abstract_france_connect_controller.rb
@@ -1,5 +1,5 @@
 class APIParticulier::V3AndMore::CNAV::AbstractFranceConnectController < APIParticulier::V3AndMore::BaseController
-  include APIParticulier::FranceConnectable
+  include APIParticulier::RequiresFranceConnect
 
   def show
     if organizer.success?

--- a/siade/app/controllers/api_particulier/v3_and_more/cnous/etudiant_boursier_with_france_connect_controller.rb
+++ b/siade/app/controllers/api_particulier/v3_and_more/cnous/etudiant_boursier_with_france_connect_controller.rb
@@ -1,5 +1,5 @@
 class APIParticulier::V3AndMore::CNOUS::EtudiantBoursierWithFranceConnectController < APIParticulier::V3AndMore::BaseController
-  include APIParticulier::FranceConnectable
+  include APIParticulier::RequiresFranceConnect
 
   def show
     if organizer.success?

--- a/siade/app/controllers/api_particulier/v3_and_more/dsnj/service_national_with_france_connect_controller.rb
+++ b/siade/app/controllers/api_particulier/v3_and_more/dsnj/service_national_with_france_connect_controller.rb
@@ -1,5 +1,5 @@
 class APIParticulier::V3AndMore::DSNJ::ServiceNationalWithFranceConnectController < APIParticulier::V3AndMore::BaseController
-  include APIParticulier::FranceConnectable
+  include APIParticulier::RequiresFranceConnect
 
   def show
     if organizer.success?

--- a/siade/app/controllers/api_particulier/v3_and_more/gip_mds/service_civique_with_france_connect_controller.rb
+++ b/siade/app/controllers/api_particulier/v3_and_more/gip_mds/service_civique_with_france_connect_controller.rb
@@ -1,5 +1,5 @@
 class APIParticulier::V3AndMore::GIPMDS::ServiceCiviqueWithFranceConnectController < APIParticulier::V3AndMore::BaseController
-  include APIParticulier::FranceConnectable
+  include APIParticulier::RequiresFranceConnect
   include APIParticulier::CivilityParameters
 
   def show

--- a/siade/app/controllers/api_particulier/v3_and_more/mesri/statut_etudiant_with_france_connect_controller.rb
+++ b/siade/app/controllers/api_particulier/v3_and_more/mesri/statut_etudiant_with_france_connect_controller.rb
@@ -1,5 +1,5 @@
 class APIParticulier::V3AndMore::MESRI::StatutEtudiantWithFranceConnectController < APIParticulier::V3AndMore::BaseController
-  include APIParticulier::FranceConnectable
+  include APIParticulier::RequiresFranceConnect
 
   def show
     if organizer.success?

--- a/siade/app/controllers/concerns/api_particulier/requires_france_connect.rb
+++ b/siade/app/controllers/concerns/api_particulier/requires_france_connect.rb
@@ -1,0 +1,19 @@
+module APIParticulier::RequiresFranceConnect
+  extend ActiveSupport::Concern
+
+  include APIParticulier::FranceConnectable
+
+  included do
+    before_action :require_france_connect_access_token!
+  end
+
+  private
+
+  def require_france_connect_access_token!
+    return if france_connect?
+
+    render content_type: content_type_header,
+      json:         ::ErrorsSerializer.new([InvalidFranceConnectAccessTokenError.new(:missing_france_connect_access_token)]).as_json,
+      status:       :unauthorized
+  end
+end

--- a/siade/app/errors/invalid_france_connect_access_token_error.rb
+++ b/siade/app/errors/invalid_france_connect_access_token_error.rb
@@ -18,7 +18,8 @@ class InvalidFranceConnectAccessTokenError < UnauthorizedError
     {
       malformed_token: '50001',
       not_found_or_expired: '50002',
-      missing_hub_identity_scope: '50003'
+      missing_hub_identity_scope: '50003',
+      missing_france_connect_access_token: '50004'
     }.fetch(type) do
       raise KeyError, "#{type} is not a valid field name"
     end

--- a/siade/config/errors.yml
+++ b/siade/config/errors.yml
@@ -554,3 +554,6 @@
 
 - code: '50003'
   detail: "Le jeton d'accès ne possède pas les données pivot requises pour effectuer cet appel."
+
+- code: '50004'
+  detail: "Le jeton d'accès FranceConnect est manquant. Cet endpoint requiert un jeton d'accès FranceConnect transmis via l'en-tête Authorization: Bearer."

--- a/siade/spec/controllers/api_particulier/v3_and_more/base_controller_requires_france_connect_spec.rb
+++ b/siade/spec/controllers/api_particulier/v3_and_more/base_controller_requires_france_connect_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe APIParticulier::V3AndMore::BaseController, 'requires france connect' do
+  controller(described_class) do
+    include APIParticulier::RequiresFranceConnect
+
+    def show
+      render json: france_connect_service_user_identity.to_h, status: :ok
+    end
+  end
+
+  subject(:make_call) do
+    routes.draw { get 'show' => 'api_particulier/v3_and_more/base#show' }
+
+    request.headers['Authorization'] = authorization if authorization
+
+    get :show, params: { recipient:, api_version: 3, token: yes_jwt }
+  end
+
+  let(:recipient) { valid_siret(:recipient) }
+  let(:authorization) { 'Bearer fc_pivot_token' }
+
+  before do
+    allow(Siade.credentials).to receive(:[]).and_call_original
+    allow(Siade.credentials).to receive(:[]).with(:france_connect_v2_base_client_id).and_return('345')
+    allow(Siade.credentials).to receive(:[]).with(:france_connect_v2_base_client_secret).and_return('345')
+
+    allow(controller).to receive(:verify_api_version!).and_return(true)
+  end
+
+  context 'when no FranceConnect bearer token is provided (only API token via query string)' do
+    let(:authorization) { nil }
+
+    it 'rejects the request with 401' do
+      expect(make_call.status).to eq(401)
+    end
+
+    it 'returns the missing FranceConnect token error code' do
+      body = JSON.parse(make_call.body)
+
+      expect(body.dig('errors', 0, 'code')).to eq('50004')
+    end
+
+    it 'does not raise NoMethodError when reading the FC identity' do
+      expect { make_call }.not_to raise_error
+    end
+  end
+
+  context 'when a valid FranceConnect bearer token is provided' do
+    before do
+      mock_valid_france_connect_checktoken(scopes: %w[openid identite_pivot allowed_scope])
+    end
+
+    it 'allows the request through' do
+      expect(make_call.status).to eq(200)
+    end
+  end
+end

--- a/siade/spec/requests/api_particulier/v3_and_more/ants/extrait_immatriculation_vehicule/extrait_immatriculation_vehicule_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/ants/extrait_immatriculation_vehicule/extrait_immatriculation_vehicule_with_france_connect_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe 'ANTS: ExtraitImmatriculationVehicule With FranceConnect', api: :
       let(:Authorization) { 'Bearer super_valid_token' }
 
       forbidden_france_connect_request
+      missing_france_connect_bearer_token_request
 
       let(:scopes) do
         %i[

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_adulte_handicape_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_adulte_handicape_with_france_connect_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe 'API Particulier: CNAV: Allocation Adulte Handicape with FranceCo
       let(:Authorization) { 'Bearer super_valid_token' }
 
       forbidden_france_connect_request
+      missing_france_connect_bearer_token_request
 
       describe 'with a FranceConnect token' do
         before do

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_enfant_handicape/allocation_enfant_handicape_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_enfant_handicape/allocation_enfant_handicape_with_france_connect_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe 'API Particulier: CNAV: Allocation enfant handicapé (AEEH) with 
       let(:Authorization) { 'Bearer super_valid_token' }
 
       forbidden_france_connect_request
+      missing_france_connect_bearer_token_request
 
       describe 'with a FranceConnect token' do
         before do

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_soutien_familial_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_soutien_familial_with_france_connect_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe 'API Particulier: CNAV: Allocation Soutien Familial with FranceCo
       let(:Authorization) { 'Bearer super_valid_token' }
 
       forbidden_france_connect_request
+      missing_france_connect_bearer_token_request
 
       let(:scopes) { %i[allocation_soutien_familial] }
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/complementaire_sante_solidaire_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/complementaire_sante_solidaire_with_france_connect_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe 'API Particulier: CNAV: Complementaire Sante Solidaire with Franc
       let(:Authorization) { 'Bearer super_valid_token' }
 
       forbidden_france_connect_request
+      missing_france_connect_bearer_token_request
 
       let(:scopes) { %i[complementaire_sante_solidaire] }
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/participation_familiale_eaje_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/participation_familiale_eaje_with_france_connect_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe 'API Particulier: CNAV: Participation familial EAJE with FranceCo
       let(:Authorization) { 'Bearer super_valid_token' }
 
       forbidden_france_connect_request
+      missing_france_connect_bearer_token_request
 
       describe 'with a FranceConnect token' do
         before do

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/prime_activite_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/prime_activite_with_france_connect_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe 'API Particulier: CNAV: Prime Activite with FranceConnect', api: 
       let(:Authorization) { 'Bearer super_valid_token' }
 
       forbidden_france_connect_request
+      missing_france_connect_bearer_token_request
 
       let(:scopes) { %i[prime_activite prime_activite_majoration] }
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/quotient_familial_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/quotient_familial_with_france_connect_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe 'API Particulier: CNAV: Quotient Familial with FranceConnect', ap
         required: false
 
       forbidden_france_connect_request
+      missing_france_connect_bearer_token_request
 
       let(:scopes) { %i[cnaf_quotient_familial cnaf_allocataires cnaf_enfants cnaf_adresse] }
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/revenu_solidarite_active_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/revenu_solidarite_active_with_france_connect_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe 'API Particulier: CNAV: Revenu Solidarite Active with FranceConne
       let(:Authorization) { 'Bearer super_valid_token' }
 
       forbidden_france_connect_request
+      missing_france_connect_bearer_token_request
 
       let(:scopes) { %i[revenu_solidarite_active revenu_solidarite_active_majoration] }
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnous/v3/etudiant_boursier_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnous/v3/etudiant_boursier_with_france_connect_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe 'API Particulier: CNOUS: Statut Etudiant with FranceConnect', api
       let(:Authorization) { 'Bearer super_valid_token' }
 
       forbidden_france_connect_request
+      missing_france_connect_bearer_token_request
 
       let(:scopes) { %i[cnous_identite cnous_email cnous_statut_boursier cnous_echelon_bourse cnous_statut_bourse cnous_periode_versement cnous_ville_etudes] }
 

--- a/siade/spec/requests/api_particulier/v3_and_more/dsnj/service_national/service_national_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/dsnj/service_national/service_national_with_france_connect_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'DSNJ: Service National With FranceConnect', api: :particulier, t
       let(:Authorization) { 'Bearer super_valid_token' }
 
       forbidden_france_connect_request
+      missing_france_connect_bearer_token_request
 
       let(:scopes) { %i[dsnj_statut_service_national] }
 

--- a/siade/spec/requests/api_particulier/v3_and_more/gip_mds/service_civique/service_civique_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/gip_mds/service_civique/service_civique_with_france_connect_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'GIPMDS: Servicecivique With FranceConnect', api: :particulier, t
       let(:Authorization) { 'Bearer super_valid_token' }
 
       forbidden_france_connect_request
+      missing_france_connect_bearer_token_request
 
       let(:scopes) { %i[gip_mds_service_civique_statut_actuel gip_mds_service_civique_statut_passe gip_mds_service_civique_organisme_accueil gip_mds_service_civique_dates] }
 

--- a/siade/spec/requests/api_particulier/v3_and_more/mesri/statut_etudiant_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/mesri/statut_etudiant_with_france_connect_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'API Particulier: Mesri: Statut Etudiant with FranceConnect', api
       let(:Authorization) { 'Bearer super_valid_token' }
 
       forbidden_france_connect_request
+      missing_france_connect_bearer_token_request
 
       let(:scopes) { %i[mesri_identite mesri_admissions mesri_admission_inscrit mesri_admission_regime_formation mesri_admission_commune_etudes mesri_admission_etablissement_etudes] }
 

--- a/siade/spec/support/helpers/authentication_stub.rb
+++ b/siade/spec/support/helpers/authentication_stub.rb
@@ -1,0 +1,12 @@
+module AuthenticationStub
+  def stub_authentication_with_jwt_user(user = yes_jwt_user)
+    allow_any_instance_of(HandleTokens).to receive(:authenticate_user!).and_wrap_original do |method_proxy, *| # rubocop:disable RSpec/AnyInstance
+      method_proxy.receiver.instance_variable_set(:@current_user, user)
+      true
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include AuthenticationStub
+end

--- a/siade/spec/support/rswag_common_errors.rb
+++ b/siade/spec/support/rswag_common_errors.rb
@@ -33,6 +33,38 @@ module RSwagCommonErrors
     end
   end
 
+  MISSING_FC_BEARER_TOKEN_EXAMPLES = {
+    missing_france_connect_access_token_error: -> { InvalidFranceConnectAccessTokenError.new(:missing_france_connect_access_token) },
+    invalid_token_error: -> { InvalidTokenError.new },
+    expired_token_error: -> { ExpiredTokenError.new },
+    blacklisted_token_error: -> { BlacklistedTokenError.new('particulier') }
+  }.freeze
+
+  # rubocop:disable Metrics/AbcSize
+  def missing_france_connect_bearer_token_request(&block)
+    describe 'with a valid API token but no FranceConnect bearer token' do
+      let(:Authorization) { nil }
+
+      before { stub_authentication_with_jwt_user }
+
+      response '401', 'Non autorisé' do
+        block.call if block_given?
+
+        MISSING_FC_BEARER_TOKEN_EXAMPLES.each do |key, builder|
+          build_rswag_example(builder.call, key)
+        end
+
+        schema '$ref' => '#/components/schemas/Error'
+
+        run_test! do |response|
+          body = JSON.parse(response.body)
+          expect(body.dig('errors', 0, 'code')).to eq('50004')
+        end
+      end
+    end
+  end
+  # rubocop:enable Metrics/AbcSize
+
   def forbidden_france_connect_request(&block)
     describe 'with valid mandatory params but insufficient privileges on token' do
       response '403', 'Accès interdit' do


### PR DESCRIPTION
FranceConnect endpoints did not check if the bearer token is a FranceConnect, leading to 500 error

Closes https://errors.data.gouv.fr/organizations/sentry/issues/293059/