### PR TITLE
Reject birthdates outside 1900..today in Civility::ValidateDateNaissance

### DIFF
--- a/siade/app/interactors/civility/validate_date_naissance.rb
+++ b/siade/app/interactors/civility/validate_date_naissance.rb
@@ -22,6 +22,15 @@ class Civility::ValidateDateNaissance < ValidateParamInteractor
   end
 
   def valid_date?
-    Date.valid_date?(param(:annee_date_naissance).to_i, param(:mois_date_naissance).to_i, param(:jour_date_naissance).to_i)
+    Date.valid_date?(param(:annee_date_naissance).to_i, param(:mois_date_naissance).to_i, param(:jour_date_naissance).to_i) &&
+      birthday_date_within_reasonable_range?
+  end
+
+  def birthday_date_within_reasonable_range?
+    (Date.new(1900, 1, 1)..Date.current).cover?(birthday_date)
+  end
+
+  def birthday_date
+    Date.new(param(:annee_date_naissance).to_i, param(:mois_date_naissance).to_i, param(:jour_date_naissance).to_i)
   end
 end

--- a/siade/spec/interactors/civility/validate_date_naissance_spec.rb
+++ b/siade/spec/interactors/civility/validate_date_naissance_spec.rb
@@ -69,5 +69,42 @@ RSpec.describe Civility::ValidateDateNaissance, type: :validate_param_interactor
         its(:errors) { is_expected.to include(instance_of(UnprocessableEntityError)) }
       end
     end
+
+    context 'when date is in the future' do
+      let(:annee_date_naissance) { Date.current.year + 1 }
+
+      it { is_expected.to be_a_failure }
+
+      its(:errors) { is_expected.to include(instance_of(UnprocessableEntityError)) }
+    end
+
+    context 'when year has more than 4 digits' do
+      let(:annee_date_naissance) { 20_214 }
+
+      it { is_expected.to be_a_failure }
+
+      its(:errors) { is_expected.to include(instance_of(UnprocessableEntityError)) }
+    end
+
+    context 'when date is before 1900/01/01' do
+      let(:annee_date_naissance) { 1899 }
+      let(:mois_date_naissance) { 12 }
+      let(:jour_date_naissance) { 31 }
+
+      it { is_expected.to be_a_failure }
+
+      its(:errors) { is_expected.to include(instance_of(UnprocessableEntityError)) }
+    end
+
+    context 'when date is today' do
+      let(:today) { Date.current }
+      let(:annee_date_naissance) { today.year }
+      let(:mois_date_naissance) { today.month }
+      let(:jour_date_naissance) { today.day }
+
+      it { is_expected.to be_a_success }
+
+      its(:errors) { is_expected.to be_empty }
+    end
   end
 end


### PR DESCRIPTION
Previously valid_year? only checked .positive?, so any positive integer passed - including 5-digit garbage years like 20214 (typo for 2014).

Closes https://errors.data.gouv.fr/organizations/sentry/issues/292237/