### PR TITLE
Fix(cnav): harden civility params against nested input

### DIFF
--- a/siade/app/controllers/api_particulier/v3_and_more/cnav/quotient_familial_with_civility_controller.rb
+++ b/siade/app/controllers/api_particulier/v3_and_more/cnav/quotient_familial_with_civility_controller.rb
@@ -8,7 +8,8 @@ class APIParticulier::V3AndMore::CNAV::QuotientFamilialWithCivilityController < 
   end
 
   def api_params
-    civility_parameters.merge({ mois: params[:mois], annee: params[:annee] })
+    extra = params.permit(:mois, :annee)
+    civility_parameters.merge(mois: extra[:mois], annee: extra[:annee])
   end
 
   def expires_in

--- a/siade/app/controllers/concerns/api_particulier/civility_parameters.rb
+++ b/siade/app/controllers/concerns/api_particulier/civility_parameters.rb
@@ -1,19 +1,21 @@
 module APIParticulier::CivilityParameters
-  # rubocop:disable Metrics/MethodLength
+  CIVILITY_SCALAR_KEYS = %i[
+    nomUsage
+    nomNaissance
+    anneeDateNaissance
+    moisDateNaissance
+    jourDateNaissance
+    sexeEtatCivil
+    nomCommuneNaissance
+    codeCogInseePaysNaissance
+    codeCogInseeDepartementNaissance
+  ].freeze
+
+  CIVILITY_KEYS = (CIVILITY_SCALAR_KEYS + %i[prenoms]).freeze
+
   def civility_parameters
     civility = {}
-    %i[
-      nomUsage
-      nomNaissance
-      prenoms
-      anneeDateNaissance
-      moisDateNaissance
-      jourDateNaissance
-      sexeEtatCivil
-      nomCommuneNaissance
-      codeCogInseePaysNaissance
-      codeCogInseeDepartementNaissance
-    ].each do |param|
+    CIVILITY_KEYS.each do |param|
       civility[to_snake_case_sym(param)] = civility_param(param)
     end
 
@@ -21,18 +23,25 @@ module APIParticulier::CivilityParameters
 
     civility
   end
-  # rubocop:enable Metrics/MethodLength
 
   protected
 
   def extract_code_cog_insee_commune_naissance
-    params[:codeCogInseeCommuneNaissance].presence
+    permitted_civility_params[:codeCogInseeCommuneNaissance].presence
   end
 
   private
 
+  def permitted_civility_params
+    @permitted_civility_params ||= params.permit(
+      *CIVILITY_SCALAR_KEYS,
+      :codeCogInseeCommuneNaissance,
+      prenoms: []
+    )
+  end
+
   def civility_param(param)
-    params[param]
+    permitted_civility_params[param]
   end
 
   def to_snake_case_sym(param)

--- a/siade/spec/controllers/concerns/api_particulier/civility_parameters_spec.rb
+++ b/siade/spec/controllers/concerns/api_particulier/civility_parameters_spec.rb
@@ -17,8 +17,7 @@ RSpec.describe APIParticulier::CivilityParameters do
     include APIParticulier::CivilityParameters
 
     def index
-      civility_parameters
-      render json: { data: true }, status: :ok
+      render json: { data: civility_parameters.to_query }, status: :ok
     end
 
     def serializer_module
@@ -56,6 +55,19 @@ RSpec.describe APIParticulier::CivilityParameters do
 
       it 'returns 200' do
         expect(subject).to have_http_status(:ok)
+      end
+    end
+
+    context 'with a nested civility parameter (malformed request)' do
+      subject do
+        routes.draw { get 'show' => 'api_particulier/v3_and_more/base#index' }
+
+        get :index, params: { nomNaissance: { evil: 'x' }, token: yes_jwt, api_version: 42 }.merge(api_particulier_mandatory_params)
+      end
+
+      it 'drops the unpermitted nested value and still serializes to a query string' do
+        expect(subject).to have_http_status(:ok)
+        expect(response.parsed_body['data']).not_to include('nom_naissance=')
       end
     end
     # rubocop:enable RSpec/VariableName


### PR DESCRIPTION
A malformed request carrying a nested civility param (e.g. `?nomNaissance[evil]=x`) caused `params[name]` to return an unpermitted `ActionController::Parameters` value. That value flowed into the hash built by `CivilityParameters#civility_parameters`, and `AbstractCivilityController#cache_key` then called `api_params.to_query`, which delegates to `to_param`/`to_h` and raises `ActionController::UnfilteredParameters` on unpermitted Parameters — crashing the request with a 500 before any provider call.

Extract values through `params.permit(...)` instead: scalar civility keys are permitted by name, `prenoms` is permitted as an array of scalars, and nested shapes are silently dropped. Apply the same defense to `mois`/`annee` in QuotientFamilialWithCivilityController, which used to merge raw `params[:mois]` / `params[:annee]` directly.

Add a regression spec on the concern that posts a nested `nomNaissance` and checks the response still renders (no UnfilteredParameters) and the nested value is dropped from the serialized query string.

Sentry: https://errors.data.gouv.fr/organizations/sentry/issues/293267/