### PR TITLE
Gate ANTS identite_particulier behind its dedicated scope

### DIFF
--- a/commons/endpoints/api_particulier/ants_siv.yml
+++ b/commons/endpoints/api_particulier/ants_siv.yml
@@ -91,6 +91,7 @@ fiche:
         attributes:
           identite_particulier:
             title: Identité
+            scope: ants_extrait_immatriculation_vehicule_identite_particulier
             type: object
             description: Identité du demandeur du dossier d'immatriculation. Ces données ne
               proviennent pas de FranceConnect et sont fournies à des fins de vérification

--- a/commons/swagger/openapi-particulier.yaml
+++ b/commons/swagger/openapi-particulier.yaml
@@ -246,6 +246,7 @@ paths:
                             type: string
                             description: Le code du département de naissance du demandeur.
                             example: '75'
+                        x-scope: ants_extrait_immatriculation_vehicule_identite_particulier
                         required:
                         - nom
                         - prenom

--- a/siade/app/interactors/france_connect/data_fetcher_through_access_token/build_user.rb
+++ b/siade/app/interactors/france_connect/data_fetcher_through_access_token/build_user.rb
@@ -1,4 +1,8 @@
 class FranceConnect::DataFetcherThroughAccessToken::BuildUser < FranceConnect::DataFetcherThroughAccessToken::BuildDataFromAccessTokenInteractor
+  ALLOWED_IDENTITY_SCOPES = %w[
+    ants_extrait_immatriculation_vehicule_identite_particulier
+  ].freeze
+
   def call
     context.user = build_user
   end
@@ -39,7 +43,7 @@ class FranceConnect::DataFetcherThroughAccessToken::BuildUser < FranceConnect::D
   end
 
   def remove_api_identity_scopes(scopes)
-    scopes.reject { |scope| scope.include? '_identite' }
+    scopes.reject { |scope| scope.include?('_identite') && ALLOWED_IDENTITY_SCOPES.exclude?(scope) }
   end
 
   def api_version

--- a/siade/app/serializers/api_particulier/ants/extrait_immatriculation_vehicule_serializer/v3.rb
+++ b/siade/app/serializers/api_particulier/ants/extrait_immatriculation_vehicule_serializer/v3.rb
@@ -1,5 +1,5 @@
 class APIParticulier::ANTS::ExtraitImmatriculationVehiculeSerializer::V3 < APIParticulier::V3AndMore::BaseSerializer
-  attribute :identite_particulier
+  attribute :identite_particulier, if: -> { scope?(:ants_extrait_immatriculation_vehicule_identite_particulier) }
   attribute :adresse_particulier, if: -> { scope?(:ants_extrait_immatriculation_vehicule_adresse_particulier) }
   attribute :statut_rattachement, if: -> { scope?(:ants_extrait_immatriculation_vehicule_statut_rattachement) }
   attribute :donnees_immatriculation_vehicule, if: -> { scope?(:ants_extrait_immatriculation_vehicule_donnees_immatriculation_vehicule) }

--- a/siade/spec/interactors/france_connect/data_fetcher_through_access_token/build_user_spec.rb
+++ b/siade/spec/interactors/france_connect/data_fetcher_through_access_token/build_user_spec.rb
@@ -14,6 +14,14 @@ RSpec.describe FranceConnect::DataFetcherThroughAccessToken::BuildUser, type: :i
       it 'gets scopes from access token payload without api_name_identite' do
         expect(call.user.scopes).to eq(%w[mesri_identifiant openid identite_pivot])
       end
+
+      context 'with an allowlisted identity scope' do
+        let(:scopes) { 'mesri_identifiant ants_extrait_immatriculation_vehicule_identite_particulier' }
+
+        it 'keeps the allowlisted identity scope' do
+          expect(call.user.scopes).to include('ants_extrait_immatriculation_vehicule_identite_particulier')
+        end
+      end
     end
 
     context 'when API version is 2' do


### PR DESCRIPTION
Until now the v3 FranceConnect ANTS endpoint returned the `identite_particulier` block unconditionally, even though `commons/data/authorizations.yml` already advertised a dedicated `ants_extrait_immatriculation_vehicule_identite_particulier` scope on the controller. As a result the scope showed up on the datapass habilitation page and on the fiche scope list without having any runtime effect — a misleading promise to consumers.

Three coordinated changes:

1. `BuildUser#remove_api_identity_scopes` (siade/app/interactors/france_connect/data_fetcher_through_ access_token/build_user.rb) strips, for v3+ FranceConnect calls, any scope whose name contains `_identite`. The rule exists because every other v3 FC variant uses an `attributes_without_identity` schema — FranceConnect already conveys the user's identity to the calling app via its token claims, so a duplicate scope on datapass would be noise.

   ANTS is the exception: `identite_particulier` is the identity of the *vehicle title holder*, not of the FC user, and the two routinely differ (a citizen looking up someone else's vehicle). Introducing `ALLOWED_IDENTITY_SCOPES` (today only the ANTS scope) skips the strip for entries it lists, so the ANTS scope reaches the serializer untouched.

2. The serializer (siade/app/serializers/api_particulier/ants/ extrait_immatriculation_vehicule_serializer/v3.rb) now wraps `:identite_particulier` in `if: -> { scope?(:ants_extrait_immatriculation_vehicule_identite_particulier) }`, mirroring the other four ANTS attributes and finally giving the scope a real gating effect.

3. The swagger source (commons/endpoints/api_particulier/ants_siv.yml) carries a matching `scope:` on the attribute, so the fiche renders the purple badge next to `identite_particulier` and the regenerated openapi-particulier.yaml exposes `x-scope` to the public Redoc.

Tests added to BuildUser spec cover the allowlist; the rswag suite for the ANTS FC endpoint still passes since the spec already grants the full scope set to the test token.