### PR TITLE
D1: Editor delegation developer docs + delegation_id OpenAPI/SDK

### DIFF
--- a/clients/node/api-entreprise/src/resources/ademe.ts
+++ b/clients/node/api-entreprise/src/resources/ademe.ts
@@ -12,7 +12,7 @@ export class Ademe {
   }
 
   /** Certification RGE */
-  async certification_rge(siret: string, options: { version?: number; recipient?: string; context?: string; object?: string; limit?: string } = {}) {
+  async certification_rge(siret: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string; limit?: string } = {}) {
     validateSiret(siret, 'siret');
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
@@ -23,6 +23,6 @@ export class Ademe {
           throw new Error(`version ${resolvedVersion} not available for /ademe/etablissements/{siret}/certification_rge; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object, 'limit': options.limit } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object, 'limit': options.limit } });
   }
 }

--- a/clients/node/api-entreprise/src/resources/banque_de_france.ts
+++ b/clients/node/api-entreprise/src/resources/banque_de_france.ts
@@ -12,7 +12,7 @@ export class BanqueDeFrance {
   }
 
   /** 3 derniers bilans annuels */
-  async bilans(siren: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async bilans(siren: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiren(siren, 'siren');
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
@@ -23,6 +23,6 @@ export class BanqueDeFrance {
           throw new Error(`version ${resolvedVersion} not available for /banque_de_france/unites_legales/{siren}/bilans; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 }

--- a/clients/node/api-entreprise/src/resources/carif_oref.ts
+++ b/clients/node/api-entreprise/src/resources/carif_oref.ts
@@ -12,7 +12,7 @@ export class CarifOref {
   }
 
   /** Qualiopi & habilitations France compétences */
-  async certifications_qualiopi_france_competences(siret: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async certifications_qualiopi_france_competences(siret: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiret(siret, 'siret');
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
@@ -23,6 +23,6 @@ export class CarifOref {
           throw new Error(`version ${resolvedVersion} not available for /carif_oref/etablissements/{siret}/certifications_qualiopi_france_competences; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 }

--- a/clients/node/api-entreprise/src/resources/cibtp.ts
+++ b/clients/node/api-entreprise/src/resources/cibtp.ts
@@ -12,7 +12,7 @@ export class Cibtp {
   }
 
   /** Certificat cotisations CIBTP */
-  async attestation_cotisations_conges_payes_chomage_intemperies(siret: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async attestation_cotisations_conges_payes_chomage_intemperies(siret: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiret(siret, 'siret');
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
@@ -23,6 +23,6 @@ export class Cibtp {
           throw new Error(`version ${resolvedVersion} not available for /cibtp/etablissements/{siret}/attestation_cotisations_conges_payes_chomage_intemperies; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 }

--- a/clients/node/api-entreprise/src/resources/cma_france.ts
+++ b/clients/node/api-entreprise/src/resources/cma_france.ts
@@ -12,7 +12,7 @@ export class CmaFrance {
   }
 
   /** Données du RNM d'une entreprise artisanale */
-  async unites_legales(siren: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async unites_legales(siren: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiren(siren, 'siren');
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
@@ -24,6 +24,6 @@ export class CmaFrance {
           throw new Error(`version ${resolvedVersion} not available for /cma_france/rnm/unites_legales/{siren}; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 }

--- a/clients/node/api-entreprise/src/resources/cnetp.ts
+++ b/clients/node/api-entreprise/src/resources/cnetp.ts
@@ -12,7 +12,7 @@ export class Cnetp {
   }
 
   /** Certificat cotisations CNETP */
-  async attestation_cotisations_conges_payes_chomage_intemperies(siren: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async attestation_cotisations_conges_payes_chomage_intemperies(siren: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiren(siren, 'siren');
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
@@ -23,6 +23,6 @@ export class Cnetp {
           throw new Error(`version ${resolvedVersion} not available for /cnetp/unites_legales/{siren}/attestation_cotisations_conges_payes_chomage_intemperies; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 }

--- a/clients/node/api-entreprise/src/resources/data_subvention.ts
+++ b/clients/node/api-entreprise/src/resources/data_subvention.ts
@@ -11,7 +11,7 @@ export class DataSubvention {
   }
 
   /** Subventions des associations */
-  async subventions(siren_or_siret_or_rna: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async subventions(siren_or_siret_or_rna: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
       switch (resolvedVersion) {
@@ -21,6 +21,6 @@ export class DataSubvention {
           throw new Error(`version ${resolvedVersion} not available for /data_subvention/associations/{siren_or_siret_or_rna}/subventions; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 }

--- a/clients/node/api-entreprise/src/resources/dgfip.ts
+++ b/clients/node/api-entreprise/src/resources/dgfip.ts
@@ -13,7 +13,7 @@ export class Dgfip {
   }
 
   /** Chiffre d'affaires */
-  async chiffres_affaires(siret: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async chiffres_affaires(siret: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiret(siret, 'siret');
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
@@ -24,11 +24,11 @@ export class Dgfip {
           throw new Error(`version ${resolvedVersion} not available for /dgfip/etablissements/{siret}/chiffres_affaires; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 
   /** Attestation fiscale */
-  async attestation_fiscale(siren: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async attestation_fiscale(siren: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiren(siren, 'siren');
     const resolvedVersion = options.version ?? 4;
     const path = (() => {
@@ -42,11 +42,11 @@ export class Dgfip {
           throw new Error(`version ${resolvedVersion} not available for /dgfip/unites_legales/{siren}/attestation_fiscale; supported: [3,4]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 
   /** Liasses fiscales */
-  async liasses_fiscales(siren: string, year: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async liasses_fiscales(siren: string, year: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiren(siren, 'siren');
     const resolvedVersion = options.version ?? 4;
     const path = (() => {
@@ -60,11 +60,11 @@ export class Dgfip {
           throw new Error(`version ${resolvedVersion} not available for /dgfip/unites_legales/{siren}/liasses_fiscales/{year}; supported: [3,4]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 
   /** Liens capitalistiques */
-  async liens_capitalistiques(siren: string, year: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async liens_capitalistiques(siren: string, year: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiren(siren, 'siren');
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
@@ -75,7 +75,7 @@ export class Dgfip {
           throw new Error(`version ${resolvedVersion} not available for /dgfip/unites_legales/{siren}/liens_capitalistiques/{year}; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 
   /** Numéro de TVA */

--- a/clients/node/api-entreprise/src/resources/dgfip.ts
+++ b/clients/node/api-entreprise/src/resources/dgfip.ts
@@ -79,7 +79,7 @@ export class Dgfip {
   }
 
   /** Numéro de TVA */
-  async numero_tva(siren: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async numero_tva(siren: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiren(siren, 'siren');
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
@@ -90,6 +90,6 @@ export class Dgfip {
           throw new Error(`version ${resolvedVersion} not available for /dgfip/unites_legales/{siren}/numero_tva; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 }

--- a/clients/node/api-entreprise/src/resources/djepva.ts
+++ b/clients/node/api-entreprise/src/resources/djepva.ts
@@ -11,7 +11,7 @@ export class Djepva {
   }
 
   /** Données association */
-  async associations(siren_or_rna: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async associations(siren_or_rna: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     const resolvedVersion = options.version ?? 4;
     const path = (() => {
       switch (resolvedVersion) {
@@ -21,11 +21,11 @@ export class Djepva {
           throw new Error(`version ${resolvedVersion} not available for /djepva/api-association/associations/{siren_or_rna}; supported: [4]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 
   /** Données association en open data */
-  async open_data(siren_or_rna: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async open_data(siren_or_rna: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     const resolvedVersion = options.version ?? 4;
     const path = (() => {
       switch (resolvedVersion) {
@@ -35,6 +35,6 @@ export class Djepva {
           throw new Error(`version ${resolvedVersion} not available for /djepva/api-association/associations/open_data/{siren_or_rna}; supported: [4]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 }

--- a/clients/node/api-entreprise/src/resources/douanes.ts
+++ b/clients/node/api-entreprise/src/resources/douanes.ts
@@ -11,7 +11,7 @@ export class Douanes {
   }
 
   /** Immatriculation EORI */
-  async immatriculations_eori(siret_or_eori: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async immatriculations_eori(siret_or_eori: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
       switch (resolvedVersion) {
@@ -21,6 +21,6 @@ export class Douanes {
           throw new Error(`version ${resolvedVersion} not available for /douanes/etablissements/{siret_or_eori}/immatriculations_eori; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 }

--- a/clients/node/api-entreprise/src/resources/european_commission.ts
+++ b/clients/node/api-entreprise/src/resources/european_commission.ts
@@ -12,7 +12,7 @@ export class EuropeanCommission {
   }
 
   /** N°TVA intracommunautaire français */
-  async numero_tva(siren: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async numero_tva(siren: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiren(siren, 'siren');
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
@@ -24,6 +24,6 @@ export class EuropeanCommission {
           throw new Error(`version ${resolvedVersion} not available for /european_commission/unites_legales/{siren}/numero_tva; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 }

--- a/clients/node/api-entreprise/src/resources/fabrique_numerique_ministeres_sociaux.ts
+++ b/clients/node/api-entreprise/src/resources/fabrique_numerique_ministeres_sociaux.ts
@@ -12,7 +12,7 @@ export class FabriqueNumeriqueMinisteresSociaux {
   }
 
   /** Conventions collectives */
-  async conventions_collectives(siret: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async conventions_collectives(siret: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiret(siret, 'siret');
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
@@ -24,6 +24,6 @@ export class FabriqueNumeriqueMinisteresSociaux {
           throw new Error(`version ${resolvedVersion} not available for /fabrique_numerique_ministeres_sociaux/etablissements/{siret}/conventions_collectives; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 }

--- a/clients/node/api-entreprise/src/resources/fntp.ts
+++ b/clients/node/api-entreprise/src/resources/fntp.ts
@@ -12,7 +12,7 @@ export class Fntp {
   }
 
   /** Carte professionnelle travaux publics */
-  async carte_professionnelle_travaux_publics(siren: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async carte_professionnelle_travaux_publics(siren: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiren(siren, 'siren');
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
@@ -23,6 +23,6 @@ export class Fntp {
           throw new Error(`version ${resolvedVersion} not available for /fntp/unites_legales/{siren}/carte_professionnelle_travaux_publics; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 }

--- a/clients/node/api-entreprise/src/resources/gip_mds.ts
+++ b/clients/node/api-entreprise/src/resources/gip_mds.ts
@@ -13,7 +13,7 @@ export class GipMds {
   }
 
   /** Effectifs mensuels d'un établissement */
-  async annee(siret: string, year: string, month: string, options: { version?: number; recipient?: string; context?: string; object?: string; profondeur?: string; nature_effectif?: string } = {}) {
+  async annee(siret: string, year: string, month: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string; profondeur?: string; nature_effectif?: string } = {}) {
     validateSiret(siret, 'siret');
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
@@ -24,11 +24,11 @@ export class GipMds {
           throw new Error(`version ${resolvedVersion} not available for /gip_mds/etablissements/{siret}/effectifs_mensuels/{month}/annee/{year}; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object, 'profondeur': options.profondeur, 'nature_effectif': options.nature_effectif } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object, 'profondeur': options.profondeur, 'nature_effectif': options.nature_effectif } });
   }
 
   /** Effectifs annuels d'une unité légale */
-  async effectifs_annuels(siren: string, year: string, options: { version?: number; recipient?: string; context?: string; object?: string; nature_effectif?: string } = {}) {
+  async effectifs_annuels(siren: string, year: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string; nature_effectif?: string } = {}) {
     validateSiren(siren, 'siren');
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
@@ -39,6 +39,6 @@ export class GipMds {
           throw new Error(`version ${resolvedVersion} not available for /gip_mds/unites_legales/{siren}/effectifs_annuels/{year}; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object, 'nature_effectif': options.nature_effectif } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object, 'nature_effectif': options.nature_effectif } });
   }
 }

--- a/clients/node/api-entreprise/src/resources/infogreffe.ts
+++ b/clients/node/api-entreprise/src/resources/infogreffe.ts
@@ -12,7 +12,7 @@ export class Infogreffe {
   }
 
   /** Extrait RCS */
-  async extrait_kbis(siren: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async extrait_kbis(siren: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiren(siren, 'siren');
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
@@ -23,11 +23,11 @@ export class Infogreffe {
           throw new Error(`version ${resolvedVersion} not available for /infogreffe/rcs/unites_legales/{siren}/extrait_kbis; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 
   /** Mandataires sociaux */
-  async mandataires_sociaux(siren: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async mandataires_sociaux(siren: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiren(siren, 'siren');
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
@@ -38,6 +38,6 @@ export class Infogreffe {
           throw new Error(`version ${resolvedVersion} not available for /infogreffe/rcs/unites_legales/{siren}/mandataires_sociaux; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 }

--- a/clients/node/api-entreprise/src/resources/inpi.ts
+++ b/clients/node/api-entreprise/src/resources/inpi.ts
@@ -12,7 +12,7 @@ export class Inpi {
   }
 
   /** Bénéficiaires effectifs */
-  async beneficiaires_effectifs(siren: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async beneficiaires_effectifs(siren: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiren(siren, 'siren');
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
@@ -23,11 +23,11 @@ export class Inpi {
           throw new Error(`version ${resolvedVersion} not available for /inpi/rne/unites_legales/{siren}/beneficiaires_effectifs; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 
   /** Attestation d'immatriculation RNE */
-  async extrait_rne(siren: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async extrait_rne(siren: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiren(siren, 'siren');
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
@@ -38,11 +38,11 @@ export class Inpi {
           throw new Error(`version ${resolvedVersion} not available for /inpi/rne/unites_legales/{siren}/extrait_rne; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 
   /** Actes et bilans */
-  async actes_bilans(siren: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async actes_bilans(siren: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiren(siren, 'siren');
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
@@ -53,6 +53,6 @@ export class Inpi {
           throw new Error(`version ${resolvedVersion} not available for /inpi/rne/unites_legales/open_data/{siren}/actes_bilans; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 }

--- a/clients/node/api-entreprise/src/resources/insee.ts
+++ b/clients/node/api-entreprise/src/resources/insee.ts
@@ -13,7 +13,7 @@ export class Insee {
   }
 
   /** Données établissement */
-  async etablissements(siret: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async etablissements(siret: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiret(siret, 'siret');
     const resolvedVersion = options.version ?? 4;
     const path = (() => {
@@ -27,11 +27,11 @@ export class Insee {
           throw new Error(`version ${resolvedVersion} not available for /insee/sirene/etablissements/{siret}; supported: [3,4]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 
   /** Adresse établissement */
-  async adresse(siret: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async adresse(siret: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiret(siret, 'siret');
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
@@ -42,11 +42,11 @@ export class Insee {
           throw new Error(`version ${resolvedVersion} not available for /insee/sirene/etablissements/{siret}/adresse; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 
   /** Liens de succession */
-  async successions(siret: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async successions(siret: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiret(siret, 'siret');
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
@@ -57,11 +57,11 @@ export class Insee {
           throw new Error(`version ${resolvedVersion} not available for /insee/sirene/etablissements/{siret}/successions; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 
   /** Données établissement en open data */
-  async diffusibles(siret: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async diffusibles(siret: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiret(siret, 'siret');
     const resolvedVersion = options.version ?? 4;
     const path = (() => {
@@ -75,11 +75,11 @@ export class Insee {
           throw new Error(`version ${resolvedVersion} not available for /insee/sirene/etablissements/diffusibles/{siret}; supported: [3,4]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 
   /** Adresse établissement en open data */
-  async etablissements_diffusibles_adresse(siret: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async etablissements_diffusibles_adresse(siret: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiret(siret, 'siret');
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
@@ -90,11 +90,11 @@ export class Insee {
           throw new Error(`version ${resolvedVersion} not available for /insee/sirene/etablissements/diffusibles/{siret}/adresse; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 
   /** Données unité légale */
-  async unites_legales(siren: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async unites_legales(siren: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiren(siren, 'siren');
     const resolvedVersion = options.version ?? 4;
     const path = (() => {
@@ -108,11 +108,11 @@ export class Insee {
           throw new Error(`version ${resolvedVersion} not available for /insee/sirene/unites_legales/{siren}; supported: [3,4]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 
   /** Données siège social */
-  async siege_social(siren: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async siege_social(siren: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiren(siren, 'siren');
     const resolvedVersion = options.version ?? 4;
     const path = (() => {
@@ -126,11 +126,11 @@ export class Insee {
           throw new Error(`version ${resolvedVersion} not available for /insee/sirene/unites_legales/{siren}/siege_social; supported: [3,4]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 
   /** Données unité légale en open data */
-  async sirene_unites_legales_diffusibles(siren: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async sirene_unites_legales_diffusibles(siren: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiren(siren, 'siren');
     const resolvedVersion = options.version ?? 4;
     const path = (() => {
@@ -144,11 +144,11 @@ export class Insee {
           throw new Error(`version ${resolvedVersion} not available for /insee/sirene/unites_legales/diffusibles/{siren}; supported: [3,4]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 
   /** Données siège social en open data */
-  async unites_legales_diffusibles_siege_social(siren: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async unites_legales_diffusibles_siege_social(siren: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiren(siren, 'siren');
     const resolvedVersion = options.version ?? 4;
     const path = (() => {
@@ -162,6 +162,6 @@ export class Insee {
           throw new Error(`version ${resolvedVersion} not available for /insee/sirene/unites_legales/diffusibles/{siren}/siege_social; supported: [3,4]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 }

--- a/clients/node/api-entreprise/src/resources/ministere_interieur.ts
+++ b/clients/node/api-entreprise/src/resources/ministere_interieur.ts
@@ -11,7 +11,7 @@ export class MinistereInterieur {
   }
 
   /** Données du RNA d'une association */
-  async associations(siret_or_rna: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async associations(siret_or_rna: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
       switch (resolvedVersion) {
@@ -22,11 +22,11 @@ export class MinistereInterieur {
           throw new Error(`version ${resolvedVersion} not available for /ministere_interieur/rna/associations/{siret_or_rna}; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 
   /** Divers documents d'une association */
-  async documents(siret_or_rna: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async documents(siret_or_rna: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
       switch (resolvedVersion) {
@@ -37,6 +37,6 @@ export class MinistereInterieur {
           throw new Error(`version ${resolvedVersion} not available for /ministere_interieur/rna/associations/{siret_or_rna}/documents; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 }

--- a/clients/node/api-entreprise/src/resources/msa.ts
+++ b/clients/node/api-entreprise/src/resources/msa.ts
@@ -12,7 +12,7 @@ export class Msa {
   }
 
   /** Conformité cotisations de sécurité sociale agricole */
-  async conformite_cotisations(siret: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async conformite_cotisations(siret: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiret(siret, 'siret');
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
@@ -23,6 +23,6 @@ export class Msa {
           throw new Error(`version ${resolvedVersion} not available for /msa/etablissements/{siret}/conformite_cotisations; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 }

--- a/clients/node/api-entreprise/src/resources/opqibi.ts
+++ b/clients/node/api-entreprise/src/resources/opqibi.ts
@@ -12,7 +12,7 @@ export class Opqibi {
   }
 
   /** Certification d'ingénierie OPQIBI */
-  async certification_ingenierie(siren: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async certification_ingenierie(siren: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiren(siren, 'siren');
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
@@ -23,6 +23,6 @@ export class Opqibi {
           throw new Error(`version ${resolvedVersion} not available for /opqibi/unites_legales/{siren}/certification_ingenierie; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 }

--- a/clients/node/api-entreprise/src/resources/probtp.ts
+++ b/clients/node/api-entreprise/src/resources/probtp.ts
@@ -12,7 +12,7 @@ export class Probtp {
   }
 
   /** Conformité cotisations retraite bâtiment */
-  async attestation_cotisations_retraite(siret: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async attestation_cotisations_retraite(siret: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiret(siret, 'siret');
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
@@ -23,11 +23,11 @@ export class Probtp {
           throw new Error(`version ${resolvedVersion} not available for /probtp/etablissements/{siret}/attestation_cotisations_retraite; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 
   /** Conformité cotisations retraite complémentaire */
-  async conformite_cotisations_retraite(siret: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async conformite_cotisations_retraite(siret: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiret(siret, 'siret');
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
@@ -38,6 +38,6 @@ export class Probtp {
           throw new Error(`version ${resolvedVersion} not available for /probtp/etablissements/{siret}/conformite_cotisations_retraite; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 }

--- a/clients/node/api-entreprise/src/resources/qualibat.ts
+++ b/clients/node/api-entreprise/src/resources/qualibat.ts
@@ -12,7 +12,7 @@ export class Qualibat {
   }
 
   /** Certification Qualibat */
-  async certification_batiment(siret: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async certification_batiment(siret: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiret(siret, 'siret');
     const resolvedVersion = options.version ?? 4;
     const path = (() => {
@@ -26,6 +26,6 @@ export class Qualibat {
           throw new Error(`version ${resolvedVersion} not available for /qualibat/etablissements/{siret}/certification_batiment; supported: [3,4]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 }

--- a/clients/node/api-entreprise/src/resources/qualifelec.ts
+++ b/clients/node/api-entreprise/src/resources/qualifelec.ts
@@ -12,7 +12,7 @@ export class Qualifelec {
   }
 
   /** Certification Qualifelec */
-  async certificats(siret: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async certificats(siret: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiret(siret, 'siret');
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
@@ -23,6 +23,6 @@ export class Qualifelec {
           throw new Error(`version ${resolvedVersion} not available for /qualifelec/etablissements/{siret}/certificats; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 }

--- a/clients/node/api-entreprise/src/resources/urssaf.ts
+++ b/clients/node/api-entreprise/src/resources/urssaf.ts
@@ -12,7 +12,7 @@ export class Urssaf {
   }
 
   /** Attestation de vigilance */
-  async attestation_vigilance(siren: string, options: { version?: number; recipient?: string; context?: string; object?: string } = {}) {
+  async attestation_vigilance(siren: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiren(siren, 'siren');
     const resolvedVersion = options.version ?? 4;
     const path = (() => {
@@ -26,6 +26,6 @@ export class Urssaf {
           throw new Error(`version ${resolvedVersion} not available for /urssaf/unites_legales/{siren}/attestation_vigilance; supported: [3,4]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'context': options.context, 'object': options.object } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 }

--- a/clients/node/api-particulier/src/resources/ants.ts
+++ b/clients/node/api-particulier/src/resources/ants.ts
@@ -11,7 +11,7 @@ export class Ants {
   }
 
   /** [FranceConnect] Extrait d'immatriculation véhicule */
-  async extrait_immatriculation_vehicule(options: { version?: number; recipient?: string; immatriculation: string }) {
+  async extrait_immatriculation_vehicule(options: { version?: number; recipient?: string; delegation_id?: string; immatriculation: string }) {
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
       switch (resolvedVersion) {
@@ -21,6 +21,6 @@ export class Ants {
           throw new Error(`version ${resolvedVersion} not available for /ants/extrait_immatriculation_vehicule/france_connect; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'immatriculation': options.immatriculation } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'immatriculation': options.immatriculation } });
   }
 }

--- a/clients/node/api-particulier/src/resources/cnous.ts
+++ b/clients/node/api-particulier/src/resources/cnous.ts
@@ -11,7 +11,7 @@ export class Cnous {
   }
 
   /** [FranceConnect] Statut étudiant boursier */
-  async etudiant_boursier(options: { version?: number; recipient?: string; campaign_year?: string } = {}) {
+  async etudiant_boursier(options: { version?: number; recipient?: string; delegation_id?: string; campaign_year?: string } = {}) {
     const resolvedVersion = options.version ?? 4;
     const path = (() => {
       switch (resolvedVersion) {
@@ -24,11 +24,11 @@ export class Cnous {
           throw new Error(`version ${resolvedVersion} not available for /cnous/etudiant_boursier/france_connect; supported: [3,4]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'campaignYear': options.campaign_year } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'campaignYear': options.campaign_year } });
   }
 
   /** [Identité] Statut étudiant boursier */
-  async etudiant_boursier_identite(options: { version?: number; recipient?: string; nom_naissance: string; prenoms: string[]; annee_date_naissance: string; mois_date_naissance: string; jour_date_naissance: string; sexe_etat_civil?: string; code_cog_insee_commune_naissance?: string; nom_commune_naissance?: string; code_cog_insee_departement_naissance?: string; campaign_year?: string }) {
+  async etudiant_boursier_identite(options: { version?: number; recipient?: string; delegation_id?: string; nom_naissance: string; prenoms: string[]; annee_date_naissance: string; mois_date_naissance: string; jour_date_naissance: string; sexe_etat_civil?: string; code_cog_insee_commune_naissance?: string; nom_commune_naissance?: string; code_cog_insee_departement_naissance?: string; campaign_year?: string }) {
     const resolvedVersion = options.version ?? 4;
     const path = (() => {
       switch (resolvedVersion) {
@@ -41,11 +41,11 @@ export class Cnous {
           throw new Error(`version ${resolvedVersion} not available for /cnous/etudiant_boursier/identite; supported: [3,4]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'nomNaissance': options.nom_naissance, 'prenoms': options.prenoms, 'anneeDateNaissance': options.annee_date_naissance, 'moisDateNaissance': options.mois_date_naissance, 'jourDateNaissance': options.jour_date_naissance, 'sexeEtatCivil': options.sexe_etat_civil, 'codeCogInseeCommuneNaissance': options.code_cog_insee_commune_naissance, 'nomCommuneNaissance': options.nom_commune_naissance, 'codeCogInseeDepartementNaissance': options.code_cog_insee_departement_naissance, 'campaignYear': options.campaign_year } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'nomNaissance': options.nom_naissance, 'prenoms': options.prenoms, 'anneeDateNaissance': options.annee_date_naissance, 'moisDateNaissance': options.mois_date_naissance, 'jourDateNaissance': options.jour_date_naissance, 'sexeEtatCivil': options.sexe_etat_civil, 'codeCogInseeCommuneNaissance': options.code_cog_insee_commune_naissance, 'nomCommuneNaissance': options.nom_commune_naissance, 'codeCogInseeDepartementNaissance': options.code_cog_insee_departement_naissance, 'campaignYear': options.campaign_year } });
   }
 
   /** [INE] Statut étudiant boursier */
-  async ine(options: { version?: number; recipient?: string; ine: string; campaign_year?: string }) {
+  async ine(options: { version?: number; recipient?: string; delegation_id?: string; ine: string; campaign_year?: string }) {
     const resolvedVersion = options.version ?? 4;
     const path = (() => {
       switch (resolvedVersion) {
@@ -58,6 +58,6 @@ export class Cnous {
           throw new Error(`version ${resolvedVersion} not available for /cnous/etudiant_boursier/ine; supported: [3,4]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'ine': options.ine, 'campaignYear': options.campaign_year } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'ine': options.ine, 'campaignYear': options.campaign_year } });
   }
 }

--- a/clients/node/api-particulier/src/resources/dsnj.ts
+++ b/clients/node/api-particulier/src/resources/dsnj.ts
@@ -11,7 +11,7 @@ export class Dsnj {
   }
 
   /** [FranceConnect] API Service national */
-  async service_national(options: { version?: number; recipient?: string } = {}) {
+  async service_national(options: { version?: number; recipient?: string; delegation_id?: string } = {}) {
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
       switch (resolvedVersion) {
@@ -21,11 +21,11 @@ export class Dsnj {
           throw new Error(`version ${resolvedVersion} not available for /dsnj/service_national/france_connect; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id } });
   }
 
   /** [Identité] API Service national */
-  async service_national_identite(options: { version?: number; recipient?: string; nom_naissance: string; prenoms: string[]; annee_date_naissance: string; mois_date_naissance: string; jour_date_naissance: string; sexe_etat_civil: string; code_cog_insee_commune_naissance?: string; code_cog_insee_pays_naissance: string }) {
+  async service_national_identite(options: { version?: number; recipient?: string; delegation_id?: string; nom_naissance: string; prenoms: string[]; annee_date_naissance: string; mois_date_naissance: string; jour_date_naissance: string; sexe_etat_civil: string; code_cog_insee_commune_naissance?: string; code_cog_insee_pays_naissance: string }) {
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
       switch (resolvedVersion) {
@@ -35,6 +35,6 @@ export class Dsnj {
           throw new Error(`version ${resolvedVersion} not available for /dsnj/service_national/identite; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'nomNaissance': options.nom_naissance, 'prenoms': options.prenoms, 'anneeDateNaissance': options.annee_date_naissance, 'moisDateNaissance': options.mois_date_naissance, 'jourDateNaissance': options.jour_date_naissance, 'sexeEtatCivil': options.sexe_etat_civil, 'codeCogInseeCommuneNaissance': options.code_cog_insee_commune_naissance, 'codeCogInseePaysNaissance': options.code_cog_insee_pays_naissance } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'nomNaissance': options.nom_naissance, 'prenoms': options.prenoms, 'anneeDateNaissance': options.annee_date_naissance, 'moisDateNaissance': options.mois_date_naissance, 'jourDateNaissance': options.jour_date_naissance, 'sexeEtatCivil': options.sexe_etat_civil, 'codeCogInseeCommuneNaissance': options.code_cog_insee_commune_naissance, 'codeCogInseePaysNaissance': options.code_cog_insee_pays_naissance } });
   }
 }

--- a/clients/node/api-particulier/src/resources/dss.ts
+++ b/clients/node/api-particulier/src/resources/dss.ts
@@ -11,7 +11,7 @@ export class Dss {
   }
 
   /** [FranceConnect] Statut allocation adulte handicapé (AAH) */
-  async allocation_adulte_handicape(options: { version?: number; recipient?: string } = {}) {
+  async allocation_adulte_handicape(options: { version?: number; recipient?: string; delegation_id?: string } = {}) {
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
       switch (resolvedVersion) {
@@ -21,11 +21,11 @@ export class Dss {
           throw new Error(`version ${resolvedVersion} not available for /dss/allocation_adulte_handicape/france_connect; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id } });
   }
 
   /** [Identité] Statut allocation adulte handicapé (AAH) */
-  async allocation_adulte_handicape_identite(options: { version?: number; recipient?: string; nom_naissance: string; nom_usage?: string; prenoms: string[]; annee_date_naissance?: string; mois_date_naissance?: string; jour_date_naissance?: string; sexe_etat_civil?: string; code_cog_insee_pays_naissance: string; code_cog_insee_commune_naissance?: string; nom_commune_naissance?: string; code_cog_insee_departement_naissance?: string }) {
+  async allocation_adulte_handicape_identite(options: { version?: number; recipient?: string; delegation_id?: string; nom_naissance: string; nom_usage?: string; prenoms: string[]; annee_date_naissance?: string; mois_date_naissance?: string; jour_date_naissance?: string; sexe_etat_civil?: string; code_cog_insee_pays_naissance: string; code_cog_insee_commune_naissance?: string; nom_commune_naissance?: string; code_cog_insee_departement_naissance?: string }) {
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
       switch (resolvedVersion) {
@@ -35,11 +35,11 @@ export class Dss {
           throw new Error(`version ${resolvedVersion} not available for /dss/allocation_adulte_handicape/identite; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'nomNaissance': options.nom_naissance, 'nomUsage': options.nom_usage, 'prenoms': options.prenoms, 'anneeDateNaissance': options.annee_date_naissance, 'moisDateNaissance': options.mois_date_naissance, 'jourDateNaissance': options.jour_date_naissance, 'sexeEtatCivil': options.sexe_etat_civil, 'codeCogInseePaysNaissance': options.code_cog_insee_pays_naissance, 'codeCogInseeCommuneNaissance': options.code_cog_insee_commune_naissance, 'nomCommuneNaissance': options.nom_commune_naissance, 'codeCogInseeDepartementNaissance': options.code_cog_insee_departement_naissance } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'nomNaissance': options.nom_naissance, 'nomUsage': options.nom_usage, 'prenoms': options.prenoms, 'anneeDateNaissance': options.annee_date_naissance, 'moisDateNaissance': options.mois_date_naissance, 'jourDateNaissance': options.jour_date_naissance, 'sexeEtatCivil': options.sexe_etat_civil, 'codeCogInseePaysNaissance': options.code_cog_insee_pays_naissance, 'codeCogInseeCommuneNaissance': options.code_cog_insee_commune_naissance, 'nomCommuneNaissance': options.nom_commune_naissance, 'codeCogInseeDepartementNaissance': options.code_cog_insee_departement_naissance } });
   }
 
   /** [FranceConnect] Statut allocation d'éducation de l'enfant handicapé (AEEH) */
-  async allocation_enfant_handicape(options: { version?: number; recipient?: string } = {}) {
+  async allocation_enfant_handicape(options: { version?: number; recipient?: string; delegation_id?: string } = {}) {
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
       switch (resolvedVersion) {
@@ -49,11 +49,11 @@ export class Dss {
           throw new Error(`version ${resolvedVersion} not available for /dss/allocation_enfant_handicape/france_connect; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id } });
   }
 
   /** [Identité] Statut allocation d'éducation de l'enfant handicapé (AEEH) */
-  async allocation_enfant_handicape_identite(options: { version?: number; recipient?: string; nom_naissance: string; nom_usage?: string; prenoms: string[]; annee_date_naissance?: string; mois_date_naissance?: string; jour_date_naissance?: string; sexe_etat_civil?: string; code_cog_insee_pays_naissance: string; code_cog_insee_commune_naissance?: string; nom_commune_naissance?: string; code_cog_insee_departement_naissance?: string }) {
+  async allocation_enfant_handicape_identite(options: { version?: number; recipient?: string; delegation_id?: string; nom_naissance: string; nom_usage?: string; prenoms: string[]; annee_date_naissance?: string; mois_date_naissance?: string; jour_date_naissance?: string; sexe_etat_civil?: string; code_cog_insee_pays_naissance: string; code_cog_insee_commune_naissance?: string; nom_commune_naissance?: string; code_cog_insee_departement_naissance?: string }) {
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
       switch (resolvedVersion) {
@@ -63,11 +63,11 @@ export class Dss {
           throw new Error(`version ${resolvedVersion} not available for /dss/allocation_enfant_handicape/identite; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'nomNaissance': options.nom_naissance, 'nomUsage': options.nom_usage, 'prenoms': options.prenoms, 'anneeDateNaissance': options.annee_date_naissance, 'moisDateNaissance': options.mois_date_naissance, 'jourDateNaissance': options.jour_date_naissance, 'sexeEtatCivil': options.sexe_etat_civil, 'codeCogInseePaysNaissance': options.code_cog_insee_pays_naissance, 'codeCogInseeCommuneNaissance': options.code_cog_insee_commune_naissance, 'nomCommuneNaissance': options.nom_commune_naissance, 'codeCogInseeDepartementNaissance': options.code_cog_insee_departement_naissance } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'nomNaissance': options.nom_naissance, 'nomUsage': options.nom_usage, 'prenoms': options.prenoms, 'anneeDateNaissance': options.annee_date_naissance, 'moisDateNaissance': options.mois_date_naissance, 'jourDateNaissance': options.jour_date_naissance, 'sexeEtatCivil': options.sexe_etat_civil, 'codeCogInseePaysNaissance': options.code_cog_insee_pays_naissance, 'codeCogInseeCommuneNaissance': options.code_cog_insee_commune_naissance, 'nomCommuneNaissance': options.nom_commune_naissance, 'codeCogInseeDepartementNaissance': options.code_cog_insee_departement_naissance } });
   }
 
   /** [FranceConnect] Statut allocation de soutien familial (ASF) */
-  async allocation_soutien_familial(options: { version?: number; recipient?: string } = {}) {
+  async allocation_soutien_familial(options: { version?: number; recipient?: string; delegation_id?: string } = {}) {
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
       switch (resolvedVersion) {
@@ -77,11 +77,11 @@ export class Dss {
           throw new Error(`version ${resolvedVersion} not available for /dss/allocation_soutien_familial/france_connect; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id } });
   }
 
   /** [Identité] Statut allocation de soutien familial (ASF) */
-  async allocation_soutien_familial_identite(options: { version?: number; recipient?: string; nom_naissance: string; nom_usage?: string; prenoms: string[]; annee_date_naissance?: string; mois_date_naissance?: string; jour_date_naissance?: string; sexe_etat_civil?: string; code_cog_insee_pays_naissance: string; code_cog_insee_commune_naissance?: string; nom_commune_naissance?: string; code_cog_insee_departement_naissance?: string }) {
+  async allocation_soutien_familial_identite(options: { version?: number; recipient?: string; delegation_id?: string; nom_naissance: string; nom_usage?: string; prenoms: string[]; annee_date_naissance?: string; mois_date_naissance?: string; jour_date_naissance?: string; sexe_etat_civil?: string; code_cog_insee_pays_naissance: string; code_cog_insee_commune_naissance?: string; nom_commune_naissance?: string; code_cog_insee_departement_naissance?: string }) {
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
       switch (resolvedVersion) {
@@ -91,11 +91,11 @@ export class Dss {
           throw new Error(`version ${resolvedVersion} not available for /dss/allocation_soutien_familial/identite; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'nomNaissance': options.nom_naissance, 'nomUsage': options.nom_usage, 'prenoms': options.prenoms, 'anneeDateNaissance': options.annee_date_naissance, 'moisDateNaissance': options.mois_date_naissance, 'jourDateNaissance': options.jour_date_naissance, 'sexeEtatCivil': options.sexe_etat_civil, 'codeCogInseePaysNaissance': options.code_cog_insee_pays_naissance, 'codeCogInseeCommuneNaissance': options.code_cog_insee_commune_naissance, 'nomCommuneNaissance': options.nom_commune_naissance, 'codeCogInseeDepartementNaissance': options.code_cog_insee_departement_naissance } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'nomNaissance': options.nom_naissance, 'nomUsage': options.nom_usage, 'prenoms': options.prenoms, 'anneeDateNaissance': options.annee_date_naissance, 'moisDateNaissance': options.mois_date_naissance, 'jourDateNaissance': options.jour_date_naissance, 'sexeEtatCivil': options.sexe_etat_civil, 'codeCogInseePaysNaissance': options.code_cog_insee_pays_naissance, 'codeCogInseeCommuneNaissance': options.code_cog_insee_commune_naissance, 'nomCommuneNaissance': options.nom_commune_naissance, 'codeCogInseeDepartementNaissance': options.code_cog_insee_departement_naissance } });
   }
 
   /** [FranceConnect] Statut complémentaire santé solidaire (C2S) */
-  async complementaire_sante_solidaire(options: { version?: number; recipient?: string } = {}) {
+  async complementaire_sante_solidaire(options: { version?: number; recipient?: string; delegation_id?: string } = {}) {
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
       switch (resolvedVersion) {
@@ -105,11 +105,11 @@ export class Dss {
           throw new Error(`version ${resolvedVersion} not available for /dss/complementaire_sante_solidaire/france_connect; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id } });
   }
 
   /** [Identité] Statut complémentaire santé solidaire (C2S) */
-  async complementaire_sante_solidaire_identite(options: { version?: number; recipient?: string; nom_naissance: string; nom_usage?: string; prenoms: string[]; annee_date_naissance?: string; mois_date_naissance?: string; jour_date_naissance?: string; sexe_etat_civil?: string; code_cog_insee_pays_naissance: string; code_cog_insee_commune_naissance?: string; nom_commune_naissance?: string; code_cog_insee_departement_naissance?: string }) {
+  async complementaire_sante_solidaire_identite(options: { version?: number; recipient?: string; delegation_id?: string; nom_naissance: string; nom_usage?: string; prenoms: string[]; annee_date_naissance?: string; mois_date_naissance?: string; jour_date_naissance?: string; sexe_etat_civil?: string; code_cog_insee_pays_naissance: string; code_cog_insee_commune_naissance?: string; nom_commune_naissance?: string; code_cog_insee_departement_naissance?: string }) {
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
       switch (resolvedVersion) {
@@ -119,11 +119,11 @@ export class Dss {
           throw new Error(`version ${resolvedVersion} not available for /dss/complementaire_sante_solidaire/identite; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'nomNaissance': options.nom_naissance, 'nomUsage': options.nom_usage, 'prenoms': options.prenoms, 'anneeDateNaissance': options.annee_date_naissance, 'moisDateNaissance': options.mois_date_naissance, 'jourDateNaissance': options.jour_date_naissance, 'sexeEtatCivil': options.sexe_etat_civil, 'codeCogInseePaysNaissance': options.code_cog_insee_pays_naissance, 'codeCogInseeCommuneNaissance': options.code_cog_insee_commune_naissance, 'nomCommuneNaissance': options.nom_commune_naissance, 'codeCogInseeDepartementNaissance': options.code_cog_insee_departement_naissance } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'nomNaissance': options.nom_naissance, 'nomUsage': options.nom_usage, 'prenoms': options.prenoms, 'anneeDateNaissance': options.annee_date_naissance, 'moisDateNaissance': options.mois_date_naissance, 'jourDateNaissance': options.jour_date_naissance, 'sexeEtatCivil': options.sexe_etat_civil, 'codeCogInseePaysNaissance': options.code_cog_insee_pays_naissance, 'codeCogInseeCommuneNaissance': options.code_cog_insee_commune_naissance, 'nomCommuneNaissance': options.nom_commune_naissance, 'codeCogInseeDepartementNaissance': options.code_cog_insee_departement_naissance } });
   }
 
   /** [FranceConnect] Participation familiale EAJE */
-  async participation_familiale_eaje(options: { version?: number; recipient?: string } = {}) {
+  async participation_familiale_eaje(options: { version?: number; recipient?: string; delegation_id?: string } = {}) {
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
       switch (resolvedVersion) {
@@ -133,11 +133,11 @@ export class Dss {
           throw new Error(`version ${resolvedVersion} not available for /dss/participation_familiale_eaje/france_connect; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id } });
   }
 
   /** [Identité] Participation familiale EAJE */
-  async participation_familiale_eaje_identite(options: { version?: number; recipient?: string; nom_naissance: string; nom_usage?: string; prenoms: string[]; annee_date_naissance?: string; mois_date_naissance?: string; jour_date_naissance?: string; sexe_etat_civil?: string; code_cog_insee_pays_naissance: string; code_cog_insee_commune_naissance?: string; nom_commune_naissance?: string; code_cog_insee_departement_naissance?: string }) {
+  async participation_familiale_eaje_identite(options: { version?: number; recipient?: string; delegation_id?: string; nom_naissance: string; nom_usage?: string; prenoms: string[]; annee_date_naissance?: string; mois_date_naissance?: string; jour_date_naissance?: string; sexe_etat_civil?: string; code_cog_insee_pays_naissance: string; code_cog_insee_commune_naissance?: string; nom_commune_naissance?: string; code_cog_insee_departement_naissance?: string }) {
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
       switch (resolvedVersion) {
@@ -147,11 +147,11 @@ export class Dss {
           throw new Error(`version ${resolvedVersion} not available for /dss/participation_familiale_eaje/identite; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'nomNaissance': options.nom_naissance, 'nomUsage': options.nom_usage, 'prenoms': options.prenoms, 'anneeDateNaissance': options.annee_date_naissance, 'moisDateNaissance': options.mois_date_naissance, 'jourDateNaissance': options.jour_date_naissance, 'sexeEtatCivil': options.sexe_etat_civil, 'codeCogInseePaysNaissance': options.code_cog_insee_pays_naissance, 'codeCogInseeCommuneNaissance': options.code_cog_insee_commune_naissance, 'nomCommuneNaissance': options.nom_commune_naissance, 'codeCogInseeDepartementNaissance': options.code_cog_insee_departement_naissance } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'nomNaissance': options.nom_naissance, 'nomUsage': options.nom_usage, 'prenoms': options.prenoms, 'anneeDateNaissance': options.annee_date_naissance, 'moisDateNaissance': options.mois_date_naissance, 'jourDateNaissance': options.jour_date_naissance, 'sexeEtatCivil': options.sexe_etat_civil, 'codeCogInseePaysNaissance': options.code_cog_insee_pays_naissance, 'codeCogInseeCommuneNaissance': options.code_cog_insee_commune_naissance, 'nomCommuneNaissance': options.nom_commune_naissance, 'codeCogInseeDepartementNaissance': options.code_cog_insee_departement_naissance } });
   }
 
   /** [FranceConnect] Statut prime d'activité */
-  async prime_activite(options: { version?: number; recipient?: string } = {}) {
+  async prime_activite(options: { version?: number; recipient?: string; delegation_id?: string } = {}) {
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
       switch (resolvedVersion) {
@@ -161,11 +161,11 @@ export class Dss {
           throw new Error(`version ${resolvedVersion} not available for /dss/prime_activite/france_connect; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id } });
   }
 
   /** [Identité] Statut prime d'activité */
-  async prime_activite_identite(options: { version?: number; recipient?: string; nom_naissance: string; nom_usage?: string; prenoms: string[]; annee_date_naissance?: string; mois_date_naissance?: string; jour_date_naissance?: string; sexe_etat_civil?: string; code_cog_insee_pays_naissance: string; code_cog_insee_commune_naissance?: string; nom_commune_naissance?: string; code_cog_insee_departement_naissance?: string }) {
+  async prime_activite_identite(options: { version?: number; recipient?: string; delegation_id?: string; nom_naissance: string; nom_usage?: string; prenoms: string[]; annee_date_naissance?: string; mois_date_naissance?: string; jour_date_naissance?: string; sexe_etat_civil?: string; code_cog_insee_pays_naissance: string; code_cog_insee_commune_naissance?: string; nom_commune_naissance?: string; code_cog_insee_departement_naissance?: string }) {
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
       switch (resolvedVersion) {
@@ -175,11 +175,11 @@ export class Dss {
           throw new Error(`version ${resolvedVersion} not available for /dss/prime_activite/identite; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'nomNaissance': options.nom_naissance, 'nomUsage': options.nom_usage, 'prenoms': options.prenoms, 'anneeDateNaissance': options.annee_date_naissance, 'moisDateNaissance': options.mois_date_naissance, 'jourDateNaissance': options.jour_date_naissance, 'sexeEtatCivil': options.sexe_etat_civil, 'codeCogInseePaysNaissance': options.code_cog_insee_pays_naissance, 'codeCogInseeCommuneNaissance': options.code_cog_insee_commune_naissance, 'nomCommuneNaissance': options.nom_commune_naissance, 'codeCogInseeDepartementNaissance': options.code_cog_insee_departement_naissance } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'nomNaissance': options.nom_naissance, 'nomUsage': options.nom_usage, 'prenoms': options.prenoms, 'anneeDateNaissance': options.annee_date_naissance, 'moisDateNaissance': options.mois_date_naissance, 'jourDateNaissance': options.jour_date_naissance, 'sexeEtatCivil': options.sexe_etat_civil, 'codeCogInseePaysNaissance': options.code_cog_insee_pays_naissance, 'codeCogInseeCommuneNaissance': options.code_cog_insee_commune_naissance, 'nomCommuneNaissance': options.nom_commune_naissance, 'codeCogInseeDepartementNaissance': options.code_cog_insee_departement_naissance } });
   }
 
   /** [FranceConnect] Quotient familial CAF & MSA */
-  async quotient_familial(options: { version?: number; recipient?: string; annee?: string; mois?: string } = {}) {
+  async quotient_familial(options: { version?: number; recipient?: string; delegation_id?: string; annee?: string; mois?: string } = {}) {
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
       switch (resolvedVersion) {
@@ -189,11 +189,11 @@ export class Dss {
           throw new Error(`version ${resolvedVersion} not available for /dss/quotient_familial/france_connect; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'annee': options.annee, 'mois': options.mois } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'annee': options.annee, 'mois': options.mois } });
   }
 
   /** [Identité] Quotient familial CAF & MSA */
-  async quotient_familial_identite(options: { version?: number; recipient?: string; nom_naissance: string; nom_usage?: string; prenoms: string[]; annee_date_naissance?: string; mois_date_naissance?: string; jour_date_naissance?: string; sexe_etat_civil?: string; code_cog_insee_pays_naissance: string; code_cog_insee_commune_naissance?: string; nom_commune_naissance?: string; code_cog_insee_departement_naissance?: string; annee?: string; mois?: string }) {
+  async quotient_familial_identite(options: { version?: number; recipient?: string; delegation_id?: string; nom_naissance: string; nom_usage?: string; prenoms: string[]; annee_date_naissance?: string; mois_date_naissance?: string; jour_date_naissance?: string; sexe_etat_civil?: string; code_cog_insee_pays_naissance: string; code_cog_insee_commune_naissance?: string; nom_commune_naissance?: string; code_cog_insee_departement_naissance?: string; annee?: string; mois?: string }) {
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
       switch (resolvedVersion) {
@@ -203,11 +203,11 @@ export class Dss {
           throw new Error(`version ${resolvedVersion} not available for /dss/quotient_familial/identite; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'nomNaissance': options.nom_naissance, 'nomUsage': options.nom_usage, 'prenoms': options.prenoms, 'anneeDateNaissance': options.annee_date_naissance, 'moisDateNaissance': options.mois_date_naissance, 'jourDateNaissance': options.jour_date_naissance, 'sexeEtatCivil': options.sexe_etat_civil, 'codeCogInseePaysNaissance': options.code_cog_insee_pays_naissance, 'codeCogInseeCommuneNaissance': options.code_cog_insee_commune_naissance, 'nomCommuneNaissance': options.nom_commune_naissance, 'codeCogInseeDepartementNaissance': options.code_cog_insee_departement_naissance, 'annee': options.annee, 'mois': options.mois } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'nomNaissance': options.nom_naissance, 'nomUsage': options.nom_usage, 'prenoms': options.prenoms, 'anneeDateNaissance': options.annee_date_naissance, 'moisDateNaissance': options.mois_date_naissance, 'jourDateNaissance': options.jour_date_naissance, 'sexeEtatCivil': options.sexe_etat_civil, 'codeCogInseePaysNaissance': options.code_cog_insee_pays_naissance, 'codeCogInseeCommuneNaissance': options.code_cog_insee_commune_naissance, 'nomCommuneNaissance': options.nom_commune_naissance, 'codeCogInseeDepartementNaissance': options.code_cog_insee_departement_naissance, 'annee': options.annee, 'mois': options.mois } });
   }
 
   /** [FranceConnect] Statut revenu de solidarité active (RSA) */
-  async revenu_solidarite_active(options: { version?: number; recipient?: string } = {}) {
+  async revenu_solidarite_active(options: { version?: number; recipient?: string; delegation_id?: string } = {}) {
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
       switch (resolvedVersion) {
@@ -217,11 +217,11 @@ export class Dss {
           throw new Error(`version ${resolvedVersion} not available for /dss/revenu_solidarite_active/france_connect; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id } });
   }
 
   /** [Identité] Statut revenu de solidarité active (RSA) */
-  async revenu_solidarite_active_identite(options: { version?: number; recipient?: string; nom_naissance: string; nom_usage?: string; prenoms: string[]; annee_date_naissance?: string; mois_date_naissance?: string; jour_date_naissance?: string; sexe_etat_civil?: string; code_cog_insee_pays_naissance: string; code_cog_insee_commune_naissance?: string; nom_commune_naissance?: string; code_cog_insee_departement_naissance?: string }) {
+  async revenu_solidarite_active_identite(options: { version?: number; recipient?: string; delegation_id?: string; nom_naissance: string; nom_usage?: string; prenoms: string[]; annee_date_naissance?: string; mois_date_naissance?: string; jour_date_naissance?: string; sexe_etat_civil?: string; code_cog_insee_pays_naissance: string; code_cog_insee_commune_naissance?: string; nom_commune_naissance?: string; code_cog_insee_departement_naissance?: string }) {
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
       switch (resolvedVersion) {
@@ -231,6 +231,6 @@ export class Dss {
           throw new Error(`version ${resolvedVersion} not available for /dss/revenu_solidarite_active/identite; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'nomNaissance': options.nom_naissance, 'nomUsage': options.nom_usage, 'prenoms': options.prenoms, 'anneeDateNaissance': options.annee_date_naissance, 'moisDateNaissance': options.mois_date_naissance, 'jourDateNaissance': options.jour_date_naissance, 'sexeEtatCivil': options.sexe_etat_civil, 'codeCogInseePaysNaissance': options.code_cog_insee_pays_naissance, 'codeCogInseeCommuneNaissance': options.code_cog_insee_commune_naissance, 'nomCommuneNaissance': options.nom_commune_naissance, 'codeCogInseeDepartementNaissance': options.code_cog_insee_departement_naissance } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'nomNaissance': options.nom_naissance, 'nomUsage': options.nom_usage, 'prenoms': options.prenoms, 'anneeDateNaissance': options.annee_date_naissance, 'moisDateNaissance': options.mois_date_naissance, 'jourDateNaissance': options.jour_date_naissance, 'sexeEtatCivil': options.sexe_etat_civil, 'codeCogInseePaysNaissance': options.code_cog_insee_pays_naissance, 'codeCogInseeCommuneNaissance': options.code_cog_insee_commune_naissance, 'nomCommuneNaissance': options.nom_commune_naissance, 'codeCogInseeDepartementNaissance': options.code_cog_insee_departement_naissance } });
   }
 }

--- a/clients/node/api-particulier/src/resources/france_travail.ts
+++ b/clients/node/api-particulier/src/resources/france_travail.ts
@@ -11,7 +11,7 @@ export class FranceTravail {
   }
 
   /** Paiements versés par France Travail */
-  async indemnites(options: { version?: number; recipient?: string; identifiant: string }) {
+  async indemnites(options: { version?: number; recipient?: string; delegation_id?: string; identifiant: string }) {
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
       switch (resolvedVersion) {
@@ -21,11 +21,11 @@ export class FranceTravail {
           throw new Error(`version ${resolvedVersion} not available for /france_travail/indemnites/identifiant; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'identifiant': options.identifiant } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'identifiant': options.identifiant } });
   }
 
   /** Statut demandeur d'emploi */
-  async statut(options: { version?: number; recipient?: string; identifiant: string }) {
+  async statut(options: { version?: number; recipient?: string; delegation_id?: string; identifiant: string }) {
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
       switch (resolvedVersion) {
@@ -35,6 +35,6 @@ export class FranceTravail {
           throw new Error(`version ${resolvedVersion} not available for /france_travail/statut/identifiant; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'identifiant': options.identifiant } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'identifiant': options.identifiant } });
   }
 }

--- a/clients/node/api-particulier/src/resources/gip_mds.ts
+++ b/clients/node/api-particulier/src/resources/gip_mds.ts
@@ -11,7 +11,7 @@ export class GipMds {
   }
 
   /** [FranceConnect] Statut service civique */
-  async service_civique(options: { version?: number; recipient?: string } = {}) {
+  async service_civique(options: { version?: number; recipient?: string; delegation_id?: string } = {}) {
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
       switch (resolvedVersion) {
@@ -21,11 +21,11 @@ export class GipMds {
           throw new Error(`version ${resolvedVersion} not available for /gip_mds/service_civique/france_connect; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id } });
   }
 
   /** [Identité] Statut service civique */
-  async service_civique_identite(options: { version?: number; recipient?: string; nom_naissance: string; prenoms: string[]; annee_date_naissance: string; mois_date_naissance: string; jour_date_naissance: string }) {
+  async service_civique_identite(options: { version?: number; recipient?: string; delegation_id?: string; nom_naissance: string; prenoms: string[]; annee_date_naissance: string; mois_date_naissance: string; jour_date_naissance: string }) {
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
       switch (resolvedVersion) {
@@ -35,6 +35,6 @@ export class GipMds {
           throw new Error(`version ${resolvedVersion} not available for /gip_mds/service_civique/identite; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'nomNaissance': options.nom_naissance, 'prenoms': options.prenoms, 'anneeDateNaissance': options.annee_date_naissance, 'moisDateNaissance': options.mois_date_naissance, 'jourDateNaissance': options.jour_date_naissance } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'nomNaissance': options.nom_naissance, 'prenoms': options.prenoms, 'anneeDateNaissance': options.annee_date_naissance, 'moisDateNaissance': options.mois_date_naissance, 'jourDateNaissance': options.jour_date_naissance } });
   }
 }

--- a/clients/node/api-particulier/src/resources/men.ts
+++ b/clients/node/api-particulier/src/resources/men.ts
@@ -11,7 +11,7 @@ export class Men {
   }
 
   /** Statut élève scolarisé et boursier */
-  async scolarites(options: { version?: number; recipient?: string; nom_naissance: string; prenoms: string[]; sexe_etat_civil: string; annee_date_naissance: string; mois_date_naissance: string; jour_date_naissance: string; code_etablissement?: string; annee_scolaire: string; degre_etablissement?: string; codes_bcn_departements?: string[]; codes_bcn_regions?: string[] }) {
+  async scolarites(options: { version?: number; recipient?: string; delegation_id?: string; nom_naissance: string; prenoms: string[]; sexe_etat_civil: string; annee_date_naissance: string; mois_date_naissance: string; jour_date_naissance: string; code_etablissement?: string; annee_scolaire: string; degre_etablissement?: string; codes_bcn_departements?: string[]; codes_bcn_regions?: string[] }) {
     const resolvedVersion = options.version ?? 5;
     const path = (() => {
       switch (resolvedVersion) {
@@ -27,6 +27,6 @@ export class Men {
           throw new Error(`version ${resolvedVersion} not available for /men/scolarites/identite; supported: [3,4,5]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'nomNaissance': options.nom_naissance, 'prenoms': options.prenoms, 'sexeEtatCivil': options.sexe_etat_civil, 'anneeDateNaissance': options.annee_date_naissance, 'moisDateNaissance': options.mois_date_naissance, 'jourDateNaissance': options.jour_date_naissance, 'codeEtablissement': options.code_etablissement, 'anneeScolaire': options.annee_scolaire, 'degreEtablissement': options.degre_etablissement, 'codesBcnDepartements': options.codes_bcn_departements, 'codesBcnRegions': options.codes_bcn_regions } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'nomNaissance': options.nom_naissance, 'prenoms': options.prenoms, 'sexeEtatCivil': options.sexe_etat_civil, 'anneeDateNaissance': options.annee_date_naissance, 'moisDateNaissance': options.mois_date_naissance, 'jourDateNaissance': options.jour_date_naissance, 'codeEtablissement': options.code_etablissement, 'anneeScolaire': options.annee_scolaire, 'degreEtablissement': options.degre_etablissement, 'codesBcnDepartements': options.codes_bcn_departements, 'codesBcnRegions': options.codes_bcn_regions } });
   }
 }

--- a/clients/node/api-particulier/src/resources/mesri.ts
+++ b/clients/node/api-particulier/src/resources/mesri.ts
@@ -11,7 +11,7 @@ export class Mesri {
   }
 
   /** [FranceConnect] Statut étudiant */
-  async statut_etudiant(options: { version?: number; recipient?: string } = {}) {
+  async statut_etudiant(options: { version?: number; recipient?: string; delegation_id?: string } = {}) {
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
       switch (resolvedVersion) {
@@ -21,11 +21,11 @@ export class Mesri {
           throw new Error(`version ${resolvedVersion} not available for /mesri/statut_etudiant/france_connect; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id } });
   }
 
   /** [Identité] Statut étudiant */
-  async statut_etudiant_identite(options: { version?: number; recipient?: string; nom_naissance: string; prenoms: string[]; annee_date_naissance: string; mois_date_naissance: string; jour_date_naissance: string; sexe_etat_civil: string; code_cog_insee_commune_naissance?: string; nom_commune_naissance?: string; code_cog_insee_departement_naissance?: string }) {
+  async statut_etudiant_identite(options: { version?: number; recipient?: string; delegation_id?: string; nom_naissance: string; prenoms: string[]; annee_date_naissance: string; mois_date_naissance: string; jour_date_naissance: string; sexe_etat_civil: string; code_cog_insee_commune_naissance?: string; nom_commune_naissance?: string; code_cog_insee_departement_naissance?: string }) {
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
       switch (resolvedVersion) {
@@ -35,11 +35,11 @@ export class Mesri {
           throw new Error(`version ${resolvedVersion} not available for /mesri/statut_etudiant/identite; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'nomNaissance': options.nom_naissance, 'prenoms': options.prenoms, 'anneeDateNaissance': options.annee_date_naissance, 'moisDateNaissance': options.mois_date_naissance, 'jourDateNaissance': options.jour_date_naissance, 'sexeEtatCivil': options.sexe_etat_civil, 'codeCogInseeCommuneNaissance': options.code_cog_insee_commune_naissance, 'nomCommuneNaissance': options.nom_commune_naissance, 'codeCogInseeDepartementNaissance': options.code_cog_insee_departement_naissance } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'nomNaissance': options.nom_naissance, 'prenoms': options.prenoms, 'anneeDateNaissance': options.annee_date_naissance, 'moisDateNaissance': options.mois_date_naissance, 'jourDateNaissance': options.jour_date_naissance, 'sexeEtatCivil': options.sexe_etat_civil, 'codeCogInseeCommuneNaissance': options.code_cog_insee_commune_naissance, 'nomCommuneNaissance': options.nom_commune_naissance, 'codeCogInseeDepartementNaissance': options.code_cog_insee_departement_naissance } });
   }
 
   /** [INE] Statut étudiant */
-  async ine(options: { version?: number; recipient?: string; ine: string }) {
+  async ine(options: { version?: number; recipient?: string; delegation_id?: string; ine: string }) {
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
       switch (resolvedVersion) {
@@ -49,6 +49,6 @@ export class Mesri {
           throw new Error(`version ${resolvedVersion} not available for /mesri/statut_etudiant/ine; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'ine': options.ine } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'ine': options.ine } });
   }
 }

--- a/clients/node/api-particulier/src/resources/sdh.ts
+++ b/clients/node/api-particulier/src/resources/sdh.ts
@@ -11,7 +11,7 @@ export class Sdh {
   }
 
   /** [Identifiant] API Statut sportif de haut niveau et sur liste ministérielle */
-  async statut_sportif(options: { version?: number; recipient?: string; identifiant: string }) {
+  async statut_sportif(options: { version?: number; recipient?: string; delegation_id?: string; identifiant: string }) {
     const resolvedVersion = options.version ?? 3;
     const path = (() => {
       switch (resolvedVersion) {
@@ -21,6 +21,6 @@ export class Sdh {
           throw new Error(`version ${resolvedVersion} not available for /sdh/statut_sportif/identifiant; supported: [3]`);
       }
     })();
-    return this.client.get(path, { params: { 'recipient': options.recipient, 'identifiant': options.identifiant } });
+    return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'identifiant': options.identifiant } });
   }
 }

--- a/clients/ruby/api_entreprise/lib/api_entreprise/resources/ademe.rb
+++ b/clients/ruby/api_entreprise/lib/api_entreprise/resources/ademe.rb
@@ -13,7 +13,7 @@ module ApiEntreprise
       # Certification RGE
       # Logical endpoint: /ademe/etablissements/{siret}/certification_rge
       # Versions available: [3] — default: 3
-      def certification_rge(siret, version: nil, recipient: nil, context: nil, object: nil, limit: nil)
+      def certification_rge(siret, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil, limit: nil)
         Commons::Siret.validate!(siret, parameter: :siret)
         path =
           case version || 3
@@ -22,7 +22,7 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /ademe/etablissements/{siret}/certification_rge; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object, "limit" => limit }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object, "limit" => limit }.compact)
       end
     end
   end

--- a/clients/ruby/api_entreprise/lib/api_entreprise/resources/banque_de_france.rb
+++ b/clients/ruby/api_entreprise/lib/api_entreprise/resources/banque_de_france.rb
@@ -13,7 +13,7 @@ module ApiEntreprise
       # 3 derniers bilans annuels
       # Logical endpoint: /banque_de_france/unites_legales/{siren}/bilans
       # Versions available: [3] — default: 3
-      def bilans(siren, version: nil, recipient: nil, context: nil, object: nil)
+      def bilans(siren, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siren.validate!(siren, parameter: :siren)
         path =
           case version || 3
@@ -22,7 +22,7 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /banque_de_france/unites_legales/{siren}/bilans; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
     end
   end

--- a/clients/ruby/api_entreprise/lib/api_entreprise/resources/carif_oref.rb
+++ b/clients/ruby/api_entreprise/lib/api_entreprise/resources/carif_oref.rb
@@ -13,7 +13,7 @@ module ApiEntreprise
       # Qualiopi & habilitations France compétences
       # Logical endpoint: /carif_oref/etablissements/{siret}/certifications_qualiopi_france_competences
       # Versions available: [3] — default: 3
-      def certifications_qualiopi_france_competences(siret, version: nil, recipient: nil, context: nil, object: nil)
+      def certifications_qualiopi_france_competences(siret, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siret.validate!(siret, parameter: :siret)
         path =
           case version || 3
@@ -22,7 +22,7 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /carif_oref/etablissements/{siret}/certifications_qualiopi_france_competences; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
     end
   end

--- a/clients/ruby/api_entreprise/lib/api_entreprise/resources/cibtp.rb
+++ b/clients/ruby/api_entreprise/lib/api_entreprise/resources/cibtp.rb
@@ -13,7 +13,7 @@ module ApiEntreprise
       # Certificat cotisations CIBTP
       # Logical endpoint: /cibtp/etablissements/{siret}/attestation_cotisations_conges_payes_chomage_intemperies
       # Versions available: [3] — default: 3
-      def attestation_cotisations_conges_payes_chomage_intemperies(siret, version: nil, recipient: nil, context: nil, object: nil)
+      def attestation_cotisations_conges_payes_chomage_intemperies(siret, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siret.validate!(siret, parameter: :siret)
         path =
           case version || 3
@@ -22,7 +22,7 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /cibtp/etablissements/{siret}/attestation_cotisations_conges_payes_chomage_intemperies; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
     end
   end

--- a/clients/ruby/api_entreprise/lib/api_entreprise/resources/cma_france.rb
+++ b/clients/ruby/api_entreprise/lib/api_entreprise/resources/cma_france.rb
@@ -13,7 +13,7 @@ module ApiEntreprise
       # Données du RNM d'une entreprise artisanale
       # Logical endpoint: /cma_france/rnm/unites_legales/{siren}
       # Versions available: [3] — default: 3 (deprecated)
-      def unites_legales(siren, version: nil, recipient: nil, context: nil, object: nil)
+      def unites_legales(siren, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siren.validate!(siren, parameter: :siren)
         path =
           case version || 3
@@ -23,7 +23,7 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /cma_france/rnm/unites_legales/{siren}; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
     end
   end

--- a/clients/ruby/api_entreprise/lib/api_entreprise/resources/cnetp.rb
+++ b/clients/ruby/api_entreprise/lib/api_entreprise/resources/cnetp.rb
@@ -13,7 +13,7 @@ module ApiEntreprise
       # Certificat cotisations CNETP
       # Logical endpoint: /cnetp/unites_legales/{siren}/attestation_cotisations_conges_payes_chomage_intemperies
       # Versions available: [3] — default: 3
-      def attestation_cotisations_conges_payes_chomage_intemperies(siren, version: nil, recipient: nil, context: nil, object: nil)
+      def attestation_cotisations_conges_payes_chomage_intemperies(siren, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siren.validate!(siren, parameter: :siren)
         path =
           case version || 3
@@ -22,7 +22,7 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /cnetp/unites_legales/{siren}/attestation_cotisations_conges_payes_chomage_intemperies; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
     end
   end

--- a/clients/ruby/api_entreprise/lib/api_entreprise/resources/data_subvention.rb
+++ b/clients/ruby/api_entreprise/lib/api_entreprise/resources/data_subvention.rb
@@ -13,7 +13,7 @@ module ApiEntreprise
       # Subventions des associations
       # Logical endpoint: /data_subvention/associations/{siren_or_siret_or_rna}/subventions
       # Versions available: [3] — default: 3
-      def subventions(siren_or_siret_or_rna, version: nil, recipient: nil, context: nil, object: nil)
+      def subventions(siren_or_siret_or_rna, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         path =
           case version || 3
           when 3
@@ -21,7 +21,7 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /data_subvention/associations/{siren_or_siret_or_rna}/subventions; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
     end
   end

--- a/clients/ruby/api_entreprise/lib/api_entreprise/resources/dgfip.rb
+++ b/clients/ruby/api_entreprise/lib/api_entreprise/resources/dgfip.rb
@@ -13,7 +13,7 @@ module ApiEntreprise
       # Chiffre d'affaires
       # Logical endpoint: /dgfip/etablissements/{siret}/chiffres_affaires
       # Versions available: [3] — default: 3
-      def chiffres_affaires(siret, version: nil, recipient: nil, context: nil, object: nil)
+      def chiffres_affaires(siret, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siret.validate!(siret, parameter: :siret)
         path =
           case version || 3
@@ -22,13 +22,13 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /dgfip/etablissements/{siret}/chiffres_affaires; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
 
       # Attestation fiscale
       # Logical endpoint: /dgfip/unites_legales/{siren}/attestation_fiscale
       # Versions available: [3, 4] — default: 4
-      def attestation_fiscale(siren, version: nil, recipient: nil, context: nil, object: nil)
+      def attestation_fiscale(siren, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siren.validate!(siren, parameter: :siren)
         path =
           case version || 4
@@ -40,13 +40,13 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /dgfip/unites_legales/{siren}/attestation_fiscale; supported: [3, 4]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
 
       # Liasses fiscales
       # Logical endpoint: /dgfip/unites_legales/{siren}/liasses_fiscales/{year}
       # Versions available: [3, 4] — default: 4
-      def liasses_fiscales(siren, year, version: nil, recipient: nil, context: nil, object: nil)
+      def liasses_fiscales(siren, year, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siren.validate!(siren, parameter: :siren)
         path =
           case version || 4
@@ -58,13 +58,13 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /dgfip/unites_legales/{siren}/liasses_fiscales/{year}; supported: [3, 4]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
 
       # Liens capitalistiques
       # Logical endpoint: /dgfip/unites_legales/{siren}/liens_capitalistiques/{year}
       # Versions available: [3] — default: 3
-      def liens_capitalistiques(siren, year, version: nil, recipient: nil, context: nil, object: nil)
+      def liens_capitalistiques(siren, year, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siren.validate!(siren, parameter: :siren)
         path =
           case version || 3
@@ -73,7 +73,7 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /dgfip/unites_legales/{siren}/liens_capitalistiques/{year}; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
 
       # Numéro de TVA

--- a/clients/ruby/api_entreprise/lib/api_entreprise/resources/dgfip.rb
+++ b/clients/ruby/api_entreprise/lib/api_entreprise/resources/dgfip.rb
@@ -79,7 +79,7 @@ module ApiEntreprise
       # Numéro de TVA
       # Logical endpoint: /dgfip/unites_legales/{siren}/numero_tva
       # Versions available: [3] — default: 3
-      def numero_tva(siren, version: nil, recipient: nil, context: nil, object: nil)
+      def numero_tva(siren, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siren.validate!(siren, parameter: :siren)
         path =
           case version || 3
@@ -88,7 +88,7 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /dgfip/unites_legales/{siren}/numero_tva; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
     end
   end

--- a/clients/ruby/api_entreprise/lib/api_entreprise/resources/djepva.rb
+++ b/clients/ruby/api_entreprise/lib/api_entreprise/resources/djepva.rb
@@ -13,7 +13,7 @@ module ApiEntreprise
       # Données association en open data
       # Logical endpoint: /djepva/api-association/associations/open_data/{siren_or_rna}
       # Versions available: [4] — default: 4
-      def open_data(siren_or_rna, version: nil, recipient: nil, context: nil, object: nil)
+      def open_data(siren_or_rna, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         path =
           case version || 4
           when 4
@@ -21,13 +21,13 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /djepva/api-association/associations/open_data/{siren_or_rna}; supported: [4]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
 
       # Données association
       # Logical endpoint: /djepva/api-association/associations/{siren_or_rna}
       # Versions available: [4] — default: 4
-      def associations(siren_or_rna, version: nil, recipient: nil, context: nil, object: nil)
+      def associations(siren_or_rna, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         path =
           case version || 4
           when 4
@@ -35,7 +35,7 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /djepva/api-association/associations/{siren_or_rna}; supported: [4]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
     end
   end

--- a/clients/ruby/api_entreprise/lib/api_entreprise/resources/douanes.rb
+++ b/clients/ruby/api_entreprise/lib/api_entreprise/resources/douanes.rb
@@ -13,7 +13,7 @@ module ApiEntreprise
       # Immatriculation EORI
       # Logical endpoint: /douanes/etablissements/{siret_or_eori}/immatriculations_eori
       # Versions available: [3] — default: 3
-      def immatriculations_eori(siret_or_eori, version: nil, recipient: nil, context: nil, object: nil)
+      def immatriculations_eori(siret_or_eori, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         path =
           case version || 3
           when 3
@@ -21,7 +21,7 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /douanes/etablissements/{siret_or_eori}/immatriculations_eori; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
     end
   end

--- a/clients/ruby/api_entreprise/lib/api_entreprise/resources/european_commission.rb
+++ b/clients/ruby/api_entreprise/lib/api_entreprise/resources/european_commission.rb
@@ -13,7 +13,7 @@ module ApiEntreprise
       # N°TVA intracommunautaire français
       # Logical endpoint: /european_commission/unites_legales/{siren}/numero_tva
       # Versions available: [3] — default: 3 (deprecated)
-      def numero_tva(siren, version: nil, recipient: nil, context: nil, object: nil)
+      def numero_tva(siren, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siren.validate!(siren, parameter: :siren)
         path =
           case version || 3
@@ -23,7 +23,7 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /european_commission/unites_legales/{siren}/numero_tva; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
     end
   end

--- a/clients/ruby/api_entreprise/lib/api_entreprise/resources/fabrique_numerique_ministeres_sociaux.rb
+++ b/clients/ruby/api_entreprise/lib/api_entreprise/resources/fabrique_numerique_ministeres_sociaux.rb
@@ -13,7 +13,7 @@ module ApiEntreprise
       # Conventions collectives
       # Logical endpoint: /fabrique_numerique_ministeres_sociaux/etablissements/{siret}/conventions_collectives
       # Versions available: [3] — default: 3 (deprecated)
-      def conventions_collectives(siret, version: nil, recipient: nil, context: nil, object: nil)
+      def conventions_collectives(siret, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siret.validate!(siret, parameter: :siret)
         path =
           case version || 3
@@ -23,7 +23,7 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /fabrique_numerique_ministeres_sociaux/etablissements/{siret}/conventions_collectives; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
     end
   end

--- a/clients/ruby/api_entreprise/lib/api_entreprise/resources/fntp.rb
+++ b/clients/ruby/api_entreprise/lib/api_entreprise/resources/fntp.rb
@@ -13,7 +13,7 @@ module ApiEntreprise
       # Carte professionnelle travaux publics
       # Logical endpoint: /fntp/unites_legales/{siren}/carte_professionnelle_travaux_publics
       # Versions available: [3] — default: 3
-      def carte_professionnelle_travaux_publics(siren, version: nil, recipient: nil, context: nil, object: nil)
+      def carte_professionnelle_travaux_publics(siren, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siren.validate!(siren, parameter: :siren)
         path =
           case version || 3
@@ -22,7 +22,7 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /fntp/unites_legales/{siren}/carte_professionnelle_travaux_publics; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
     end
   end

--- a/clients/ruby/api_entreprise/lib/api_entreprise/resources/gip_mds.rb
+++ b/clients/ruby/api_entreprise/lib/api_entreprise/resources/gip_mds.rb
@@ -13,7 +13,7 @@ module ApiEntreprise
       # Effectifs mensuels d'un établissement
       # Logical endpoint: /gip_mds/etablissements/{siret}/effectifs_mensuels/{month}/annee/{year}
       # Versions available: [3] — default: 3
-      def annee(siret, year, month, version: nil, recipient: nil, context: nil, object: nil, profondeur: nil, nature_effectif: nil)
+      def annee(siret, year, month, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil, profondeur: nil, nature_effectif: nil)
         Commons::Siret.validate!(siret, parameter: :siret)
         path =
           case version || 3
@@ -22,13 +22,13 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /gip_mds/etablissements/{siret}/effectifs_mensuels/{month}/annee/{year}; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object, "profondeur" => profondeur, "nature_effectif" => nature_effectif }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object, "profondeur" => profondeur, "nature_effectif" => nature_effectif }.compact)
       end
 
       # Effectifs annuels d'une unité légale
       # Logical endpoint: /gip_mds/unites_legales/{siren}/effectifs_annuels/{year}
       # Versions available: [3] — default: 3
-      def effectifs_annuels(siren, year, version: nil, recipient: nil, context: nil, object: nil, nature_effectif: nil)
+      def effectifs_annuels(siren, year, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil, nature_effectif: nil)
         Commons::Siren.validate!(siren, parameter: :siren)
         path =
           case version || 3
@@ -37,7 +37,7 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /gip_mds/unites_legales/{siren}/effectifs_annuels/{year}; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object, "nature_effectif" => nature_effectif }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object, "nature_effectif" => nature_effectif }.compact)
       end
     end
   end

--- a/clients/ruby/api_entreprise/lib/api_entreprise/resources/infogreffe.rb
+++ b/clients/ruby/api_entreprise/lib/api_entreprise/resources/infogreffe.rb
@@ -13,7 +13,7 @@ module ApiEntreprise
       # Extrait RCS
       # Logical endpoint: /infogreffe/rcs/unites_legales/{siren}/extrait_kbis
       # Versions available: [3] — default: 3
-      def extrait_kbis(siren, version: nil, recipient: nil, context: nil, object: nil)
+      def extrait_kbis(siren, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siren.validate!(siren, parameter: :siren)
         path =
           case version || 3
@@ -22,13 +22,13 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /infogreffe/rcs/unites_legales/{siren}/extrait_kbis; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
 
       # Mandataires sociaux
       # Logical endpoint: /infogreffe/rcs/unites_legales/{siren}/mandataires_sociaux
       # Versions available: [3] — default: 3
-      def mandataires_sociaux(siren, version: nil, recipient: nil, context: nil, object: nil)
+      def mandataires_sociaux(siren, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siren.validate!(siren, parameter: :siren)
         path =
           case version || 3
@@ -37,7 +37,7 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /infogreffe/rcs/unites_legales/{siren}/mandataires_sociaux; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
     end
   end

--- a/clients/ruby/api_entreprise/lib/api_entreprise/resources/inpi.rb
+++ b/clients/ruby/api_entreprise/lib/api_entreprise/resources/inpi.rb
@@ -13,7 +13,7 @@ module ApiEntreprise
       # Actes et bilans
       # Logical endpoint: /inpi/rne/unites_legales/open_data/{siren}/actes_bilans
       # Versions available: [3] — default: 3
-      def actes_bilans(siren, version: nil, recipient: nil, context: nil, object: nil)
+      def actes_bilans(siren, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siren.validate!(siren, parameter: :siren)
         path =
           case version || 3
@@ -22,13 +22,13 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /inpi/rne/unites_legales/open_data/{siren}/actes_bilans; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
 
       # Bénéficiaires effectifs
       # Logical endpoint: /inpi/rne/unites_legales/{siren}/beneficiaires_effectifs
       # Versions available: [3] — default: 3
-      def beneficiaires_effectifs(siren, version: nil, recipient: nil, context: nil, object: nil)
+      def beneficiaires_effectifs(siren, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siren.validate!(siren, parameter: :siren)
         path =
           case version || 3
@@ -37,13 +37,13 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /inpi/rne/unites_legales/{siren}/beneficiaires_effectifs; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
 
       # Attestation d'immatriculation RNE
       # Logical endpoint: /inpi/rne/unites_legales/{siren}/extrait_rne
       # Versions available: [3] — default: 3
-      def extrait_rne(siren, version: nil, recipient: nil, context: nil, object: nil)
+      def extrait_rne(siren, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siren.validate!(siren, parameter: :siren)
         path =
           case version || 3
@@ -52,7 +52,7 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /inpi/rne/unites_legales/{siren}/extrait_rne; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
     end
   end

--- a/clients/ruby/api_entreprise/lib/api_entreprise/resources/insee.rb
+++ b/clients/ruby/api_entreprise/lib/api_entreprise/resources/insee.rb
@@ -13,7 +13,7 @@ module ApiEntreprise
       # Données établissement en open data
       # Logical endpoint: /insee/sirene/etablissements/diffusibles/{siret}
       # Versions available: [3, 4] — default: 4
-      def diffusibles(siret, version: nil, recipient: nil, context: nil, object: nil)
+      def diffusibles(siret, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siret.validate!(siret, parameter: :siret)
         path =
           case version || 4
@@ -25,13 +25,13 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /insee/sirene/etablissements/diffusibles/{siret}; supported: [3, 4]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
 
       # Adresse établissement en open data
       # Logical endpoint: /insee/sirene/etablissements/diffusibles/{siret}/adresse
       # Versions available: [3] — default: 3
-      def adresse(siret, version: nil, recipient: nil, context: nil, object: nil)
+      def adresse(siret, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siret.validate!(siret, parameter: :siret)
         path =
           case version || 3
@@ -40,13 +40,13 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /insee/sirene/etablissements/diffusibles/{siret}/adresse; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
 
       # Données établissement
       # Logical endpoint: /insee/sirene/etablissements/{siret}
       # Versions available: [3, 4] — default: 4
-      def etablissements(siret, version: nil, recipient: nil, context: nil, object: nil)
+      def etablissements(siret, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siret.validate!(siret, parameter: :siret)
         path =
           case version || 4
@@ -58,13 +58,13 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /insee/sirene/etablissements/{siret}; supported: [3, 4]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
 
       # Adresse établissement
       # Logical endpoint: /insee/sirene/etablissements/{siret}/adresse
       # Versions available: [3] — default: 3
-      def sirene_etablissements_adresse(siret, version: nil, recipient: nil, context: nil, object: nil)
+      def sirene_etablissements_adresse(siret, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siret.validate!(siret, parameter: :siret)
         path =
           case version || 3
@@ -73,13 +73,13 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /insee/sirene/etablissements/{siret}/adresse; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
 
       # Liens de succession
       # Logical endpoint: /insee/sirene/etablissements/{siret}/successions
       # Versions available: [3] — default: 3
-      def successions(siret, version: nil, recipient: nil, context: nil, object: nil)
+      def successions(siret, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siret.validate!(siret, parameter: :siret)
         path =
           case version || 3
@@ -88,13 +88,13 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /insee/sirene/etablissements/{siret}/successions; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
 
       # Données unité légale en open data
       # Logical endpoint: /insee/sirene/unites_legales/diffusibles/{siren}
       # Versions available: [3, 4] — default: 4
-      def sirene_unites_legales_diffusibles(siren, version: nil, recipient: nil, context: nil, object: nil)
+      def sirene_unites_legales_diffusibles(siren, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siren.validate!(siren, parameter: :siren)
         path =
           case version || 4
@@ -106,13 +106,13 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /insee/sirene/unites_legales/diffusibles/{siren}; supported: [3, 4]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
 
       # Données siège social en open data
       # Logical endpoint: /insee/sirene/unites_legales/diffusibles/{siren}/siege_social
       # Versions available: [3, 4] — default: 4
-      def siege_social(siren, version: nil, recipient: nil, context: nil, object: nil)
+      def siege_social(siren, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siren.validate!(siren, parameter: :siren)
         path =
           case version || 4
@@ -124,13 +124,13 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /insee/sirene/unites_legales/diffusibles/{siren}/siege_social; supported: [3, 4]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
 
       # Données unité légale
       # Logical endpoint: /insee/sirene/unites_legales/{siren}
       # Versions available: [3, 4] — default: 4
-      def unites_legales(siren, version: nil, recipient: nil, context: nil, object: nil)
+      def unites_legales(siren, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siren.validate!(siren, parameter: :siren)
         path =
           case version || 4
@@ -142,13 +142,13 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /insee/sirene/unites_legales/{siren}; supported: [3, 4]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
 
       # Données siège social
       # Logical endpoint: /insee/sirene/unites_legales/{siren}/siege_social
       # Versions available: [3, 4] — default: 4
-      def sirene_unites_legales_siege_social(siren, version: nil, recipient: nil, context: nil, object: nil)
+      def sirene_unites_legales_siege_social(siren, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siren.validate!(siren, parameter: :siren)
         path =
           case version || 4
@@ -160,7 +160,7 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /insee/sirene/unites_legales/{siren}/siege_social; supported: [3, 4]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
     end
   end

--- a/clients/ruby/api_entreprise/lib/api_entreprise/resources/ministere_interieur.rb
+++ b/clients/ruby/api_entreprise/lib/api_entreprise/resources/ministere_interieur.rb
@@ -13,7 +13,7 @@ module ApiEntreprise
       # Données du RNA d'une association
       # Logical endpoint: /ministere_interieur/rna/associations/{siret_or_rna}
       # Versions available: [3] — default: 3 (deprecated)
-      def associations(siret_or_rna, version: nil, recipient: nil, context: nil, object: nil)
+      def associations(siret_or_rna, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         path =
           case version || 3
           when 3
@@ -22,13 +22,13 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /ministere_interieur/rna/associations/{siret_or_rna}; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
 
       # Divers documents d'une association
       # Logical endpoint: /ministere_interieur/rna/associations/{siret_or_rna}/documents
       # Versions available: [3] — default: 3 (deprecated)
-      def documents(siret_or_rna, version: nil, recipient: nil, context: nil, object: nil)
+      def documents(siret_or_rna, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         path =
           case version || 3
           when 3
@@ -37,7 +37,7 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /ministere_interieur/rna/associations/{siret_or_rna}/documents; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
     end
   end

--- a/clients/ruby/api_entreprise/lib/api_entreprise/resources/msa.rb
+++ b/clients/ruby/api_entreprise/lib/api_entreprise/resources/msa.rb
@@ -13,7 +13,7 @@ module ApiEntreprise
       # Conformité cotisations de sécurité sociale agricole
       # Logical endpoint: /msa/etablissements/{siret}/conformite_cotisations
       # Versions available: [3] — default: 3
-      def conformite_cotisations(siret, version: nil, recipient: nil, context: nil, object: nil)
+      def conformite_cotisations(siret, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siret.validate!(siret, parameter: :siret)
         path =
           case version || 3
@@ -22,7 +22,7 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /msa/etablissements/{siret}/conformite_cotisations; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
     end
   end

--- a/clients/ruby/api_entreprise/lib/api_entreprise/resources/opqibi.rb
+++ b/clients/ruby/api_entreprise/lib/api_entreprise/resources/opqibi.rb
@@ -13,7 +13,7 @@ module ApiEntreprise
       # Certification d'ingénierie OPQIBI
       # Logical endpoint: /opqibi/unites_legales/{siren}/certification_ingenierie
       # Versions available: [3] — default: 3
-      def certification_ingenierie(siren, version: nil, recipient: nil, context: nil, object: nil)
+      def certification_ingenierie(siren, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siren.validate!(siren, parameter: :siren)
         path =
           case version || 3
@@ -22,7 +22,7 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /opqibi/unites_legales/{siren}/certification_ingenierie; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
     end
   end

--- a/clients/ruby/api_entreprise/lib/api_entreprise/resources/probtp.rb
+++ b/clients/ruby/api_entreprise/lib/api_entreprise/resources/probtp.rb
@@ -13,7 +13,7 @@ module ApiEntreprise
       # Conformité cotisations retraite bâtiment
       # Logical endpoint: /probtp/etablissements/{siret}/attestation_cotisations_retraite
       # Versions available: [3] — default: 3
-      def attestation_cotisations_retraite(siret, version: nil, recipient: nil, context: nil, object: nil)
+      def attestation_cotisations_retraite(siret, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siret.validate!(siret, parameter: :siret)
         path =
           case version || 3
@@ -22,13 +22,13 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /probtp/etablissements/{siret}/attestation_cotisations_retraite; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
 
       # Conformité cotisations retraite complémentaire
       # Logical endpoint: /probtp/etablissements/{siret}/conformite_cotisations_retraite
       # Versions available: [3] — default: 3
-      def conformite_cotisations_retraite(siret, version: nil, recipient: nil, context: nil, object: nil)
+      def conformite_cotisations_retraite(siret, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siret.validate!(siret, parameter: :siret)
         path =
           case version || 3
@@ -37,7 +37,7 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /probtp/etablissements/{siret}/conformite_cotisations_retraite; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
     end
   end

--- a/clients/ruby/api_entreprise/lib/api_entreprise/resources/qualibat.rb
+++ b/clients/ruby/api_entreprise/lib/api_entreprise/resources/qualibat.rb
@@ -13,7 +13,7 @@ module ApiEntreprise
       # Certification Qualibat
       # Logical endpoint: /qualibat/etablissements/{siret}/certification_batiment
       # Versions available: [3, 4] — default: 4
-      def certification_batiment(siret, version: nil, recipient: nil, context: nil, object: nil)
+      def certification_batiment(siret, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siret.validate!(siret, parameter: :siret)
         path =
           case version || 4
@@ -25,7 +25,7 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /qualibat/etablissements/{siret}/certification_batiment; supported: [3, 4]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
     end
   end

--- a/clients/ruby/api_entreprise/lib/api_entreprise/resources/qualifelec.rb
+++ b/clients/ruby/api_entreprise/lib/api_entreprise/resources/qualifelec.rb
@@ -13,7 +13,7 @@ module ApiEntreprise
       # Certification Qualifelec
       # Logical endpoint: /qualifelec/etablissements/{siret}/certificats
       # Versions available: [3] — default: 3
-      def certificats(siret, version: nil, recipient: nil, context: nil, object: nil)
+      def certificats(siret, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siret.validate!(siret, parameter: :siret)
         path =
           case version || 3
@@ -22,7 +22,7 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /qualifelec/etablissements/{siret}/certificats; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
     end
   end

--- a/clients/ruby/api_entreprise/lib/api_entreprise/resources/urssaf.rb
+++ b/clients/ruby/api_entreprise/lib/api_entreprise/resources/urssaf.rb
@@ -13,7 +13,7 @@ module ApiEntreprise
       # Attestation de vigilance
       # Logical endpoint: /urssaf/unites_legales/{siren}/attestation_vigilance
       # Versions available: [3, 4] — default: 4
-      def attestation_vigilance(siren, version: nil, recipient: nil, context: nil, object: nil)
+      def attestation_vigilance(siren, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)
         Commons::Siren.validate!(siren, parameter: :siren)
         path =
           case version || 4
@@ -25,7 +25,7 @@ module ApiEntreprise
           else
             raise ArgumentError, "version #{version.inspect} not available for /urssaf/unites_legales/{siren}/attestation_vigilance; supported: [3, 4]"
           end
-        @client.get(path, params: { "recipient" => recipient, "context" => context, "object" => object }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
     end
   end

--- a/clients/ruby/api_particulier/lib/api_particulier/resources/ants.rb
+++ b/clients/ruby/api_particulier/lib/api_particulier/resources/ants.rb
@@ -13,7 +13,7 @@ module ApiParticulier
       # [FranceConnect] Extrait d'immatriculation véhicule
       # Logical endpoint: /ants/extrait_immatriculation_vehicule/france_connect
       # Versions available: [3] — default: 3
-      def extrait_immatriculation_vehicule(version: nil, recipient: nil, immatriculation:)
+      def extrait_immatriculation_vehicule(version: nil, recipient: nil, delegation_id: nil, immatriculation:)
         path =
           case version || 3
           when 3
@@ -21,7 +21,7 @@ module ApiParticulier
           else
             raise ArgumentError, "version #{version.inspect} not available for /ants/extrait_immatriculation_vehicule/france_connect; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "immatriculation" => immatriculation }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "immatriculation" => immatriculation }.compact)
       end
     end
   end

--- a/clients/ruby/api_particulier/lib/api_particulier/resources/cnous.rb
+++ b/clients/ruby/api_particulier/lib/api_particulier/resources/cnous.rb
@@ -13,7 +13,7 @@ module ApiParticulier
       # [FranceConnect] Statut étudiant boursier
       # Logical endpoint: /cnous/etudiant_boursier/france_connect
       # Versions available: [3, 4] — default: 4
-      def etudiant_boursier(version: nil, recipient: nil, campaign_year: nil)
+      def etudiant_boursier(version: nil, recipient: nil, delegation_id: nil, campaign_year: nil)
         path =
           case version || 4
           when 3
@@ -24,13 +24,13 @@ module ApiParticulier
           else
             raise ArgumentError, "version #{version.inspect} not available for /cnous/etudiant_boursier/france_connect; supported: [3, 4]"
           end
-        @client.get(path, params: { "recipient" => recipient, "campaignYear" => campaign_year }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "campaignYear" => campaign_year }.compact)
       end
 
       # [Identité] Statut étudiant boursier
       # Logical endpoint: /cnous/etudiant_boursier/identite
       # Versions available: [3, 4] — default: 4
-      def etudiant_boursier_identite(version: nil, recipient: nil, nom_naissance:, prenoms:, annee_date_naissance:, mois_date_naissance:, jour_date_naissance:, sexe_etat_civil: nil, code_cog_insee_commune_naissance: nil, nom_commune_naissance: nil, code_cog_insee_departement_naissance: nil, campaign_year: nil)
+      def etudiant_boursier_identite(version: nil, recipient: nil, delegation_id: nil, nom_naissance:, prenoms:, annee_date_naissance:, mois_date_naissance:, jour_date_naissance:, sexe_etat_civil: nil, code_cog_insee_commune_naissance: nil, nom_commune_naissance: nil, code_cog_insee_departement_naissance: nil, campaign_year: nil)
         path =
           case version || 4
           when 3
@@ -41,13 +41,13 @@ module ApiParticulier
           else
             raise ArgumentError, "version #{version.inspect} not available for /cnous/etudiant_boursier/identite; supported: [3, 4]"
           end
-        @client.get(path, params: { "recipient" => recipient, "nomNaissance" => nom_naissance, "prenoms" => prenoms, "anneeDateNaissance" => annee_date_naissance, "moisDateNaissance" => mois_date_naissance, "jourDateNaissance" => jour_date_naissance, "sexeEtatCivil" => sexe_etat_civil, "codeCogInseeCommuneNaissance" => code_cog_insee_commune_naissance, "nomCommuneNaissance" => nom_commune_naissance, "codeCogInseeDepartementNaissance" => code_cog_insee_departement_naissance, "campaignYear" => campaign_year }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "nomNaissance" => nom_naissance, "prenoms" => prenoms, "anneeDateNaissance" => annee_date_naissance, "moisDateNaissance" => mois_date_naissance, "jourDateNaissance" => jour_date_naissance, "sexeEtatCivil" => sexe_etat_civil, "codeCogInseeCommuneNaissance" => code_cog_insee_commune_naissance, "nomCommuneNaissance" => nom_commune_naissance, "codeCogInseeDepartementNaissance" => code_cog_insee_departement_naissance, "campaignYear" => campaign_year }.compact)
       end
 
       # [INE] Statut étudiant boursier
       # Logical endpoint: /cnous/etudiant_boursier/ine
       # Versions available: [3, 4] — default: 4
-      def ine(version: nil, recipient: nil, ine:, campaign_year: nil)
+      def ine(version: nil, recipient: nil, delegation_id: nil, ine:, campaign_year: nil)
         path =
           case version || 4
           when 3
@@ -58,7 +58,7 @@ module ApiParticulier
           else
             raise ArgumentError, "version #{version.inspect} not available for /cnous/etudiant_boursier/ine; supported: [3, 4]"
           end
-        @client.get(path, params: { "recipient" => recipient, "ine" => ine, "campaignYear" => campaign_year }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "ine" => ine, "campaignYear" => campaign_year }.compact)
       end
     end
   end

--- a/clients/ruby/api_particulier/lib/api_particulier/resources/dsnj.rb
+++ b/clients/ruby/api_particulier/lib/api_particulier/resources/dsnj.rb
@@ -13,7 +13,7 @@ module ApiParticulier
       # [FranceConnect] API Service national
       # Logical endpoint: /dsnj/service_national/france_connect
       # Versions available: [3] — default: 3
-      def service_national(version: nil, recipient: nil)
+      def service_national(version: nil, recipient: nil, delegation_id: nil)
         path =
           case version || 3
           when 3
@@ -21,13 +21,13 @@ module ApiParticulier
           else
             raise ArgumentError, "version #{version.inspect} not available for /dsnj/service_national/france_connect; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id }.compact)
       end
 
       # [Identité] API Service national
       # Logical endpoint: /dsnj/service_national/identite
       # Versions available: [3] — default: 3
-      def service_national_identite(version: nil, recipient: nil, nom_naissance:, prenoms:, annee_date_naissance:, mois_date_naissance:, jour_date_naissance:, sexe_etat_civil:, code_cog_insee_commune_naissance: nil, code_cog_insee_pays_naissance:)
+      def service_national_identite(version: nil, recipient: nil, delegation_id: nil, nom_naissance:, prenoms:, annee_date_naissance:, mois_date_naissance:, jour_date_naissance:, sexe_etat_civil:, code_cog_insee_commune_naissance: nil, code_cog_insee_pays_naissance:)
         path =
           case version || 3
           when 3
@@ -35,7 +35,7 @@ module ApiParticulier
           else
             raise ArgumentError, "version #{version.inspect} not available for /dsnj/service_national/identite; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "nomNaissance" => nom_naissance, "prenoms" => prenoms, "anneeDateNaissance" => annee_date_naissance, "moisDateNaissance" => mois_date_naissance, "jourDateNaissance" => jour_date_naissance, "sexeEtatCivil" => sexe_etat_civil, "codeCogInseeCommuneNaissance" => code_cog_insee_commune_naissance, "codeCogInseePaysNaissance" => code_cog_insee_pays_naissance }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "nomNaissance" => nom_naissance, "prenoms" => prenoms, "anneeDateNaissance" => annee_date_naissance, "moisDateNaissance" => mois_date_naissance, "jourDateNaissance" => jour_date_naissance, "sexeEtatCivil" => sexe_etat_civil, "codeCogInseeCommuneNaissance" => code_cog_insee_commune_naissance, "codeCogInseePaysNaissance" => code_cog_insee_pays_naissance }.compact)
       end
     end
   end

--- a/clients/ruby/api_particulier/lib/api_particulier/resources/dss.rb
+++ b/clients/ruby/api_particulier/lib/api_particulier/resources/dss.rb
@@ -13,7 +13,7 @@ module ApiParticulier
       # [FranceConnect] Statut allocation adulte handicapé (AAH)
       # Logical endpoint: /dss/allocation_adulte_handicape/france_connect
       # Versions available: [3] — default: 3
-      def allocation_adulte_handicape(version: nil, recipient: nil)
+      def allocation_adulte_handicape(version: nil, recipient: nil, delegation_id: nil)
         path =
           case version || 3
           when 3
@@ -21,13 +21,13 @@ module ApiParticulier
           else
             raise ArgumentError, "version #{version.inspect} not available for /dss/allocation_adulte_handicape/france_connect; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id }.compact)
       end
 
       # [Identité] Statut allocation adulte handicapé (AAH)
       # Logical endpoint: /dss/allocation_adulte_handicape/identite
       # Versions available: [3] — default: 3
-      def allocation_adulte_handicape_identite(version: nil, recipient: nil, nom_naissance:, nom_usage: nil, prenoms:, annee_date_naissance: nil, mois_date_naissance: nil, jour_date_naissance: nil, sexe_etat_civil: nil, code_cog_insee_pays_naissance:, code_cog_insee_commune_naissance: nil, nom_commune_naissance: nil, code_cog_insee_departement_naissance: nil)
+      def allocation_adulte_handicape_identite(version: nil, recipient: nil, delegation_id: nil, nom_naissance:, nom_usage: nil, prenoms:, annee_date_naissance: nil, mois_date_naissance: nil, jour_date_naissance: nil, sexe_etat_civil: nil, code_cog_insee_pays_naissance:, code_cog_insee_commune_naissance: nil, nom_commune_naissance: nil, code_cog_insee_departement_naissance: nil)
         path =
           case version || 3
           when 3
@@ -35,13 +35,13 @@ module ApiParticulier
           else
             raise ArgumentError, "version #{version.inspect} not available for /dss/allocation_adulte_handicape/identite; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "nomNaissance" => nom_naissance, "nomUsage" => nom_usage, "prenoms" => prenoms, "anneeDateNaissance" => annee_date_naissance, "moisDateNaissance" => mois_date_naissance, "jourDateNaissance" => jour_date_naissance, "sexeEtatCivil" => sexe_etat_civil, "codeCogInseePaysNaissance" => code_cog_insee_pays_naissance, "codeCogInseeCommuneNaissance" => code_cog_insee_commune_naissance, "nomCommuneNaissance" => nom_commune_naissance, "codeCogInseeDepartementNaissance" => code_cog_insee_departement_naissance }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "nomNaissance" => nom_naissance, "nomUsage" => nom_usage, "prenoms" => prenoms, "anneeDateNaissance" => annee_date_naissance, "moisDateNaissance" => mois_date_naissance, "jourDateNaissance" => jour_date_naissance, "sexeEtatCivil" => sexe_etat_civil, "codeCogInseePaysNaissance" => code_cog_insee_pays_naissance, "codeCogInseeCommuneNaissance" => code_cog_insee_commune_naissance, "nomCommuneNaissance" => nom_commune_naissance, "codeCogInseeDepartementNaissance" => code_cog_insee_departement_naissance }.compact)
       end
 
       # [FranceConnect] Statut allocation d'éducation de l'enfant handicapé (AEEH)
       # Logical endpoint: /dss/allocation_enfant_handicape/france_connect
       # Versions available: [3] — default: 3
-      def allocation_enfant_handicape(version: nil, recipient: nil)
+      def allocation_enfant_handicape(version: nil, recipient: nil, delegation_id: nil)
         path =
           case version || 3
           when 3
@@ -49,13 +49,13 @@ module ApiParticulier
           else
             raise ArgumentError, "version #{version.inspect} not available for /dss/allocation_enfant_handicape/france_connect; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id }.compact)
       end
 
       # [Identité] Statut allocation d'éducation de l'enfant handicapé (AEEH)
       # Logical endpoint: /dss/allocation_enfant_handicape/identite
       # Versions available: [3] — default: 3
-      def allocation_enfant_handicape_identite(version: nil, recipient: nil, nom_naissance:, nom_usage: nil, prenoms:, annee_date_naissance: nil, mois_date_naissance: nil, jour_date_naissance: nil, sexe_etat_civil: nil, code_cog_insee_pays_naissance:, code_cog_insee_commune_naissance: nil, nom_commune_naissance: nil, code_cog_insee_departement_naissance: nil)
+      def allocation_enfant_handicape_identite(version: nil, recipient: nil, delegation_id: nil, nom_naissance:, nom_usage: nil, prenoms:, annee_date_naissance: nil, mois_date_naissance: nil, jour_date_naissance: nil, sexe_etat_civil: nil, code_cog_insee_pays_naissance:, code_cog_insee_commune_naissance: nil, nom_commune_naissance: nil, code_cog_insee_departement_naissance: nil)
         path =
           case version || 3
           when 3
@@ -63,13 +63,13 @@ module ApiParticulier
           else
             raise ArgumentError, "version #{version.inspect} not available for /dss/allocation_enfant_handicape/identite; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "nomNaissance" => nom_naissance, "nomUsage" => nom_usage, "prenoms" => prenoms, "anneeDateNaissance" => annee_date_naissance, "moisDateNaissance" => mois_date_naissance, "jourDateNaissance" => jour_date_naissance, "sexeEtatCivil" => sexe_etat_civil, "codeCogInseePaysNaissance" => code_cog_insee_pays_naissance, "codeCogInseeCommuneNaissance" => code_cog_insee_commune_naissance, "nomCommuneNaissance" => nom_commune_naissance, "codeCogInseeDepartementNaissance" => code_cog_insee_departement_naissance }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "nomNaissance" => nom_naissance, "nomUsage" => nom_usage, "prenoms" => prenoms, "anneeDateNaissance" => annee_date_naissance, "moisDateNaissance" => mois_date_naissance, "jourDateNaissance" => jour_date_naissance, "sexeEtatCivil" => sexe_etat_civil, "codeCogInseePaysNaissance" => code_cog_insee_pays_naissance, "codeCogInseeCommuneNaissance" => code_cog_insee_commune_naissance, "nomCommuneNaissance" => nom_commune_naissance, "codeCogInseeDepartementNaissance" => code_cog_insee_departement_naissance }.compact)
       end
 
       # [FranceConnect] Statut allocation de soutien familial (ASF)
       # Logical endpoint: /dss/allocation_soutien_familial/france_connect
       # Versions available: [3] — default: 3
-      def allocation_soutien_familial(version: nil, recipient: nil)
+      def allocation_soutien_familial(version: nil, recipient: nil, delegation_id: nil)
         path =
           case version || 3
           when 3
@@ -77,13 +77,13 @@ module ApiParticulier
           else
             raise ArgumentError, "version #{version.inspect} not available for /dss/allocation_soutien_familial/france_connect; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id }.compact)
       end
 
       # [Identité] Statut allocation de soutien familial (ASF)
       # Logical endpoint: /dss/allocation_soutien_familial/identite
       # Versions available: [3] — default: 3
-      def allocation_soutien_familial_identite(version: nil, recipient: nil, nom_naissance:, nom_usage: nil, prenoms:, annee_date_naissance: nil, mois_date_naissance: nil, jour_date_naissance: nil, sexe_etat_civil: nil, code_cog_insee_pays_naissance:, code_cog_insee_commune_naissance: nil, nom_commune_naissance: nil, code_cog_insee_departement_naissance: nil)
+      def allocation_soutien_familial_identite(version: nil, recipient: nil, delegation_id: nil, nom_naissance:, nom_usage: nil, prenoms:, annee_date_naissance: nil, mois_date_naissance: nil, jour_date_naissance: nil, sexe_etat_civil: nil, code_cog_insee_pays_naissance:, code_cog_insee_commune_naissance: nil, nom_commune_naissance: nil, code_cog_insee_departement_naissance: nil)
         path =
           case version || 3
           when 3
@@ -91,13 +91,13 @@ module ApiParticulier
           else
             raise ArgumentError, "version #{version.inspect} not available for /dss/allocation_soutien_familial/identite; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "nomNaissance" => nom_naissance, "nomUsage" => nom_usage, "prenoms" => prenoms, "anneeDateNaissance" => annee_date_naissance, "moisDateNaissance" => mois_date_naissance, "jourDateNaissance" => jour_date_naissance, "sexeEtatCivil" => sexe_etat_civil, "codeCogInseePaysNaissance" => code_cog_insee_pays_naissance, "codeCogInseeCommuneNaissance" => code_cog_insee_commune_naissance, "nomCommuneNaissance" => nom_commune_naissance, "codeCogInseeDepartementNaissance" => code_cog_insee_departement_naissance }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "nomNaissance" => nom_naissance, "nomUsage" => nom_usage, "prenoms" => prenoms, "anneeDateNaissance" => annee_date_naissance, "moisDateNaissance" => mois_date_naissance, "jourDateNaissance" => jour_date_naissance, "sexeEtatCivil" => sexe_etat_civil, "codeCogInseePaysNaissance" => code_cog_insee_pays_naissance, "codeCogInseeCommuneNaissance" => code_cog_insee_commune_naissance, "nomCommuneNaissance" => nom_commune_naissance, "codeCogInseeDepartementNaissance" => code_cog_insee_departement_naissance }.compact)
       end
 
       # [FranceConnect] Statut complémentaire santé solidaire (C2S)
       # Logical endpoint: /dss/complementaire_sante_solidaire/france_connect
       # Versions available: [3] — default: 3
-      def complementaire_sante_solidaire(version: nil, recipient: nil)
+      def complementaire_sante_solidaire(version: nil, recipient: nil, delegation_id: nil)
         path =
           case version || 3
           when 3
@@ -105,13 +105,13 @@ module ApiParticulier
           else
             raise ArgumentError, "version #{version.inspect} not available for /dss/complementaire_sante_solidaire/france_connect; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id }.compact)
       end
 
       # [Identité] Statut complémentaire santé solidaire (C2S)
       # Logical endpoint: /dss/complementaire_sante_solidaire/identite
       # Versions available: [3] — default: 3
-      def complementaire_sante_solidaire_identite(version: nil, recipient: nil, nom_naissance:, nom_usage: nil, prenoms:, annee_date_naissance: nil, mois_date_naissance: nil, jour_date_naissance: nil, sexe_etat_civil: nil, code_cog_insee_pays_naissance:, code_cog_insee_commune_naissance: nil, nom_commune_naissance: nil, code_cog_insee_departement_naissance: nil)
+      def complementaire_sante_solidaire_identite(version: nil, recipient: nil, delegation_id: nil, nom_naissance:, nom_usage: nil, prenoms:, annee_date_naissance: nil, mois_date_naissance: nil, jour_date_naissance: nil, sexe_etat_civil: nil, code_cog_insee_pays_naissance:, code_cog_insee_commune_naissance: nil, nom_commune_naissance: nil, code_cog_insee_departement_naissance: nil)
         path =
           case version || 3
           when 3
@@ -119,13 +119,13 @@ module ApiParticulier
           else
             raise ArgumentError, "version #{version.inspect} not available for /dss/complementaire_sante_solidaire/identite; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "nomNaissance" => nom_naissance, "nomUsage" => nom_usage, "prenoms" => prenoms, "anneeDateNaissance" => annee_date_naissance, "moisDateNaissance" => mois_date_naissance, "jourDateNaissance" => jour_date_naissance, "sexeEtatCivil" => sexe_etat_civil, "codeCogInseePaysNaissance" => code_cog_insee_pays_naissance, "codeCogInseeCommuneNaissance" => code_cog_insee_commune_naissance, "nomCommuneNaissance" => nom_commune_naissance, "codeCogInseeDepartementNaissance" => code_cog_insee_departement_naissance }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "nomNaissance" => nom_naissance, "nomUsage" => nom_usage, "prenoms" => prenoms, "anneeDateNaissance" => annee_date_naissance, "moisDateNaissance" => mois_date_naissance, "jourDateNaissance" => jour_date_naissance, "sexeEtatCivil" => sexe_etat_civil, "codeCogInseePaysNaissance" => code_cog_insee_pays_naissance, "codeCogInseeCommuneNaissance" => code_cog_insee_commune_naissance, "nomCommuneNaissance" => nom_commune_naissance, "codeCogInseeDepartementNaissance" => code_cog_insee_departement_naissance }.compact)
       end
 
       # [FranceConnect] Participation familiale EAJE
       # Logical endpoint: /dss/participation_familiale_eaje/france_connect
       # Versions available: [3] — default: 3
-      def participation_familiale_eaje(version: nil, recipient: nil)
+      def participation_familiale_eaje(version: nil, recipient: nil, delegation_id: nil)
         path =
           case version || 3
           when 3
@@ -133,13 +133,13 @@ module ApiParticulier
           else
             raise ArgumentError, "version #{version.inspect} not available for /dss/participation_familiale_eaje/france_connect; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id }.compact)
       end
 
       # [Identité] Participation familiale EAJE
       # Logical endpoint: /dss/participation_familiale_eaje/identite
       # Versions available: [3] — default: 3
-      def participation_familiale_eaje_identite(version: nil, recipient: nil, nom_naissance:, nom_usage: nil, prenoms:, annee_date_naissance: nil, mois_date_naissance: nil, jour_date_naissance: nil, sexe_etat_civil: nil, code_cog_insee_pays_naissance:, code_cog_insee_commune_naissance: nil, nom_commune_naissance: nil, code_cog_insee_departement_naissance: nil)
+      def participation_familiale_eaje_identite(version: nil, recipient: nil, delegation_id: nil, nom_naissance:, nom_usage: nil, prenoms:, annee_date_naissance: nil, mois_date_naissance: nil, jour_date_naissance: nil, sexe_etat_civil: nil, code_cog_insee_pays_naissance:, code_cog_insee_commune_naissance: nil, nom_commune_naissance: nil, code_cog_insee_departement_naissance: nil)
         path =
           case version || 3
           when 3
@@ -147,13 +147,13 @@ module ApiParticulier
           else
             raise ArgumentError, "version #{version.inspect} not available for /dss/participation_familiale_eaje/identite; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "nomNaissance" => nom_naissance, "nomUsage" => nom_usage, "prenoms" => prenoms, "anneeDateNaissance" => annee_date_naissance, "moisDateNaissance" => mois_date_naissance, "jourDateNaissance" => jour_date_naissance, "sexeEtatCivil" => sexe_etat_civil, "codeCogInseePaysNaissance" => code_cog_insee_pays_naissance, "codeCogInseeCommuneNaissance" => code_cog_insee_commune_naissance, "nomCommuneNaissance" => nom_commune_naissance, "codeCogInseeDepartementNaissance" => code_cog_insee_departement_naissance }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "nomNaissance" => nom_naissance, "nomUsage" => nom_usage, "prenoms" => prenoms, "anneeDateNaissance" => annee_date_naissance, "moisDateNaissance" => mois_date_naissance, "jourDateNaissance" => jour_date_naissance, "sexeEtatCivil" => sexe_etat_civil, "codeCogInseePaysNaissance" => code_cog_insee_pays_naissance, "codeCogInseeCommuneNaissance" => code_cog_insee_commune_naissance, "nomCommuneNaissance" => nom_commune_naissance, "codeCogInseeDepartementNaissance" => code_cog_insee_departement_naissance }.compact)
       end
 
       # [FranceConnect] Statut prime d'activité
       # Logical endpoint: /dss/prime_activite/france_connect
       # Versions available: [3] — default: 3
-      def prime_activite(version: nil, recipient: nil)
+      def prime_activite(version: nil, recipient: nil, delegation_id: nil)
         path =
           case version || 3
           when 3
@@ -161,13 +161,13 @@ module ApiParticulier
           else
             raise ArgumentError, "version #{version.inspect} not available for /dss/prime_activite/france_connect; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id }.compact)
       end
 
       # [Identité] Statut prime d'activité
       # Logical endpoint: /dss/prime_activite/identite
       # Versions available: [3] — default: 3
-      def prime_activite_identite(version: nil, recipient: nil, nom_naissance:, nom_usage: nil, prenoms:, annee_date_naissance: nil, mois_date_naissance: nil, jour_date_naissance: nil, sexe_etat_civil: nil, code_cog_insee_pays_naissance:, code_cog_insee_commune_naissance: nil, nom_commune_naissance: nil, code_cog_insee_departement_naissance: nil)
+      def prime_activite_identite(version: nil, recipient: nil, delegation_id: nil, nom_naissance:, nom_usage: nil, prenoms:, annee_date_naissance: nil, mois_date_naissance: nil, jour_date_naissance: nil, sexe_etat_civil: nil, code_cog_insee_pays_naissance:, code_cog_insee_commune_naissance: nil, nom_commune_naissance: nil, code_cog_insee_departement_naissance: nil)
         path =
           case version || 3
           when 3
@@ -175,13 +175,13 @@ module ApiParticulier
           else
             raise ArgumentError, "version #{version.inspect} not available for /dss/prime_activite/identite; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "nomNaissance" => nom_naissance, "nomUsage" => nom_usage, "prenoms" => prenoms, "anneeDateNaissance" => annee_date_naissance, "moisDateNaissance" => mois_date_naissance, "jourDateNaissance" => jour_date_naissance, "sexeEtatCivil" => sexe_etat_civil, "codeCogInseePaysNaissance" => code_cog_insee_pays_naissance, "codeCogInseeCommuneNaissance" => code_cog_insee_commune_naissance, "nomCommuneNaissance" => nom_commune_naissance, "codeCogInseeDepartementNaissance" => code_cog_insee_departement_naissance }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "nomNaissance" => nom_naissance, "nomUsage" => nom_usage, "prenoms" => prenoms, "anneeDateNaissance" => annee_date_naissance, "moisDateNaissance" => mois_date_naissance, "jourDateNaissance" => jour_date_naissance, "sexeEtatCivil" => sexe_etat_civil, "codeCogInseePaysNaissance" => code_cog_insee_pays_naissance, "codeCogInseeCommuneNaissance" => code_cog_insee_commune_naissance, "nomCommuneNaissance" => nom_commune_naissance, "codeCogInseeDepartementNaissance" => code_cog_insee_departement_naissance }.compact)
       end
 
       # [FranceConnect] Quotient familial CAF & MSA
       # Logical endpoint: /dss/quotient_familial/france_connect
       # Versions available: [3] — default: 3
-      def quotient_familial(version: nil, recipient: nil, annee: nil, mois: nil)
+      def quotient_familial(version: nil, recipient: nil, delegation_id: nil, annee: nil, mois: nil)
         path =
           case version || 3
           when 3
@@ -189,13 +189,13 @@ module ApiParticulier
           else
             raise ArgumentError, "version #{version.inspect} not available for /dss/quotient_familial/france_connect; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "annee" => annee, "mois" => mois }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "annee" => annee, "mois" => mois }.compact)
       end
 
       # [Identité] Quotient familial CAF & MSA
       # Logical endpoint: /dss/quotient_familial/identite
       # Versions available: [3] — default: 3
-      def quotient_familial_identite(version: nil, recipient: nil, nom_naissance:, nom_usage: nil, prenoms:, annee_date_naissance: nil, mois_date_naissance: nil, jour_date_naissance: nil, sexe_etat_civil: nil, code_cog_insee_pays_naissance:, code_cog_insee_commune_naissance: nil, nom_commune_naissance: nil, code_cog_insee_departement_naissance: nil, annee: nil, mois: nil)
+      def quotient_familial_identite(version: nil, recipient: nil, delegation_id: nil, nom_naissance:, nom_usage: nil, prenoms:, annee_date_naissance: nil, mois_date_naissance: nil, jour_date_naissance: nil, sexe_etat_civil: nil, code_cog_insee_pays_naissance:, code_cog_insee_commune_naissance: nil, nom_commune_naissance: nil, code_cog_insee_departement_naissance: nil, annee: nil, mois: nil)
         path =
           case version || 3
           when 3
@@ -203,13 +203,13 @@ module ApiParticulier
           else
             raise ArgumentError, "version #{version.inspect} not available for /dss/quotient_familial/identite; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "nomNaissance" => nom_naissance, "nomUsage" => nom_usage, "prenoms" => prenoms, "anneeDateNaissance" => annee_date_naissance, "moisDateNaissance" => mois_date_naissance, "jourDateNaissance" => jour_date_naissance, "sexeEtatCivil" => sexe_etat_civil, "codeCogInseePaysNaissance" => code_cog_insee_pays_naissance, "codeCogInseeCommuneNaissance" => code_cog_insee_commune_naissance, "nomCommuneNaissance" => nom_commune_naissance, "codeCogInseeDepartementNaissance" => code_cog_insee_departement_naissance, "annee" => annee, "mois" => mois }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "nomNaissance" => nom_naissance, "nomUsage" => nom_usage, "prenoms" => prenoms, "anneeDateNaissance" => annee_date_naissance, "moisDateNaissance" => mois_date_naissance, "jourDateNaissance" => jour_date_naissance, "sexeEtatCivil" => sexe_etat_civil, "codeCogInseePaysNaissance" => code_cog_insee_pays_naissance, "codeCogInseeCommuneNaissance" => code_cog_insee_commune_naissance, "nomCommuneNaissance" => nom_commune_naissance, "codeCogInseeDepartementNaissance" => code_cog_insee_departement_naissance, "annee" => annee, "mois" => mois }.compact)
       end
 
       # [FranceConnect] Statut revenu de solidarité active (RSA)
       # Logical endpoint: /dss/revenu_solidarite_active/france_connect
       # Versions available: [3] — default: 3
-      def revenu_solidarite_active(version: nil, recipient: nil)
+      def revenu_solidarite_active(version: nil, recipient: nil, delegation_id: nil)
         path =
           case version || 3
           when 3
@@ -217,13 +217,13 @@ module ApiParticulier
           else
             raise ArgumentError, "version #{version.inspect} not available for /dss/revenu_solidarite_active/france_connect; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id }.compact)
       end
 
       # [Identité] Statut revenu de solidarité active (RSA)
       # Logical endpoint: /dss/revenu_solidarite_active/identite
       # Versions available: [3] — default: 3
-      def revenu_solidarite_active_identite(version: nil, recipient: nil, nom_naissance:, nom_usage: nil, prenoms:, annee_date_naissance: nil, mois_date_naissance: nil, jour_date_naissance: nil, sexe_etat_civil: nil, code_cog_insee_pays_naissance:, code_cog_insee_commune_naissance: nil, nom_commune_naissance: nil, code_cog_insee_departement_naissance: nil)
+      def revenu_solidarite_active_identite(version: nil, recipient: nil, delegation_id: nil, nom_naissance:, nom_usage: nil, prenoms:, annee_date_naissance: nil, mois_date_naissance: nil, jour_date_naissance: nil, sexe_etat_civil: nil, code_cog_insee_pays_naissance:, code_cog_insee_commune_naissance: nil, nom_commune_naissance: nil, code_cog_insee_departement_naissance: nil)
         path =
           case version || 3
           when 3
@@ -231,7 +231,7 @@ module ApiParticulier
           else
             raise ArgumentError, "version #{version.inspect} not available for /dss/revenu_solidarite_active/identite; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "nomNaissance" => nom_naissance, "nomUsage" => nom_usage, "prenoms" => prenoms, "anneeDateNaissance" => annee_date_naissance, "moisDateNaissance" => mois_date_naissance, "jourDateNaissance" => jour_date_naissance, "sexeEtatCivil" => sexe_etat_civil, "codeCogInseePaysNaissance" => code_cog_insee_pays_naissance, "codeCogInseeCommuneNaissance" => code_cog_insee_commune_naissance, "nomCommuneNaissance" => nom_commune_naissance, "codeCogInseeDepartementNaissance" => code_cog_insee_departement_naissance }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "nomNaissance" => nom_naissance, "nomUsage" => nom_usage, "prenoms" => prenoms, "anneeDateNaissance" => annee_date_naissance, "moisDateNaissance" => mois_date_naissance, "jourDateNaissance" => jour_date_naissance, "sexeEtatCivil" => sexe_etat_civil, "codeCogInseePaysNaissance" => code_cog_insee_pays_naissance, "codeCogInseeCommuneNaissance" => code_cog_insee_commune_naissance, "nomCommuneNaissance" => nom_commune_naissance, "codeCogInseeDepartementNaissance" => code_cog_insee_departement_naissance }.compact)
       end
     end
   end

--- a/clients/ruby/api_particulier/lib/api_particulier/resources/france_travail.rb
+++ b/clients/ruby/api_particulier/lib/api_particulier/resources/france_travail.rb
@@ -13,7 +13,7 @@ module ApiParticulier
       # Paiements versés par France Travail
       # Logical endpoint: /france_travail/indemnites/identifiant
       # Versions available: [3] — default: 3
-      def indemnites(version: nil, recipient: nil, identifiant:)
+      def indemnites(version: nil, recipient: nil, delegation_id: nil, identifiant:)
         path =
           case version || 3
           when 3
@@ -21,13 +21,13 @@ module ApiParticulier
           else
             raise ArgumentError, "version #{version.inspect} not available for /france_travail/indemnites/identifiant; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "identifiant" => identifiant }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "identifiant" => identifiant }.compact)
       end
 
       # Statut demandeur d'emploi
       # Logical endpoint: /france_travail/statut/identifiant
       # Versions available: [3] — default: 3
-      def statut(version: nil, recipient: nil, identifiant:)
+      def statut(version: nil, recipient: nil, delegation_id: nil, identifiant:)
         path =
           case version || 3
           when 3
@@ -35,7 +35,7 @@ module ApiParticulier
           else
             raise ArgumentError, "version #{version.inspect} not available for /france_travail/statut/identifiant; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "identifiant" => identifiant }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "identifiant" => identifiant }.compact)
       end
     end
   end

--- a/clients/ruby/api_particulier/lib/api_particulier/resources/gip_mds.rb
+++ b/clients/ruby/api_particulier/lib/api_particulier/resources/gip_mds.rb
@@ -13,7 +13,7 @@ module ApiParticulier
       # [FranceConnect] Statut service civique
       # Logical endpoint: /gip_mds/service_civique/france_connect
       # Versions available: [3] — default: 3
-      def service_civique(version: nil, recipient: nil)
+      def service_civique(version: nil, recipient: nil, delegation_id: nil)
         path =
           case version || 3
           when 3
@@ -21,13 +21,13 @@ module ApiParticulier
           else
             raise ArgumentError, "version #{version.inspect} not available for /gip_mds/service_civique/france_connect; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id }.compact)
       end
 
       # [Identité] Statut service civique
       # Logical endpoint: /gip_mds/service_civique/identite
       # Versions available: [3] — default: 3
-      def service_civique_identite(version: nil, recipient: nil, nom_naissance:, prenoms:, annee_date_naissance:, mois_date_naissance:, jour_date_naissance:)
+      def service_civique_identite(version: nil, recipient: nil, delegation_id: nil, nom_naissance:, prenoms:, annee_date_naissance:, mois_date_naissance:, jour_date_naissance:)
         path =
           case version || 3
           when 3
@@ -35,7 +35,7 @@ module ApiParticulier
           else
             raise ArgumentError, "version #{version.inspect} not available for /gip_mds/service_civique/identite; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "nomNaissance" => nom_naissance, "prenoms" => prenoms, "anneeDateNaissance" => annee_date_naissance, "moisDateNaissance" => mois_date_naissance, "jourDateNaissance" => jour_date_naissance }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "nomNaissance" => nom_naissance, "prenoms" => prenoms, "anneeDateNaissance" => annee_date_naissance, "moisDateNaissance" => mois_date_naissance, "jourDateNaissance" => jour_date_naissance }.compact)
       end
     end
   end

--- a/clients/ruby/api_particulier/lib/api_particulier/resources/men.rb
+++ b/clients/ruby/api_particulier/lib/api_particulier/resources/men.rb
@@ -13,7 +13,7 @@ module ApiParticulier
       # Statut élève scolarisé et boursier
       # Logical endpoint: /men/scolarites/identite
       # Versions available: [3, 4, 5] — default: 5
-      def scolarites(version: nil, recipient: nil, nom_naissance:, prenoms:, sexe_etat_civil:, annee_date_naissance:, mois_date_naissance:, jour_date_naissance:, code_etablissement: nil, annee_scolaire:, degre_etablissement: nil, codes_bcn_departements: nil, codes_bcn_regions: nil)
+      def scolarites(version: nil, recipient: nil, delegation_id: nil, nom_naissance:, prenoms:, sexe_etat_civil:, annee_date_naissance:, mois_date_naissance:, jour_date_naissance:, code_etablissement: nil, annee_scolaire:, degre_etablissement: nil, codes_bcn_departements: nil, codes_bcn_regions: nil)
         path =
           case version || 5
           when 3
@@ -27,7 +27,7 @@ module ApiParticulier
           else
             raise ArgumentError, "version #{version.inspect} not available for /men/scolarites/identite; supported: [3, 4, 5]"
           end
-        @client.get(path, params: { "recipient" => recipient, "nomNaissance" => nom_naissance, "prenoms" => prenoms, "sexeEtatCivil" => sexe_etat_civil, "anneeDateNaissance" => annee_date_naissance, "moisDateNaissance" => mois_date_naissance, "jourDateNaissance" => jour_date_naissance, "codeEtablissement" => code_etablissement, "anneeScolaire" => annee_scolaire, "degreEtablissement" => degre_etablissement, "codesBcnDepartements" => codes_bcn_departements, "codesBcnRegions" => codes_bcn_regions }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "nomNaissance" => nom_naissance, "prenoms" => prenoms, "sexeEtatCivil" => sexe_etat_civil, "anneeDateNaissance" => annee_date_naissance, "moisDateNaissance" => mois_date_naissance, "jourDateNaissance" => jour_date_naissance, "codeEtablissement" => code_etablissement, "anneeScolaire" => annee_scolaire, "degreEtablissement" => degre_etablissement, "codesBcnDepartements" => codes_bcn_departements, "codesBcnRegions" => codes_bcn_regions }.compact)
       end
     end
   end

--- a/clients/ruby/api_particulier/lib/api_particulier/resources/mesri.rb
+++ b/clients/ruby/api_particulier/lib/api_particulier/resources/mesri.rb
@@ -13,7 +13,7 @@ module ApiParticulier
       # [FranceConnect] Statut étudiant
       # Logical endpoint: /mesri/statut_etudiant/france_connect
       # Versions available: [3] — default: 3
-      def statut_etudiant(version: nil, recipient: nil)
+      def statut_etudiant(version: nil, recipient: nil, delegation_id: nil)
         path =
           case version || 3
           when 3
@@ -21,13 +21,13 @@ module ApiParticulier
           else
             raise ArgumentError, "version #{version.inspect} not available for /mesri/statut_etudiant/france_connect; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id }.compact)
       end
 
       # [Identité] Statut étudiant
       # Logical endpoint: /mesri/statut_etudiant/identite
       # Versions available: [3] — default: 3
-      def statut_etudiant_identite(version: nil, recipient: nil, nom_naissance:, prenoms:, annee_date_naissance:, mois_date_naissance:, jour_date_naissance:, sexe_etat_civil:, code_cog_insee_commune_naissance: nil, nom_commune_naissance: nil, code_cog_insee_departement_naissance: nil)
+      def statut_etudiant_identite(version: nil, recipient: nil, delegation_id: nil, nom_naissance:, prenoms:, annee_date_naissance:, mois_date_naissance:, jour_date_naissance:, sexe_etat_civil:, code_cog_insee_commune_naissance: nil, nom_commune_naissance: nil, code_cog_insee_departement_naissance: nil)
         path =
           case version || 3
           when 3
@@ -35,13 +35,13 @@ module ApiParticulier
           else
             raise ArgumentError, "version #{version.inspect} not available for /mesri/statut_etudiant/identite; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "nomNaissance" => nom_naissance, "prenoms" => prenoms, "anneeDateNaissance" => annee_date_naissance, "moisDateNaissance" => mois_date_naissance, "jourDateNaissance" => jour_date_naissance, "sexeEtatCivil" => sexe_etat_civil, "codeCogInseeCommuneNaissance" => code_cog_insee_commune_naissance, "nomCommuneNaissance" => nom_commune_naissance, "codeCogInseeDepartementNaissance" => code_cog_insee_departement_naissance }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "nomNaissance" => nom_naissance, "prenoms" => prenoms, "anneeDateNaissance" => annee_date_naissance, "moisDateNaissance" => mois_date_naissance, "jourDateNaissance" => jour_date_naissance, "sexeEtatCivil" => sexe_etat_civil, "codeCogInseeCommuneNaissance" => code_cog_insee_commune_naissance, "nomCommuneNaissance" => nom_commune_naissance, "codeCogInseeDepartementNaissance" => code_cog_insee_departement_naissance }.compact)
       end
 
       # [INE] Statut étudiant
       # Logical endpoint: /mesri/statut_etudiant/ine
       # Versions available: [3] — default: 3
-      def ine(version: nil, recipient: nil, ine:)
+      def ine(version: nil, recipient: nil, delegation_id: nil, ine:)
         path =
           case version || 3
           when 3
@@ -49,7 +49,7 @@ module ApiParticulier
           else
             raise ArgumentError, "version #{version.inspect} not available for /mesri/statut_etudiant/ine; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "ine" => ine }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "ine" => ine }.compact)
       end
     end
   end

--- a/clients/ruby/api_particulier/lib/api_particulier/resources/sdh.rb
+++ b/clients/ruby/api_particulier/lib/api_particulier/resources/sdh.rb
@@ -13,7 +13,7 @@ module ApiParticulier
       # [Identifiant] API Statut sportif de haut niveau et sur liste ministérielle
       # Logical endpoint: /sdh/statut_sportif/identifiant
       # Versions available: [3] — default: 3
-      def statut_sportif(version: nil, recipient: nil, identifiant:)
+      def statut_sportif(version: nil, recipient: nil, delegation_id: nil, identifiant:)
         path =
           case version || 3
           when 3
@@ -21,7 +21,7 @@ module ApiParticulier
           else
             raise ArgumentError, "version #{version.inspect} not available for /sdh/statut_sportif/identifiant; supported: [3]"
           end
-        @client.get(path, params: { "recipient" => recipient, "identifiant" => identifiant }.compact)
+        @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "identifiant" => identifiant }.compact)
       end
     end
   end

--- a/commons/endpoints/_swagger_shared/00_commons.yml
+++ b/commons/endpoints/_swagger_shared/00_commons.yml
@@ -130,3 +130,10 @@ parameters:
 
       L’identifiant peut être interne à votre organisation ou bien un numéro de marché publique, un nom de procédure ; l’essentiel est que celui-ci vous permette de tracer et de retrouver les informations relatives à l’appel. En effet, vous devez pouvoir justifier de la raison d’un appel auprès du fournisseur de données. Description courte ( < 50 caractères )."
     example: "marché numéro 127"
+  delegation_id:
+    description: >-
+      "**Identifiant de la délégation éditeur**
+
+
+      UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+    example: "6f3c8d9a-1b2c-4d5e-8f90-abcdef012345"

--- a/commons/swagger/openapi-entreprise.yaml
+++ b/commons/swagger/openapi-entreprise.yaml
@@ -121,6 +121,19 @@ paths:
           content:
             application/json:
               examples:
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_context_error:
                   value:
                     errors:
@@ -233,6 +246,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -465,6 +488,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '502':
@@ -795,6 +831,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -1215,6 +1261,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 unprocessable_content_error_siret_error:
                   value:
                     errors:
@@ -1429,6 +1488,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -1963,6 +2032,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -2203,6 +2285,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -2670,6 +2762,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -2873,6 +2978,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -3093,6 +3208,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '502':
@@ -3334,6 +3462,16 @@ paths:
         required: true
         schema:
           type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
+        schema:
+          type: string
       - name: context
         in: query
         description: |-
@@ -3546,6 +3684,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '502':
@@ -3831,6 +3982,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -4341,6 +4502,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -4560,6 +4734,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -4799,6 +4983,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -5061,6 +5258,16 @@ paths:
         required: true
         schema:
           type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
+        schema:
+          type: string
       - name: context
         in: query
         description: |-
@@ -5310,6 +5517,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '502':
@@ -5612,6 +5832,16 @@ paths:
         required: true
         schema:
           type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
+        schema:
+          type: string
       - name: context
         in: query
         description: |-
@@ -5879,6 +6109,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '502':
@@ -6147,6 +6390,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -6433,6 +6686,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '502':
@@ -6623,6 +6889,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -7116,6 +7392,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 unprocessable_content_error_year_error:
                   value:
                     errors:
@@ -7332,6 +7621,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -7795,6 +8094,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 unprocessable_content_error_year_error:
                   value:
                     errors:
@@ -8011,6 +8323,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -8654,6 +8976,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 unprocessable_content_error_year_error:
                   value:
                     errors:
@@ -9321,6 +9656,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -10982,6 +11327,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -11198,6 +11556,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -12468,6 +12836,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -12672,6 +13053,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -12886,6 +13277,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '502':
@@ -13086,6 +13490,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -13391,6 +13805,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -13594,6 +14021,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -13809,6 +14246,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '502':
@@ -14091,6 +14541,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -14436,6 +14896,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 unprocessable_content_error_year_error:
                   value:
                     errors:
@@ -14649,6 +15122,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -15045,6 +15528,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 unprocessable_content_error_month_error:
                   value:
                     errors:
@@ -15269,6 +15765,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -15949,6 +16455,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -16184,6 +16703,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -16556,6 +17085,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -16759,6 +17301,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -17095,6 +17647,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -17298,6 +17863,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -18274,6 +18849,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '502':
@@ -18453,6 +19041,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -19181,6 +19779,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '502':
@@ -19394,6 +20005,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -19846,6 +20467,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -20083,6 +20717,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -20565,6 +21209,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -20802,6 +21459,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -21989,6 +22656,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -22232,6 +22912,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -23476,6 +24166,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -23719,6 +24422,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -24954,6 +25667,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -25191,6 +25917,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -26483,6 +27219,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -26718,6 +27467,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -27953,6 +28712,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -28188,6 +28960,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -29480,6 +30262,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -29715,6 +30510,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -30903,6 +31708,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -31138,6 +31956,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -32383,6 +33211,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -32620,6 +33461,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -32905,6 +33756,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '502':
@@ -33116,6 +33980,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -33792,6 +34666,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -34033,6 +34920,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -34737,6 +35634,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -34978,6 +35888,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -35672,6 +36592,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -35913,6 +36846,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -36635,6 +37578,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -36865,6 +37821,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -37135,6 +38101,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '502':
@@ -37425,6 +38404,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -37764,6 +38753,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -38003,6 +39005,16 @@ paths:
         required: true
         schema:
           type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
+        schema:
+          type: string
       - name: context
         in: query
         description: |-
@@ -38210,6 +39222,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -38416,6 +39441,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -38734,6 +39769,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -38973,6 +40021,16 @@ paths:
         required: true
         schema:
           type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
+        schema:
+          type: string
       - name: context
         in: query
         description: |-
@@ -39180,6 +40238,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '502':
@@ -39464,6 +40535,16 @@ paths:
         required: true
         schema:
           type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
+        schema:
+          type: string
       - name: context
         in: query
         description: |-
@@ -39672,6 +40753,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -39911,6 +41005,16 @@ paths:
         required: true
         schema:
           type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
+        schema:
+          type: string
       - name: context
         in: query
         description: |-
@@ -40119,6 +41223,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '502':
@@ -40442,6 +41559,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -40769,6 +41896,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '502':
@@ -41085,6 +42225,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -41514,6 +42664,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '429':
@@ -41768,6 +42931,16 @@ paths:
         required: true
         schema:
           type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
+        schema:
+          type: string
       - name: context
         in: query
         description: |-
@@ -41987,6 +43160,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':
@@ -42229,6 +43415,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: context
@@ -42527,6 +43723,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '502':

--- a/commons/swagger/openapi-entreprise.yaml
+++ b/commons/swagger/openapi-entreprise.yaml
@@ -9190,6 +9190,16 @@ paths:
         required: true
         schema:
           type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
+        schema:
+          type: string
       - name: context
         in: query
         description: |-
@@ -9289,26 +9299,6 @@ paths:
                   description: 'Votre jeton est sur liste noire, celui-ci a certainement
                     été divulgué sur un canal non-sécurisé. Vous pouvez trouver un
                     jeton valide sur votre espace personnel: https://entreprise.api.gouv.fr/compte'
-              schema:
-                "$ref": "#/components/schemas/Error"
-        '403':
-          description: Accès interdit
-          content:
-            application/json:
-              examples:
-                insufficient_privileges_error:
-                  value:
-                    errors:
-                    - code: '00100'
-                      title: Privilèges insuffisants
-                      detail: Votre token est valide mais vos privilèges sont insuffisants.
-                        Listez vos privilèges sur /v2/privileges
-                      source:
-                        parameter: token
-                      meta: {}
-                  summary: Privilèges insuffisants
-                  description: Votre token est valide mais vos privilèges sont insuffisants.
-                    Listez vos privilèges sur /v2/privileges
               schema:
                 "$ref": "#/components/schemas/Error"
         '429':
@@ -9454,6 +9444,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '502':
@@ -9589,6 +9592,26 @@ paths:
                         provider: DGFIP - TVA
                   summary: Erreur de résolution DNS
                   description: Problème de résolution DNS de l'adresse du serveur
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '403':
+          description: Accès interdit
+          content:
+            application/json:
+              examples:
+                insufficient_privileges_error:
+                  value:
+                    errors:
+                    - code: '00100'
+                      title: Privilèges insuffisants
+                      detail: Votre token est valide mais vos privilèges sont insuffisants.
+                        Listez vos privilèges sur /v2/privileges
+                      source:
+                        parameter: token
+                      meta: {}
+                  summary: Privilèges insuffisants
+                  description: Votre token est valide mais vos privilèges sont insuffisants.
+                    Listez vos privilèges sur /v2/privileges
               schema:
                 "$ref": "#/components/schemas/Error"
         '409':

--- a/commons/swagger/openapi-particulier.yaml
+++ b/commons/swagger/openapi-particulier.yaml
@@ -74,6 +74,16 @@ paths:
         required: true
         schema:
           type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
+        schema:
+          type: string
       - name: immatriculation
         in: query
         description: Identifiant de l'immatriculation du véhicule.
@@ -717,6 +727,19 @@ paths:
           content:
             application/json:
               examples:
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_recipient_error:
                   value:
                     errors:
@@ -761,6 +784,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: Cache-Control
@@ -1077,6 +1110,19 @@ paths:
                   summary: Entité non traitable
                   description: Un ou plusieurs paramètres de civilité ne sont pas
                     correctement formatés
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_recipient_error:
                   value:
                     errors:
@@ -1321,6 +1367,16 @@ paths:
         required: true
         schema:
           type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
+        schema:
+          type: string
       - name: Cache-Control
         in: header
         description: Si cette valeur est fixée à "no-cache", le système de cache est
@@ -1485,6 +1541,19 @@ paths:
                   summary: Entité non traitable
                   description: Un ou plusieurs paramètres de civilité ne sont pas
                     correctement formatés
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_recipient_error:
                   value:
                     errors:
@@ -1596,6 +1665,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: Cache-Control
@@ -1927,6 +2006,19 @@ paths:
                   summary: Entité non traitable
                   description: Un ou plusieurs paramètres de civilité ne sont pas
                     correctement formatés
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_recipient_error:
                   value:
                     errors:
@@ -2172,6 +2264,16 @@ paths:
         required: true
         schema:
           type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
+        schema:
+          type: string
       - name: Cache-Control
         in: header
         description: Si cette valeur est fixée à "no-cache", le système de cache est
@@ -2351,6 +2453,19 @@ paths:
                   summary: Entité non traitable
                   description: Un ou plusieurs paramètres de civilité ne sont pas
                     correctement formatés
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_recipient_error:
                   value:
                     errors:
@@ -2462,6 +2577,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: Cache-Control
@@ -2780,6 +2905,19 @@ paths:
                   summary: Entité non traitable
                   description: Un ou plusieurs paramètres de civilité ne sont pas
                     correctement formatés
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_recipient_error:
                   value:
                     errors:
@@ -3024,6 +3162,16 @@ paths:
         required: true
         schema:
           type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
+        schema:
+          type: string
       - name: Cache-Control
         in: header
         description: Si cette valeur est fixée à "no-cache", le système de cache est
@@ -3190,6 +3338,19 @@ paths:
                   summary: Entité non traitable
                   description: Un ou plusieurs paramètres de civilité ne sont pas
                     correctement formatés
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_recipient_error:
                   value:
                     errors:
@@ -3301,6 +3462,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: Cache-Control
@@ -3641,6 +3812,19 @@ paths:
                   summary: Entité non traitable
                   description: Un ou plusieurs paramètres de civilité ne sont pas
                     correctement formatés
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_recipient_error:
                   value:
                     errors:
@@ -3885,6 +4069,16 @@ paths:
         required: true
         schema:
           type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
+        schema:
+          type: string
       - name: Cache-Control
         in: header
         description: Si cette valeur est fixée à "no-cache", le système de cache est
@@ -4073,6 +4267,19 @@ paths:
                   summary: Entité non traitable
                   description: Un ou plusieurs paramètres de civilité ne sont pas
                     correctement formatés
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_recipient_error:
                   value:
                     errors:
@@ -4184,6 +4391,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: Cache-Control
@@ -4883,6 +5100,19 @@ paths:
           content:
             application/json:
               examples:
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_recipient_error:
                   value:
                     errors:
@@ -4910,6 +5140,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: Cache-Control
@@ -5292,6 +5532,19 @@ paths:
           content:
             application/json:
               examples:
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_recipient_error:
                   value:
                     errors:
@@ -5336,6 +5589,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: Cache-Control
@@ -5664,6 +5927,19 @@ paths:
                   summary: Entité non traitable
                   description: Un ou plusieurs paramètres de civilité ne sont pas
                     correctement formatés
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_recipient_error:
                   value:
                     errors:
@@ -5908,6 +6184,16 @@ paths:
         required: true
         schema:
           type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
+        schema:
+          type: string
       - name: Cache-Control
         in: header
         description: Si cette valeur est fixée à "no-cache", le système de cache est
@@ -6084,6 +6370,19 @@ paths:
                   summary: Entité non traitable
                   description: Un ou plusieurs paramètres de civilité ne sont pas
                     correctement formatés
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_recipient_error:
                   value:
                     errors:
@@ -6343,6 +6642,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: Cache-Control
@@ -6898,6 +7207,19 @@ paths:
                   summary: Entité non traitable
                   description: Un ou plusieurs paramètres de civilité ne sont pas
                     correctement formatés
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_recipient_error:
                   value:
                     errors:
@@ -7153,6 +7475,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: Cache-Control
@@ -7558,6 +7890,19 @@ paths:
                   summary: Entité non traitable
                   description: Un ou plusieurs paramètres de civilité ne sont pas
                     correctement formatés
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_recipient_error:
                   value:
                     errors:
@@ -7682,6 +8027,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: Cache-Control
@@ -8010,6 +8365,19 @@ paths:
                   summary: Entité non traitable
                   description: Un ou plusieurs paramètres de civilité ne sont pas
                     correctement formatés
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_recipient_error:
                   value:
                     errors:
@@ -8254,6 +8622,16 @@ paths:
         required: true
         schema:
           type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
+        schema:
+          type: string
       - name: Cache-Control
         in: header
         description: Si cette valeur est fixée à "no-cache", le système de cache est
@@ -8430,6 +8808,19 @@ paths:
                   summary: Entité non traitable
                   description: Un ou plusieurs paramètres de civilité ne sont pas
                     correctement formatés
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_recipient_error:
                   value:
                     errors:
@@ -8542,6 +8933,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: nomNaissance
@@ -8952,6 +9353,19 @@ paths:
                   summary: Entité non traitable
                   description: Un ou plusieurs paramètres de civilité ne sont pas
                     correctement formatés
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_recipient_error:
                   value:
                     errors:
@@ -9136,6 +9550,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       security:
@@ -9374,6 +9798,19 @@ paths:
                   summary: Entité non traitable
                   description: Un ou plusieurs paramètres de civilité ne sont pas
                     correctement formatés
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_recipient_error:
                   value:
                     errors:
@@ -9440,6 +9877,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: ine
@@ -9749,6 +10196,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le numéro d'INE n'est pas correctement formatté
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_recipient_error:
                   value:
                     errors:
@@ -9932,6 +10392,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: nomNaissance
@@ -10353,6 +10823,19 @@ paths:
           content:
             application/json:
               examples:
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_recipient_error:
                   value:
                     errors:
@@ -10397,6 +10880,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: campaignYear
@@ -10651,6 +11144,19 @@ paths:
           content:
             application/json:
               examples:
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_recipient_error:
                   value:
                     errors:
@@ -10695,6 +11201,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: ine
@@ -11015,6 +11531,19 @@ paths:
           content:
             application/json:
               examples:
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_recipient_error:
                   value:
                     errors:
@@ -11059,6 +11588,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: nomNaissance
@@ -11359,6 +11898,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '502':
@@ -11531,6 +12083,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       security:
@@ -11731,6 +12293,19 @@ paths:
           content:
             application/json:
               examples:
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_recipient_error:
                   value:
                     errors:
@@ -11775,6 +12350,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: identifiant
@@ -12140,6 +12725,19 @@ paths:
           content:
             application/json:
               examples:
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_recipient_error:
                   value:
                     errors:
@@ -12167,6 +12765,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: identifiant
@@ -12712,6 +13320,19 @@ paths:
           content:
             application/json:
               examples:
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_recipient_error:
                   value:
                     errors:
@@ -12739,6 +13360,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: nomNaissance
@@ -13098,6 +13729,19 @@ paths:
                   description: Les paramètres d'identité correspondent à plusieurs
                     personnes. Nous ne pouvons pas fournir les informations de service
                     civique pour cet individu.
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_recipient_error:
                   value:
                     errors:
@@ -13281,6 +13925,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       security:
@@ -13591,6 +14245,19 @@ paths:
           content:
             application/json:
               examples:
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_recipient_error:
                   value:
                     errors:
@@ -13717,6 +14384,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: nomNaissance
@@ -14266,6 +14943,19 @@ paths:
           content:
             application/json:
               examples:
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_recipient_error:
                   value:
                     errors:
@@ -14294,6 +14984,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: nomNaissance
@@ -14745,6 +15445,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '502':
@@ -14917,6 +15630,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: nomNaissance
@@ -15408,6 +16131,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '502':
@@ -15580,6 +16316,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: nomNaissance
@@ -16143,6 +16889,19 @@ paths:
           content:
             application/json:
               examples:
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_recipient_error:
                   value:
                     errors:
@@ -16170,6 +16929,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       security:
@@ -16446,6 +17215,19 @@ paths:
           content:
             application/json:
               examples:
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_recipient_error:
                   value:
                     errors:
@@ -16490,6 +17272,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: ine
@@ -16953,6 +17745,19 @@ paths:
           content:
             application/json:
               examples:
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
                 missing_mandatory_params_recipient_error:
                   value:
                     errors:
@@ -16980,6 +17785,16 @@ paths:
           SIRET de l’administration destinatrice des données."
         example: '13002526500013'
         required: true
+        schema:
+          type: string
+      - name: delegation_id
+        in: query
+        description: |-
+          "**Identifiant de la délégation éditeur**
+
+          UUID d’une délégation précise, réservé aux jetons éditeur. Optionnel : requis uniquement lorsque plusieurs délégations actives existent pour le même `recipient`, afin de lever l’ambiguïté (cf. erreur 00212)."
+        example: 6f3c8d9a-1b2c-4d5e-8f90-abcdef012345
+        required: false
         schema:
           type: string
       - name: identifiant
@@ -17463,6 +18278,19 @@ paths:
                       meta: {}
                   summary: Entité non traitable
                   description: Le paramètre recipient est obligatoire
+                ambiguous_delegation_error:
+                  value:
+                    errors:
+                    - code: '00212'
+                      title: Entité non traitable
+                      detail: Plusieurs délégations actives existent pour ce SIRET.
+                        Le paramètre delegation_id est requis pour identifier la délégation.
+                      source:
+                        parameter: delegation_id
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Plusieurs délégations actives existent pour ce SIRET.
+                    Le paramètre delegation_id est requis pour identifier la délégation.
               schema:
                 "$ref": "#/components/schemas/Error"
         '502':

--- a/siade/app/services/openapi/error_injector.rb
+++ b/siade/app/services/openapi/error_injector.rb
@@ -104,9 +104,8 @@ class Openapi::ErrorInjector
     return unless error_config
     return unless responses.key?('422')
 
-    path_params = extract_path_params(path)
-    mandatory_params = error_config['mandatory_params'].map(&:to_sym)
-    extra_examples = builder.build_422_for_params(path_params:, mandatory_params:)
+    extra_examples = build_examples(error_config, extract_provider(path))
+    add_mandatory_params_examples(extra_examples, path, error_config)
 
     existing_examples = responses.dig('422', 'content', 'application/json', 'examples') || {}
     extra_examples.each do |key, value|

--- a/siade/config/openapi_common_errors/entreprise.yml
+++ b/siade/config/openapi_common_errors/entreprise.yml
@@ -29,6 +29,9 @@ responses:
       - context
       - object
       - recipient
+    examples:
+      ambiguous_delegation_error:
+        error_class: AmbiguousDelegationError
 
   '429':
     description: Trop de requêtes

--- a/siade/config/openapi_common_errors/particulier.yml
+++ b/siade/config/openapi_common_errors/particulier.yml
@@ -27,6 +27,9 @@ responses:
     description: Paramètre(s) invalide(s)
     mandatory_params:
       - recipient
+    examples:
+      ambiguous_delegation_error:
+        error_class: AmbiguousDelegationError
 
   '429':
     description: Trop de requêtes

--- a/siade/spec/services/openapi/error_injector_spec.rb
+++ b/siade/spec/services/openapi/error_injector_spec.rb
@@ -65,6 +65,18 @@ RSpec.describe Openapi::ErrorInjector do
         expect(examples).to have_key('missing_mandatory_params_recipient_error')
       end
 
+      it 'documents the ambiguous editor delegation error on 422' do
+        described_class.new(open_api, config_path:).perform
+
+        examples = open_api.dig(
+          'paths', '/v3/insee/sirene/unites_legales/{siren}', 'get', 'responses',
+          '422', 'content', 'application/json', 'examples'
+        )
+
+        expect(examples).to have_key('ambiguous_delegation_error')
+        expect(examples.dig('ambiguous_delegation_error', 'value', 'errors', 0, 'code')).to eq('00212')
+      end
+
       it 'uses provider name in 502/504 examples' do
         described_class.new(open_api, config_path:).perform
 
@@ -173,6 +185,18 @@ RSpec.describe Openapi::ErrorInjector do
 
         expect(examples).to have_key('custom_error')
         expect(examples).to have_key('missing_mandatory_params_context_error')
+      end
+
+      it 'merges the configured ambiguous delegation example into an existing 422' do
+        described_class.new(open_api, config_path:).perform
+
+        examples = open_api.dig(
+          'paths', '/v3/insee/sirene/unites_legales/{siren}', 'get', 'responses',
+          '422', 'content', 'application/json', 'examples'
+        )
+
+        expect(examples).to have_key('custom_error')
+        expect(examples).to have_key('ambiguous_delegation_error')
       end
     end
 

--- a/siade/spec/support/rswag_common_responses.rb
+++ b/siade/spec/support/rswag_common_responses.rb
@@ -10,9 +10,20 @@ module RSwagCommonResponses
       example: SwaggerData.get('parameters.recipient.example'),
       required: true
 
+    delegation_id_action_attribute
+
     specific_api_entreprise_action_attributes if describe.metadata[:api] == :entreprise
 
     security [{ jwt_bearer_token: [] }]
+  end
+
+  def delegation_id_action_attribute
+    parameter name: :delegation_id,
+      in: :query,
+      type: :string,
+      description: SwaggerData.get('parameters.delegation_id.description'),
+      example: SwaggerData.get('parameters.delegation_id.example'),
+      required: false
   end
 
   def specific_api_entreprise_action_attributes
@@ -40,6 +51,8 @@ module RSwagCommonResponses
       description: SwaggerData.get('parameters.recipient.description'),
       example: SwaggerData.get('parameters.recipient.example'),
       required: true
+
+    delegation_id_action_attribute
 
     security [{ jwt_bearer_token: [] }]
   end

--- a/site/config/changelogs.yml
+++ b/site/config/changelogs.yml
@@ -1,3 +1,9 @@
+- date: 2026-06-09
+  scope: both
+  title: "Espace développeurs : intégration éditeur et délégations"
+  description: |
+    L'[espace développeurs](<%= developers_path %>) documente désormais l'**intégration éditeur** : comment, avec un **jeton éditeur** unique, appeler nos API **pour le compte d'une administration cliente** via la **délégation**. La nouvelle rubrique couvre les concepts, le listing des délégations (`GET /editeur/api/v1/delegations`), la transmission via les paramètres `recipient` (SIRET du client) et `delegation_id` (UUID, pour lever l'ambiguïté entre plusieurs délégations actives), des exemples `curl` du flux complet et le contrat d'erreurs (`422` ambiguïté, `401`&nbsp;/&nbsp;`403` volontairement opaques). Le paramètre `delegation_id` est par ailleurs documenté dans l'[OpenAPI](<%= developers_openapi_path %>) sur les endpoints de consommation.
+
 - date: 2026-06-04
   scope: api_particulier
   title: "Fiches API Particulier : le scope est affiché sur chaque donnée"

--- a/site/config/changelogs.yml
+++ b/site/config/changelogs.yml
@@ -1,9 +1,3 @@
-- date: 2026-06-09
-  scope: both
-  title: "Espace développeurs : intégration éditeur et délégations"
-  description: |
-    L'[espace développeurs](<%= developers_path %>) documente désormais l'**intégration éditeur** : comment, avec un **jeton éditeur** unique, appeler nos API **pour le compte d'une administration cliente** via la **délégation**. La nouvelle rubrique couvre les concepts, le listing des délégations (`GET /editeur/api/v1/delegations`), la transmission via les paramètres `recipient` (SIRET du client) et `delegation_id` (UUID, pour lever l'ambiguïté entre plusieurs délégations actives), des exemples `curl` du flux complet et le contrat d'erreurs (`422` ambiguïté, `401`&nbsp;/&nbsp;`403` volontairement opaques). Le paramètre `delegation_id` est par ailleurs documenté dans l'[OpenAPI](<%= developers_openapi_path %>) sur les endpoints de consommation.
-
 - date: 2026-06-04
   scope: api_particulier
   title: "Fiches API Particulier : le scope est affiché sur chaque donnée"

--- a/site/config/locales/api_entreprise/documentation.fr.yml
+++ b/site/config/locales/api_entreprise/documentation.fr.yml
@@ -353,6 +353,94 @@ fr:
 
               Vous souhaitez contribuer un port dans un autre langage&nbsp;? Suivez la checklist de conformité de [`SPECS.md`](https://github.com/datagouv/apistration/blob/develop/clients/SPECS.md){:target="_blank"} et inspirez-vous de l'implémentation Ruby.
 
+          - anchor: 'integration-editeur'
+            title: Intégration éditeur&nbsp;🤝
+            subsections:
+              - title: Le jeton éditeur et la délégation
+                anchor: 'editeur-concepts'
+                content: |+
+                  Un **éditeur de logiciel** intègre l'API&nbsp;Entreprise pour le compte de ses administrations clientes. Plutôt que de gérer un jeton par client, il utilise un **jeton éditeur** unique et permanent et **agit pour le compte d'un client** grâce à la **délégation**.
+
+                  {:.fr-table}
+                  | Notion | Description |
+                  |---|---|
+                  | **Jeton éditeur** | Un jeton JWT unique, fourni à l'éditeur. Il ne porte aucune habilitation en propre&nbsp;: les droits sont résolus à chaque appel via la délégation. |
+                  | **Délégation** | Le lien entre l'éditeur et l'habilitation d'une administration cliente. L'administration délègue à l'éditeur l'usage de son habilitation. |
+                  | **`recipient`** | Le **SIRET de l'administration cliente** pour laquelle l'appel est effectué. Il détermine l'habilitation — et donc les droits — appliquée à la requête. |
+                  | **`delegation_id`** | L'**identifiant (UUID) d'une délégation précise**. Optionnel&nbsp;: nécessaire uniquement lorsque l'éditeur dispose de **plusieurs délégations actives sur le même `recipient`** (voir [contrat d'erreurs](<%= developers_path(anchor: 'editeur-contrat-erreurs') %>)). |
+
+                  {:.fr-highlight}
+                  > ℹ️ À chaque appel, l'API résout l'habilitation effective à partir du jeton éditeur et du `recipient`. Le rate-limit et les scopes appliqués sont ceux de l'habilitation cliente résolue.
+
+              - title: Lister vos délégations
+                anchor: 'editeur-lister-delegations'
+                content: |+
+                  L'endpoint **`GET /editeur/api/v1/delegations`** renvoie la liste des délégations dont dispose l'éditeur authentifié sur l'API courante (déterminée par le domaine appelé). Authentifiez-vous avec votre **jeton éditeur** via l'en-tête `Authorization: Bearer`.
+
+                  {:.fr-h6}
+                  ##### Exemple de requête&nbsp;:
+
+                  ```
+                  curl https://entreprise.api.gouv.fr/editeur/api/v1/delegations \
+                    -H "Authorization: Bearer <VOTRE_JETON_ÉDITEUR>"
+                  ```
+
+                  La réponse est paginée (`meta`) et chaque délégation (`data`) expose&nbsp;:
+
+                  {:.fr-table}
+                  | Champ | Description |
+                  |---|---|
+                  | `id` | UUID de la délégation, à transmettre en `delegation_id` lors d'un appel de consommation. |
+                  | `authorization_request_id` | Identifiant de l'habilitation déléguée. |
+                  | `siret` | SIRET de l'administration cliente — la valeur à passer en `recipient`. |
+                  | `intitule` | Intitulé de l'habilitation. |
+                  | `scopes` | Périmètres ouverts par l'habilitation. |
+                  | `statut` | `active` ou `revoked`. |
+                  | `created_at` | Date de création (ISO&nbsp;8601, UTC). |
+
+                  Le détail du schéma est disponible dans le [Swagger](<%= developers_openapi_path %>){:target="_blank"}.
+
+              - title: Appeler l'API pour le compte d'un client
+                anchor: 'editeur-appeler-pour-un-client'
+                content: |+
+                  Pour interroger un endpoint de consommation au nom d'une administration cliente, ajoutez le paramètre **`recipient`** (SIRET du client) à votre requête, authentifiée avec votre **jeton éditeur**.
+
+                  {:.fr-h6}
+                  ##### Exemple — une seule délégation sur ce client&nbsp;:
+
+                  ```
+                  curl "https://entreprise.api.gouv.fr/v3/insee/unites_legales/418166096?context=Instruction%20de%20dossier&object=Demande%20de%20subvention&recipient=13002526500013" \
+                    -H "Authorization: Bearer <VOTRE_JETON_ÉDITEUR>"
+                  ```
+
+                  Lorsque l'éditeur dispose de **plusieurs délégations actives sur le même `recipient`**, l'appel doit préciser **`delegation_id`** (l'`id` obtenu via le listing des délégations) pour lever l'ambiguïté&nbsp;:
+
+                  {:.fr-h6}
+                  ##### Exemple — plusieurs délégations sur ce client&nbsp;:
+
+                  ```
+                  curl "https://entreprise.api.gouv.fr/v3/insee/unites_legales/418166096?context=Instruction%20de%20dossier&object=Demande%20de%20subvention&recipient=13002526500013&delegation_id=6f3c8d9a-1b2c-4d5e-8f90-abcdef012345" \
+                    -H "Authorization: Bearer <VOTRE_JETON_ÉDITEUR>"
+                  ```
+
+                  {:.fr-highlight}
+                  > ℹ️ `context` et `object` restent obligatoires sur les appels API&nbsp;Entreprise, exactement comme pour un jeton classique. Seul le couple `recipient`&nbsp;/&nbsp;`delegation_id` est spécifique à l'usage éditeur.
+
+              - title: Contrat d'erreurs de la délégation
+                anchor: 'editeur-contrat-erreurs'
+                content: |+
+                  La résolution de la délégation peut renvoyer les erreurs suivantes&nbsp;:
+
+                  {:.fr-table}
+                  | Situation | Réponse |
+                  |---|---|
+                  | `recipient` absent ou SIRET invalide | `422` — paramètre invalide. |
+                  | Plusieurs délégations actives sur le `recipient`, sans `delegation_id` | `422` — délégation ambiguë (code `00212`)&nbsp;: précisez `delegation_id`. |
+                  | Délégation absente, `delegation_id` inconnu, invalide ou révoqué, ou accès non autorisé | `401`&nbsp;/&nbsp;`403` — réponse volontairement opaque. |
+
+                  {:.fr-highlight}
+                  > 🔒 Par choix de sécurité, les cas «&nbsp;délégation manquante&nbsp;», «&nbsp;`delegation_id` invalide ou révoqué&nbsp;» et «&nbsp;accès non autorisé&nbsp;» renvoient une **réponse 401&nbsp;/&nbsp;403 indifférenciée**&nbsp;: l'API ne révèle jamais l'existence d'une délégation à un appelant qui n'y a pas droit.
+
           - anchor: 'kit-de-mise-en-production'
             title: Kit de mise en production&nbsp;🚀
             subsections:

--- a/site/config/locales/api_particulier/documentation.fr.yml
+++ b/site/config/locales/api_particulier/documentation.fr.yml
@@ -613,6 +613,91 @@ fr:
 
               Vous souhaitez contribuer un port dans un autre langage&nbsp;? Suivez la checklist de conformité de [`SPECS.md`](https://github.com/datagouv/apistration/blob/develop/clients/SPECS.md){:target="_blank"} et inspirez-vous de l'implémentation Ruby.
 
+          - anchor: 'integration-editeur'
+            title: Intégration éditeur&nbsp;🤝
+            subsections:
+              - title: Le jeton éditeur et la délégation
+                anchor: 'editeur-concepts'
+                content: |+
+                  Un **éditeur de logiciel** intègre l'API&nbsp;Particulier pour le compte de ses administrations clientes. Plutôt que de gérer un jeton par client, il utilise un **jeton éditeur** unique et permanent et **agit pour le compte d'un client** grâce à la **délégation**.
+
+                  {:.fr-table}
+                  | Notion | Description |
+                  |---|---|
+                  | **Jeton éditeur** | Un jeton JWT unique, fourni à l'éditeur. Il ne porte aucune habilitation en propre&nbsp;: les droits sont résolus à chaque appel via la délégation. |
+                  | **Délégation** | Le lien entre l'éditeur et l'habilitation d'une administration cliente. L'administration délègue à l'éditeur l'usage de son habilitation. |
+                  | **`recipient`** | Le **SIRET de l'administration cliente** pour laquelle l'appel est effectué. Il détermine l'habilitation — et donc les droits — appliquée à la requête. |
+                  | **`delegation_id`** | L'**identifiant (UUID) d'une délégation précise**. Optionnel&nbsp;: nécessaire uniquement lorsque l'éditeur dispose de **plusieurs délégations actives sur le même `recipient`** (voir [contrat d'erreurs](<%= developers_path(anchor: 'editeur-contrat-erreurs') %>)). |
+
+                  {:.fr-highlight}
+                  > ℹ️ À chaque appel, l'API résout l'habilitation effective à partir du jeton éditeur et du `recipient`. Le rate-limit et les scopes appliqués sont ceux de l'habilitation cliente résolue.
+
+              - title: Lister vos délégations
+                anchor: 'editeur-lister-delegations'
+                content: |+
+                  L'endpoint **`GET /editeur/api/v1/delegations`** renvoie la liste des délégations dont dispose l'éditeur authentifié sur l'API courante (déterminée par le domaine appelé). Authentifiez-vous avec votre **jeton éditeur** via l'en-tête `Authorization: Bearer`.
+
+                  {:.fr-h6}
+                  ##### Exemple de requête&nbsp;:
+
+                  ```
+                  curl https://particulier.api.gouv.fr/editeur/api/v1/delegations \
+                    -H "Authorization: Bearer <VOTRE_JETON_ÉDITEUR>"
+                  ```
+
+                  La réponse est paginée (`meta`) et chaque délégation (`data`) expose&nbsp;:
+
+                  {:.fr-table}
+                  | Champ | Description |
+                  |---|---|
+                  | `id` | UUID de la délégation, à transmettre en `delegation_id` lors d'un appel de consommation. |
+                  | `authorization_request_id` | Identifiant de l'habilitation déléguée. |
+                  | `siret` | SIRET de l'administration cliente — la valeur à passer en `recipient`. |
+                  | `intitule` | Intitulé de l'habilitation. |
+                  | `scopes` | Périmètres ouverts par l'habilitation. |
+                  | `statut` | `active` ou `revoked`. |
+                  | `created_at` | Date de création (ISO&nbsp;8601, UTC). |
+
+                  Le détail du schéma est disponible dans le [Swagger](<%= developers_openapi_path %>){:target="_blank"}.
+
+              - title: Appeler l'API pour le compte d'un client
+                anchor: 'editeur-appeler-pour-un-client'
+                content: |+
+                  Pour interroger un endpoint de consommation au nom d'une administration cliente, ajoutez le paramètre **`recipient`** (SIRET du client) à votre requête, authentifiée avec votre **jeton éditeur**. Les paramètres d'identité propres à l'endpoint restent inchangés.
+
+                  {:.fr-h6}
+                  ##### Exemple — une seule délégation sur ce client&nbsp;:
+
+                  ```
+                  curl "https://particulier.api.gouv.fr/v3/dss/quotient_familial/identite?recipient=13002526500013" \
+                    -H "Authorization: Bearer <VOTRE_JETON_ÉDITEUR>"
+                  ```
+
+                  Lorsque l'éditeur dispose de **plusieurs délégations actives sur le même `recipient`**, l'appel doit préciser **`delegation_id`** (l'`id` obtenu via le listing des délégations) pour lever l'ambiguïté&nbsp;:
+
+                  {:.fr-h6}
+                  ##### Exemple — plusieurs délégations sur ce client&nbsp;:
+
+                  ```
+                  curl "https://particulier.api.gouv.fr/v3/dss/quotient_familial/identite?recipient=13002526500013&delegation_id=6f3c8d9a-1b2c-4d5e-8f90-abcdef012345" \
+                    -H "Authorization: Bearer <VOTRE_JETON_ÉDITEUR>"
+                  ```
+
+              - title: Contrat d'erreurs de la délégation
+                anchor: 'editeur-contrat-erreurs'
+                content: |+
+                  La résolution de la délégation peut renvoyer les erreurs suivantes&nbsp;:
+
+                  {:.fr-table}
+                  | Situation | Réponse |
+                  |---|---|
+                  | `recipient` absent ou SIRET invalide | `422` — paramètre invalide. |
+                  | Plusieurs délégations actives sur le `recipient`, sans `delegation_id` | `422` — délégation ambiguë (code `00212`)&nbsp;: précisez `delegation_id`. |
+                  | Délégation absente, `delegation_id` inconnu, invalide ou révoqué, ou accès non autorisé | `401`&nbsp;/&nbsp;`403` — réponse volontairement opaque. |
+
+                  {:.fr-highlight}
+                  > 🔒 Par choix de sécurité, les cas «&nbsp;délégation manquante&nbsp;», «&nbsp;`delegation_id` invalide ou révoqué&nbsp;» et «&nbsp;accès non autorisé&nbsp;» renvoient une **réponse 401&nbsp;/&nbsp;403 indifférenciée**&nbsp;: l'API ne révèle jamais l'existence d'une délégation à un appelant qui n'y a pas droit.
+
           - anchor: 'kit-de-mise-en-production'
             title: Kit de mise en production&nbsp;🚀
             subsections:

--- a/site/spec/features/api_entreprise/documentation_spec.rb
+++ b/site/spec/features/api_entreprise/documentation_spec.rb
@@ -5,4 +5,20 @@ require_relative '../../support/shared_examples/features/documentation'
 
 RSpec.describe 'Documentation pages', app: :api_entreprise do
   it_behaves_like 'a documentation feature'
+
+  describe '/developpeurs editor delegation section' do
+    before { visit developers_path }
+
+    it 'documents the editor delegation integration (concepts, listing, consumption, errors)' do
+      expect(page).to have_css('#integration-editeur')
+      expect(page).to have_css('#editeur-concepts')
+      expect(page).to have_css('#editeur-lister-delegations')
+      expect(page).to have_css('#editeur-appeler-pour-un-client')
+      expect(page).to have_css('#editeur-contrat-erreurs')
+
+      expect(page).to have_text('recipient')
+      expect(page).to have_text('delegation_id')
+      expect(page).to have_text('/editeur/api/v1/delegations')
+    end
+  end
 end

--- a/site/spec/features/api_particulier/documentation_spec.rb
+++ b/site/spec/features/api_particulier/documentation_spec.rb
@@ -15,4 +15,20 @@ RSpec.describe 'Documentation pages', app: :api_particulier do
       expect(page).to have_css('#savoir-quels-champs-necessitent-un-scope')
     end
   end
+
+  describe '/developpeurs editor delegation section' do
+    before { visit developers_path }
+
+    it 'documents the editor delegation integration (concepts, listing, consumption, errors)' do
+      expect(page).to have_css('#integration-editeur')
+      expect(page).to have_css('#editeur-concepts')
+      expect(page).to have_css('#editeur-lister-delegations')
+      expect(page).to have_css('#editeur-appeler-pour-un-client')
+      expect(page).to have_css('#editeur-contrat-erreurs')
+
+      expect(page).to have_text('recipient')
+      expect(page).to have_text('delegation_id')
+      expect(page).to have_text('/editeur/api/v1/delegations')
+    end
+  end
 end


### PR DESCRIPTION
## Contexte

[API-6652](https://linear.app/pole-api/issue/API-6652) — D1 (V1). Publie la documentation développeur de l'**intégration éditeur** en se limitant à la **surface déjà livrée** (T8 ✅, T12 ✅). Hors périmètre → D1b (API-6860) : self-service tokens, whitelist IP, rotation, header `X-Delegation-Id` (**non documenté ici**).

Scope validé : **les deux API** (Entreprise + Particulier) — la délégation est câblée dans les deux `base_controller`.

## Changements

**A. Doc utilisateur (`/developpeurs`, AE + AP)** — nouvelle rubrique « Intégration éditeur » : concepts (jeton éditeur, délégation, `delegation_id`), listing `GET /editeur/api/v1/delegations`, transmission `recipient` + `delegation_id`, exemples curl du flux complet, contrat d'erreurs (422 ambiguïté / 401-403 opaque). + entrée `changelogs.yml` (`scope: both`).

**B. OpenAPI** — `delegation_id` (query, optionnel, UUID) ajouté au helper rswag partagé + `00_commons.yml` ; erreur 422 ambiguïté (`00212`) injectée sur les endpoints de consommation des deux API (extension du merge-path de `ErrorInjector`). Swagger régénéré via `siade/bin/generate_swagger.sh`.

**C. SDK Ruby** — `bin/scaffold_resources --api all` régénéré : chaque méthode de consommation expose un kwarg optionnel `delegation_id:` (rétro-compatible, nil-compacté).

## Tests

- Site : features doc AE + AP (assertions sur la nouvelle rubrique), changelog specs — vert.
- siade : `Openapi::ErrorInjector` spec (build-path + merge-path du 00212) — 11 ex. vert.
- Régénération swagger : **783 examples, 0 failures** ; `delegation_id` (211 AE / 144 AP) et `00212` (105 AE / 72 AP) présents.
- SDK : `api_entreprise` 40, `api_particulier` 18, `commons` 70 — vert ; `scaffold_resources --api all --check` et `sync_commons --check` OK.

## Suite (post-merge, hors PR)

Release SemVer des gems = **PATCH** (param optionnel via régén scaffolding, cf. skill `release-new-version`), en PR de release dédiée par gem + tag sur le merge commit `develop`. À noter : `api_particulier` a un **0.1.2 in-flight** (version.rb bumpée, jamais publié — rubygems = 0.1.1) → décision mainteneur (plier dans 0.1.2 ou couper 0.1.3). Publication rubygems (tag → OIDC) volontairement non faite ici.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
