### PR TITLE
Reset Timecop after each OpenBureauDate example to stop clock leak

### DIFF
--- a/site/spec/services/open_bureau_date_spec.rb
+++ b/site/spec/services/open_bureau_date_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe OpenBureauDate, type: :service do
+  after { Timecop.return }
+
   describe '#next' do
     subject { described_class.new.next_date.to_s }
 


### PR DESCRIPTION
open_bureau_date_spec freezes Timecop in seven `before` blocks (to dates in 2021/2022/2024) but never calls Timecop.return, and there is no global Timecop.return guard in rails_helper. Timecop state is process-global, so once any example here runs, the clock stays frozen in the past until some later spec happens to touch Timecop again.

Under RSpec's randomized order this leaks into provider/dashboard_query_spec: its `before` creates access_logs at the frozen (past) time, but the ConsumptionSummary SQL view filters on `timestamp >= now() - 1.5y` using the real Postgres clock, which Timecop cannot affect. Logs dated 2021/2024 fall outside that window, the view returns no rows, and every dashboard query aggregates to 0 — making the whole file fail intermittently on CI and on develop, depending on run order.

Add `after { Timecop.return }` at the describe level so the clock is restored after each example, scoping the freezes to where they belong.