### PR TITLE
Fix CI failures for DGFIP TVA endpoint

### DIFF
--- a/siade/config/endpoints_with_test_case.yml
+++ b/siade/config/endpoints_with_test_case.yml
@@ -34,7 +34,7 @@
 
 - name: 'DGFIP Numéros de TVA intracommunautaire'
   api: 'entreprise'
-  path: '/v3/dgfip/numero_tva/217500016'
+  path: '/v3/dgfip/unites_legales/217500016/numero_tva'
 
 - name: 'ADEME Certification RGE'
   api: 'entreprise'

--- a/siade/spec/requests/api_entreprise/v3_and_more/dgfip/tva/v3_spec.rb
+++ b/siade/spec/requests/api_entreprise/v3_and_more/dgfip/tva/v3_spec.rb
@@ -15,10 +15,6 @@ RSpec.describe 'DGFIP: Numéro de TVA intracommunautaire', api: :entreprise, typ
         let(:siren) { valid_siren(:dgfip) }
       end
 
-      forbidden_request do
-        let(:siren) { valid_siren(:dgfip) }
-      end
-
       too_many_requests(DGFIP::TVA) do
         let(:siren) { valid_siren(:dgfip) }
       end


### PR DESCRIPTION
- endpoints_with_test_case.yml: update path to new URL convention
- v3_spec.rb: remove forbidden_request (scope [] means all valid tokens have access, so no 403 is possible; same pattern as european_commission/vies)

@skelz0r pour info