### PR TITLE
Fix(docker): add commons volume

### DIFF
--- a/site/docker-compose.yml
+++ b/site/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     command: bin/rails server --port 5000 --binding 0.0.0.0
     volumes:
       - .:/app:consistent
+      - ../commons:/commons:consistent
     ports:
       - "5000:5000"
     environment:
@@ -34,6 +35,7 @@ services:
     command: bundle exec good_job start
     volumes:
       - .:/app
+      - ../commons:/commons
     depends_on:
       - db
       - redis


### PR DESCRIPTION
Previously the symlinks to commons weren't
accessible to the docker container

Which made endpoint catalogue not work

@skelz0r FYI (je merge pour @DorineLam )