### PR TITLE
feat: partial swagger filtering

### DIFF
--- a/site/app/controllers/api_entreprise/open_api_controller.rb
+++ b/site/app/controllers/api_entreprise/open_api_controller.rb
@@ -1,0 +1,9 @@
+class APIEntreprise::OpenAPIController < APIEntrepriseController
+  def show
+    if params[:operation_id].present?
+      render plain: APIEntreprise::OpenAPIDefinition.instance.open_api_partial_definition_content(Array(params[:operation_id]))
+    else
+      render plain: APIEntreprise::OpenAPIDefinition.instance.open_api_definition_content
+    end
+  end
+end

--- a/site/app/controllers/api_particulier/open_api_controller.rb
+++ b/site/app/controllers/api_particulier/open_api_controller.rb
@@ -1,0 +1,9 @@
+class APIParticulier::OpenAPIController < APIParticulierController
+  def show
+    if params[:operation_id].present?
+      render plain: APIParticulier::OpenAPIDefinition.instance.open_api_partial_definition_content(Array(params[:operation_id]))
+    else
+      render plain: APIParticulier::OpenAPIDefinition.instance.open_api_definition_content
+    end
+  end
+end

--- a/site/app/services/abstract_open_api_definition.rb
+++ b/site/app/services/abstract_open_api_definition.rb
@@ -41,6 +41,14 @@ class AbstractOpenAPIDefinition
     backend.merge('paths' => paths).to_yaml
   end
 
+  def open_api_partial_definition_content(operation_ids)
+    paths = backend['paths'].select do |_, definition|
+      operation_ids.include?(definition.dig('get', 'responses', '200', 'x-operationId'))
+    end
+
+    backend.merge('paths' => paths).to_yaml
+  end
+
   def open_api_definition_content
     local_path.read
   end

--- a/site/config/routes/api_entreprise.rb
+++ b/site/config/routes/api_entreprise.rb
@@ -72,7 +72,7 @@ constraints(APIEntrepriseDomainConstraint.new) do
 
     get '/apis/status', to: 'pages#current_status', as: :current_status
 
-    get '/open-api.yml', to: ->(env) { [200, {}, [APIEntreprise::OpenAPIDefinition.instance.open_api_definition_content]] }, as: :openapi_definition
+    get '/open-api.yml', to: 'open_api#show', as: :openapi_definition
     get '/open-api-without-deprecated-paths.yml', to: ->(env) { [200, {}, [APIEntreprise::OpenAPIDefinition.instance.open_api_without_deprecated_paths_definition_content]] }, as: :openapi_without_deprecated_definition
     get '/robots.txt', to: ->(env) { [200, {}, [File.read('config/seo/robots.txt') % { app: 'entreprise' }]] }
 

--- a/site/config/routes/api_particulier.rb
+++ b/site/config/routes/api_particulier.rb
@@ -24,7 +24,7 @@ constraints(APIParticulierDomainConstraint.new) do
     get '/catalogue/*uid/status', as: :endpoint_status, to: 'endpoints#status'
     get '/catalogue/*uid', as: :endpoint, to: 'endpoints#show'
 
-    get '/open-api.yml', to: ->(env) { [200, {}, [APIParticulier::OpenAPIDefinition.instance.open_api_definition_content]] }, as: :openapi_definition
+    get '/open-api.yml', to: 'open_api#show', as: :openapi_definition
     get '/open-api-v2.yml', to: ->(env) { [200, {}, [APIParticulier::OpenAPIDefinition.instance.open_api_v2_definition_content]] }, as: :openapi_v2_definition
     get '/open-api-v3.yml', to: ->(env) { [200, {}, [APIParticulier::OpenAPIDefinition.instance.open_api_v3_definition_content]] }, as: :openapi_v3_definition
     get '/open-api-without-deprecated-paths.yml', to: ->(env) { [200, {}, [APIParticulier::OpenAPIDefinition.instance.open_api_without_deprecated_paths_definition_content]] }, as: :openapi_without_deprecated_definition

--- a/site/spec/requests/open_api_spec.rb
+++ b/site/spec/requests/open_api_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /open-api.yml' do
+  context 'when on API Entreprise' do
+    before { host! 'entreprise.api.localtest.me' }
+
+    it 'returns 200' do
+      allow(APIEntreprise::OpenAPIDefinition.instance)
+        .to receive(:open_api_definition_content)
+        .and_return("info:\n  title: Test\npaths: {}\n")
+
+      get '/open-api.yml'
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns the full definition when no operation_id params are given' do
+      allow(APIEntreprise::OpenAPIDefinition.instance)
+        .to receive(:open_api_definition_content)
+        .and_return("info:\n  title: Full\npaths: {}\n")
+
+      get '/open-api.yml'
+
+      expect(APIEntreprise::OpenAPIDefinition.instance)
+        .to have_received(:open_api_definition_content)
+      expect(response.body).to eq("info:\n  title: Full\npaths: {}\n")
+    end
+
+    it 'passes all operation_ids to the partial service' do
+      allow(APIEntreprise::OpenAPIDefinition.instance)
+        .to receive(:open_api_partial_definition_content)
+        .and_return("info:\n  title: Partial\npaths: {}\n")
+
+      get '/open-api.yml?operation_id[]=op_id_one&operation_id[]=op_id_two'
+
+      expect(APIEntreprise::OpenAPIDefinition.instance)
+        .to have_received(:open_api_partial_definition_content)
+        .with(%w[op_id_one op_id_two])
+    end
+
+    it 'returns the filtered YAML when operation_id params are given' do
+      allow(APIEntreprise::OpenAPIDefinition.instance)
+        .to receive(:open_api_partial_definition_content)
+        .and_return("info:\n  title: Filtered\npaths: {}\n")
+
+      get '/open-api.yml?operation_id[]=op_id_one'
+
+      expect(response.body).to eq("info:\n  title: Filtered\npaths: {}\n")
+    end
+  end
+
+  context 'when on API Particulier' do
+    before { host! 'particulier.api.localtest.me' }
+
+    it 'returns 200' do
+      allow(APIParticulier::OpenAPIDefinition.instance)
+        .to receive(:open_api_definition_content)
+        .and_return("info:\n  title: Test\npaths: {}\n")
+
+      get '/open-api.yml'
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns the full definition when no operation_id params are given' do
+      allow(APIParticulier::OpenAPIDefinition.instance)
+        .to receive(:open_api_definition_content)
+        .and_return("info:\n  title: Full Particulier\npaths: {}\n")
+
+      get '/open-api.yml'
+
+      expect(APIParticulier::OpenAPIDefinition.instance)
+        .to have_received(:open_api_definition_content)
+      expect(response.body).to eq("info:\n  title: Full Particulier\npaths: {}\n")
+    end
+
+    it 'passes all operation_ids to the partial service' do
+      allow(APIParticulier::OpenAPIDefinition.instance)
+        .to receive(:open_api_partial_definition_content)
+        .and_return("info:\n  title: Partial\npaths: {}\n")
+
+      get '/open-api.yml?operation_id[]=op_id_one&operation_id[]=op_id_two'
+
+      expect(APIParticulier::OpenAPIDefinition.instance)
+        .to have_received(:open_api_partial_definition_content)
+        .with(%w[op_id_one op_id_two])
+    end
+
+    it 'returns the filtered YAML when operation_id params are given' do
+      allow(APIParticulier::OpenAPIDefinition.instance)
+        .to receive(:open_api_partial_definition_content)
+        .and_return("info:\n  title: Filtered Particulier\npaths: {}\n")
+
+      get '/open-api.yml?operation_id[]=op_id_one'
+
+      expect(response.body).to eq("info:\n  title: Filtered Particulier\npaths: {}\n")
+    end
+  end
+end

--- a/site/spec/services/abstract_open_api_definition_spec.rb
+++ b/site/spec/services/abstract_open_api_definition_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe AbstractOpenAPIDefinition do
+  subject(:definition) { APIEntreprise::OpenAPIDefinition.instance }
+
+  describe '#open_api_partial_definition_content' do
+    let(:backend) do
+      {
+        'info' => { 'title' => 'Test API' },
+        'components' => { 'schemas' => {} },
+        'paths' => {
+          '/v3/foo/bar' => {
+            'get' => {
+              'responses' => {
+                '200' => { 'x-operationId' => 'api_entreprise_v3_foo_bar' }
+              }
+            }
+          },
+          '/v3/baz/qux' => {
+            'get' => {
+              'responses' => {
+                '200' => { 'x-operationId' => 'api_entreprise_v3_baz_qux' }
+              }
+            }
+          }
+        }
+      }
+    end
+
+    let(:original_backend) { definition.instance_variable_get(:@backend) }
+
+    before do
+      original_backend
+      definition.instance_variable_set(:@backend, backend)
+    end
+
+    after do
+      definition.instance_variable_set(:@backend, original_backend)
+    end
+
+    it 'returns only the path matching the given operation_id' do
+      result = YAML.safe_load(definition.open_api_partial_definition_content(%w[api_entreprise_v3_foo_bar]))
+
+      expect(result['paths'].keys).to contain_exactly('/v3/foo/bar')
+    end
+
+    it 'returns multiple paths when multiple operation_ids are given' do
+      result = YAML.safe_load(
+        definition.open_api_partial_definition_content(
+          %w[api_entreprise_v3_foo_bar api_entreprise_v3_baz_qux]
+        )
+      )
+
+      expect(result['paths'].keys).to contain_exactly('/v3/foo/bar', '/v3/baz/qux')
+    end
+
+    it 'preserves all top-level keys outside paths' do
+      result = YAML.safe_load(definition.open_api_partial_definition_content(%w[api_entreprise_v3_foo_bar]))
+
+      expect(result['info']).to eq({ 'title' => 'Test API' })
+      expect(result['components']).to eq({ 'schemas' => {} })
+    end
+
+    it 'returns empty paths when no operation_ids match' do
+      result = YAML.safe_load(definition.open_api_partial_definition_content(%w[nonexistent]))
+
+      expect(result['paths']).to be_empty
+    end
+
+    it 'returns empty paths when called with an empty array' do
+      result = YAML.safe_load(definition.open_api_partial_definition_content([]))
+
+      expect(result['paths']).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
Review: ça se lit d'une traite

## Summary

- Adds `GET /open-api-partial.yml?operation_id=foo&operation_id=bar` to both API Entreprise and API Particulier
- Returns a complete, valid OpenAPI YAML document filtered to only the paths whose `x-operationId` matches the requested list
- Multiple operation IDs passed as repeated query params; malformed query strings return 400

## Implementation

- `AbstractOpenAPIDefinition#open_api_partial_definition_content(operation_ids)` — filters `backend['paths']` by `get.responses.200.x-operationId`, returns full doc with all top-level keys preserved
- Two inline Rack lambda routes (one per API) parse params via `Rack::Utils.parse_query` + `Array(...)`

## Test Plan

- [x] `bundle exec rspec spec/services/abstract_open_api_definition_spec.rb` — 5 unit tests (single match, multi-match, key preservation, no match, empty input)
- [x] `bundle exec rspec spec/requests/open_api_partial_spec.rb` — 8 request tests covering both APIs (200, param forwarding, empty array, body passthrough)
- [x] Verify manually: `curl 'https://entreprise.api.gouv.fr/open-api.yml?operation_id=api_entreprise_v3_acoss_attestations_sociales'`