### PR TITLE
fix(a11y): skip links, main landmark and role=banner (RGAA 9.2, 12.6, 12.7)

### DIFF
--- a/site/app/views/layouts/api_entreprise/application.html.erb
+++ b/site/app/views/layouts/api_entreprise/application.html.erb
@@ -21,17 +21,28 @@
   </head>
 
   <body>
+    <div class="fr-skiplinks">
+      <nav class="fr-container" role="navigation" aria-label="Accès rapide">
+        <ul class="fr-skiplinks__list">
+          <li><a class="fr-link" href="#contenu">Contenu</a></li>
+          <li><a class="fr-link" href="#navigation-header-menu">Menu</a></li>
+          <li><a class="fr-link" href="#footer">Pied de page</a></li>
+        </ul>
+      </nav>
+    </div>
     <%= render partial: 'shared/development_warning' %>
     <%= render partial: 'shared/impersonate' %>
     <%= render partial: 'shared/matomo' %>
     <%= render partial: 'shared/announcement_banner' %>
     <%= render partial: 'shared/api_entreprise/header' %>
 
-    <% if content_for?(:no_container) %>
-      <%= yield(:no_container) %>
-    <% else %>
-      <%= render partial: 'shared/api_entreprise/containerized_body' %>
-    <% end %>
+    <main id="contenu">
+      <% if content_for?(:no_container) %>
+        <%= yield(:no_container) %>
+      <% else %>
+        <%= render partial: 'shared/api_entreprise/containerized_body' %>
+      <% end %>
+    </main>
 
     <% unless @no_newsletter_banner %>
       <%= render partial: 'shared/newsletter_banner' %>

--- a/site/app/views/layouts/api_particulier/application.html.erb
+++ b/site/app/views/layouts/api_particulier/application.html.erb
@@ -21,17 +21,28 @@
   </head>
 
   <body>
+    <div class="fr-skiplinks">
+      <nav class="fr-container" role="navigation" aria-label="Accès rapide">
+        <ul class="fr-skiplinks__list">
+          <li><a class="fr-link" href="#contenu">Contenu</a></li>
+          <li><a class="fr-link" href="#navigation-header-menu">Menu</a></li>
+          <li><a class="fr-link" href="#footer">Pied de page</a></li>
+        </ul>
+      </nav>
+    </div>
     <%= render partial: 'shared/development_warning' %>
     <%= render partial: 'shared/impersonate' %>
     <%= render partial: 'shared/matomo' %>
     <%= render partial: 'shared/announcement_banner' %>
     <%= render partial: 'shared/api_particulier/header' %>
 
-    <% if content_for?(:no_container) %>
-      <%= yield(:no_container) %>
-    <% else %>
-      <%= render partial: 'shared/api_particulier/containerized_body' %>
-    <% end %>
+    <main id="contenu">
+      <% if content_for?(:no_container) %>
+        <%= yield(:no_container) %>
+      <% else %>
+        <%= render partial: 'shared/api_particulier/containerized_body' %>
+      <% end %>
+    </main>
 
     <% unless @no_newsletter_banner %>
       <%= render partial: 'shared/newsletter_banner' %>

--- a/site/app/views/shared/api_entreprise/_header.html.erb
+++ b/site/app/views/shared/api_entreprise/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="fr-header">
+<header class="fr-header" role="banner">
   <div class="fr-header__body">
     <div class="fr-container">
       <div class="fr-header__body-row">

--- a/site/app/views/shared/api_particulier/_header.html.erb
+++ b/site/app/views/shared/api_particulier/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="fr-header">
+<header class="fr-header" role="banner">
   <div class="fr-header__body">
     <div class="fr-container">
       <div class="fr-header__body-row">

--- a/site/spec/features/api_entreprise/pages_spec.rb
+++ b/site/spec/features/api_entreprise/pages_spec.rb
@@ -4,4 +4,14 @@ RSpec.describe 'Simple pages', app: :api_entreprise do
   it_behaves_like 'static pages feature',
     developers_content: 'siret',
     expected_api_name: 'API Entreprise'
+
+  it_behaves_like 'layout landmarks', %i[root_path cas_usages_path endpoints_path faq_index_path]
+
+  context 'when authenticated' do
+    let(:user) { create(:user) }
+
+    before { login_as(user) }
+
+    it_behaves_like 'layout landmarks', %i[authorization_requests_path]
+  end
 end

--- a/site/spec/features/api_particulier/pages_spec.rb
+++ b/site/spec/features/api_particulier/pages_spec.rb
@@ -8,4 +8,14 @@ RSpec.describe 'Simple pages', app: :api_particulier do
     developers_content: 'Quotient familial',
     expected_api_name: 'API Particulier',
     unexpected_api_name: 'API Entreprise'
+
+  it_behaves_like 'layout landmarks', %i[root_path cas_usages_path endpoints_path faq_index_path]
+
+  context 'when authenticated' do
+    let(:user) { create(:user, :with_token) }
+
+    before { login_as(user) }
+
+    it_behaves_like 'layout landmarks', %i[api_particulier_user_profile_path]
+  end
 end

--- a/site/spec/support/shared_examples/features/layout_landmarks.rb
+++ b/site/spec/support/shared_examples/features/layout_landmarks.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.shared_examples 'layout landmarks' do |path_helpers = [:root_path]|
+  Array(path_helpers).each do |path_helper|
+    describe "RGAA 9.2/12.6/12.7 on #{path_helper}" do
+      before { visit send(path_helper) }
+
+      it 'has a main landmark targeting #contenu' do
+        expect(page).to have_css('main#contenu')
+      end
+
+      it 'has a banner landmark on the header' do
+        expect(page).to have_css('header[role="banner"]')
+      end
+
+      it 'has a skip link to main content' do
+        expect(page).to have_css('.fr-skiplinks a[href="#contenu"]')
+      end
+
+      it 'has a skip link to navigation' do
+        expect(page).to have_css('.fr-skiplinks a[href="#navigation-header-menu"]')
+      end
+
+      it 'has a skip link to footer' do
+        expect(page).to have_css('.fr-skiplinks a[href="#footer"]')
+      end
+    end
+  end
+end


### PR DESCRIPTION
RGAA 9.2, 12.6, 12.7 — landmarks de navigation sur les deux sites.

`fr-skiplinks` en premier enfant de `<body>` (liens vers `#contenu`, `#navigation-header-menu`, `#footer`), contenu principal dans `<main id="contenu">`, `role="banner"` sur les deux `<header>`. Shared example RSpec couvrant les 5 assertions sur les pages principales et authentifiées.

Closes [API-6743](https://linear.app/pole-api/issue/API-6743)