### PR TITLE
feat(a11y): dynamic <title> per page (RGAA 8.5/8.6)

### DIFF
--- a/site/app/helpers/application_helper.rb
+++ b/site/app/helpers/application_helper.rb
@@ -36,6 +36,13 @@ module ApplicationHelper
     I18n.t(i18n_key)
   end
 
+  def full_page_title
+    namespace = controller_path.split('/').first
+    site_name = t("layouts.#{namespace}.application.title")
+    title = content_for?(:page_title) ? content_for(:page_title) : static_page_title
+    title.present? ? "#{title} — #{site_name}" : site_name
+  end
+
   def icon(kind)
     "<span class=\"icon #{kind}\" aria-hidden=\"true\"></span>".html_safe
   end
@@ -46,5 +53,14 @@ module ApplicationHelper
 
   def support_email
     t("#{namespace}.support_email")
+  end
+
+  private
+
+  def static_page_title
+    key = "#{controller_path.tr('/', '.')}.#{action_name}.page_title"
+    return t(key).presence if I18n.exists?(key)
+
+    raise "Missing page title for '#{key}'. Use content_for(:page_title) or add the i18n key." if Rails.env.local?
   end
 end

--- a/site/app/models/abstract_blog_post.rb
+++ b/site/app/models/abstract_blog_post.rb
@@ -4,6 +4,10 @@ class AbstractBlogPost
 
   attr_accessor :id, :content
 
+  def title
+    content.lines.find { |l| l.start_with?('# ') }&.delete_prefix('# ')&.strip
+  end
+
   def self.find(id)
     file = Rails.root.join('config/blog_posts', api, "#{id}.md")
 

--- a/site/app/views/api_entreprise/cas_usages/show.html.erb
+++ b/site/app/views/api_entreprise/cas_usages/show.html.erb
@@ -1,1 +1,2 @@
+<% content_for :page_title, @cas_usage.name %>
 <%= render partial: 'shared/cas_usages/show', locals: { api: 'api_entreprise' } %>

--- a/site/app/views/api_entreprise/endpoints/show.html.erb
+++ b/site/app/views/api_entreprise/endpoints/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :page_title, @endpoint.title %>
 <% layout_main_bloc = 8 %>
 <article id="<%= dom_id(@endpoint) %>" class="endpoint">
   <h1>

--- a/site/app/views/api_particulier/cas_usages/show.html.erb
+++ b/site/app/views/api_particulier/cas_usages/show.html.erb
@@ -1,1 +1,2 @@
+<% content_for :page_title, @cas_usage.name %>
 <%= render partial: 'shared/cas_usages/show', locals: { api: 'api_particulier' } %>

--- a/site/app/views/api_particulier/endpoints/show.html.erb
+++ b/site/app/views/api_particulier/endpoints/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :page_title, @endpoint.title %>
 <% layout_main_bloc = 8 %>
 <article id="<%= dom_id(@endpoint) %>" class="endpoint">
   <h1>

--- a/site/app/views/layouts/api_entreprise/application.html.erb
+++ b/site/app/views/layouts/api_entreprise/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="fr" data-fr-scheme="light">
   <head>
-    <title><%= t('.title') %></title>
+    <title><%= full_page_title %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <% unless Rails.env.production? %>
       <meta name="robots" content="noindex">

--- a/site/app/views/layouts/api_particulier/application.html.erb
+++ b/site/app/views/layouts/api_particulier/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="fr" data-fr-scheme="light">
   <head>
-    <title><%= t('.title') %></title>
+    <title><%= full_page_title %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <% unless Rails.env.production? %>
       <meta name="robots" content="noindex">

--- a/site/app/views/shared/authorization_requests/show.html.erb
+++ b/site/app/views/shared/authorization_requests/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :page_title, @authorization_request.intitule %>
 <div class="fr-container fr-pr-0 fr-pl-0" data-controller="anchor-buttons">
   <div class="fr-grid-row">
     <div class="fr-col-12 fr-col-md-3 fr-pr-0 fr-pl-0">

--- a/site/app/views/shared/blog_posts/show.html.erb
+++ b/site/app/views/shared/blog_posts/show.html.erb
@@ -1,1 +1,2 @@
+<% content_for :page_title, @blog_post.title %>
 <%= markdown_to_html(@blog_post.content) %>

--- a/site/app/views/shared/endpoints/example.html.erb
+++ b/site/app/views/shared/endpoints/example.html.erb
@@ -1,3 +1,4 @@
+<% content_for :page_title, @endpoint.title %>
 <turbo-frame id="main-modal-content">
   <div class="single-page">
     <h3 class="center">

--- a/site/config/i18n-tasks.yml
+++ b/site/config/i18n-tasks.yml
@@ -124,6 +124,7 @@ ignore_unused:
   - 'editors.roles.*'
   - 'editors.deployment_types.*'
   - 'api_particulier.reporters_mailer.*'
+  - '*.page_title'
   - 'shared.tokens.prolong.description.future'
   - 'shared.tokens.prolong.description.past'
   - 'activerecord.attributes.*'

--- a/site/config/locales/api_entreprise/fr.yml
+++ b/site/config/locales/api_entreprise/fr.yml
@@ -55,6 +55,7 @@ fr:
   api_entreprise:
     download_attestations:
       new:
+        page_title: Télécharger des attestations
         interface: "Interface d'appel"
         description: "Récupérez les attestations sociales ou fiscales d'une entreprise ou d'une association, en entrant son numéro SIREN."
         description_cgu_html: "Pour rappel, les %{href} vous engagent à <strong>ne pas diffuser les données reçues, ici les attestations fiscales et sociales, à des tiers non-autorisés</strong>."
@@ -65,6 +66,8 @@ fr:
           label: "🔑 Jeton d'habilitation :"
         siren_number:
           label: 'Numéro de SIREN :'
+      create:
+        page_title: Télécharger des attestations
       result:
         download_attestation_fiscale_cta: 'Attestation fiscale (PDF)'
         download_attestation_sociale_cta: 'Attestation sociale (PDF)'
@@ -77,6 +80,16 @@ fr:
         attestation_sociale_not_downloadable: "Attestation sociale non‑téléchargeable"
         attestation_fiscale_not_downloadable: 'Attestation fiscale non‑téléchargeable'
     tokens:
+      show:
+        page_title: ""
+      stats:
+        page_title: Statistiques d'utilisation
+      renew:
+        page_title: ""
+      prolong:
+        page_title: Prolonger mon jeton
+      ask_for_prolongation:
+        page_title: ""
       token:
         scope:
           etablissements:
@@ -193,7 +206,14 @@ fr:
             label: Data Subvention || API Subventions
 
     sessions:
+      new:
+        page_title: Se connecter
+      create_from_magic_link:
+        page_title: ""
+      dev_login:
+        page_title: ""
       create_from_oauth:
+        page_title: ""
         not_found:
           title: "Votre compte ne semble pas être rattaché à une habilitation API Entreprise."
           description: "Veuillez vérifier que l'e-mail %{email} utilisé ici correspond à l'e-mail utilisé lors de votre demande d'habilitation API Entreprise. \n\n
@@ -201,12 +221,15 @@ fr:
             Après validation de celle-ci, vous pourrez vous connecter au compte API Entreprise."
 
       failure:
+        page_title: ""
         unknown: Une erreur inconnue est survenue, veuillez contacter le support.
       after_logout:
+        page_title: ""
         success: Déconnexion réussie.
 
     public_token_magic_links:
       show:
+        page_title: ""
         error:
           expired:
             title: Lien expiré
@@ -223,6 +246,7 @@ fr:
 
     endpoints:
       index:
+        page_title: Catalogue des API
         title: "Catalogue des API"
         search:
           label: "Rechercher une API"
@@ -325,10 +349,12 @@ fr:
         test_cases: "Cas de tests"
     faq:
       index:
+        page_title: FAQ & contact
         title: "FAQ & contact"
 
     cas_usages:
       index:
+        page_title: "Cas d'usages"
         title: "Cas d'usages"
         description: "Consultez les <strong>fiches pratiques des cas d’utilisation</strong> de l’API Entreprise.<br>Retrouvez, entre autres, les <strong>données utiles</strong> pour les cas d’usages."
         cards:
@@ -352,6 +378,7 @@ fr:
             description: "Donnez accès à l'API Entreprise à vos clients publics."
     pages:
       newsletter:
+        page_title: Lettres d'information
         main:
           title: Abonnez-vous à nos lettres d'infos&nbsp;!
           newsletter_title: 💌 Actualités et guides pratiques&nbsp;:&nbsp;
@@ -368,6 +395,7 @@ fr:
           title: Lettres d'information
           description: Abonnez-vous à nos différentes lettres d'informations pour être informé <strong>des actualités, des évènements, des nouveautés et des ruptures de service.</strong>
       home:
+        page_title: ""
         section_welcome:
           title: <strong>Vous êtes un acteur public ?</strong><br>Gagnez du temps dans vos démarches<br> entreprises & associations&nbsp;!
           subtitle: <br><strong>Intégrez l'API&nbsp;Entreprise👇</strong>
@@ -438,7 +466,21 @@ fr:
           swagger_link: Spécifications techniques de chaque API
           swagger_description: Utilisez notre Swagger (OpenApi)
           status_link: Statuts des API
+      cgu:
+        page_title: "Conditions générales d’utilisation"
+      mentions:
+        page_title: Mentions légales
+      donnees_personnelles:
+        page_title: Données personnelles
+      accessibility:
+        page_title: Accessibilité
+      current_status:
+        page_title: Statut des API
+      redoc:
+        page_title: ""
     documentation:
+      developers:
+        page_title: Espace développeur
       index:
         card_swagger_link: 🕹 Swagger
         card_swagger_description: Spécifications techniques de chacune des API&nbsp;:&nbsp;<br/>- Paramètres d’appels<br/>- Détail de la réponse JSON<br/>- Codes erreurs
@@ -448,6 +490,28 @@ fr:
         link_specs: 🎛 Spécifications générales
         link_kit: 🚀 Kit de mise en production
         link_preprod: 🧪 Environnement de test
+    stats:
+      index:
+        page_title: Statistiques
+    users:
+      profile:
+        page_title: Mon compte
+    authorization_requests:
+      index:
+        page_title: Mes demandes
+    transfer_tokens:
+      new:
+        page_title: ""
+    prolong_token_wizard:
+      start:
+        page_title: ""
+      show:
+        page_title: ""
+      finished:
+        page_title: ""
+    changelogs:
+      index:
+        page_title: Nouveautés
   beta:
     label: Version beta
     color: purple-glycine

--- a/site/config/locales/api_particulier/fr.yml
+++ b/site/config/locales/api_particulier/fr.yml
@@ -57,6 +57,7 @@ fr:
   api_particulier:
     pages:
       home:
+        page_title: ""
         section_welcome:
           title: <strong>Vous êtes un acteur public ?</strong><br />Gagnez du temps dans vos démarches<br />auprès des particuliers !
           subtitle: Intégrez l'API Particulier 👇
@@ -119,6 +120,7 @@ fr:
           swagger_link: Spécifications techniques de chaque API
           swagger_description: Utilisez notre Swagger (OpenAPI)
       newsletter:
+        page_title: Lettres d'information
         banner:
           title: Restez informé des nouveautés de l'API Particulier
           description: Recevez les dernières actualités de l'API Particulier et des informations sur les nouvelles API disponibles.
@@ -131,9 +133,22 @@ fr:
           changelog_title: 📋 Nouveautés / changelog&nbsp;:&nbsp;
           changelog_description: Retrouvez l'historique des évolutions du service (nouvelles API, montées de version, dépréciations) et abonnez-vous pour recevoir un récapitulatif hebdomadaire&nbsp;:&nbsp;
           changelog_button: Voir les nouveautés
+      cgu:
+        page_title: "Conditions générales d'utilisation"
+      mentions:
+        page_title: Mentions légales
+      donnees_personnelles:
+        page_title: Données personnelles
+      accessibility:
+        page_title: Accessibilité
+      current_status:
+        page_title: Statut des API
+      redoc:
+        page_title: ""
 
     endpoints:
       index:
+        page_title: Catalogue des API
         title: Catalogue des API
         search:
           label: "Rechercher une API"
@@ -224,10 +239,12 @@ fr:
         test_cases: "Cas de tests"
     faq:
       index:
+        page_title: FAQ & contact
         title: "FAQ & contact"
 
     cas_usages:
       index:
+        page_title: "Cas d'usages & modalités d'appel"
         title: "Cas d'usages & modalités d'appel"
         description: "Consultez les <strong>fiches pratiques des cas d’usages & les guides des modalités d'appel</strong> de l’API Particulier"
         cards:
@@ -259,6 +276,16 @@ fr:
             title: "Formulaire de collecte du QF"
             description: "Collecter facilement le quotient familial CAF ou MSA des particuliers"
     tokens:
+      show:
+        page_title: ""
+      stats:
+        page_title: Statistiques d'utilisation
+      renew:
+        page_title: ""
+      prolong:
+        page_title: Prolonger mon jeton
+      ask_for_prolongation:
+        page_title: ""
       token:
         scope:
           cnaf_quotient_familial:
@@ -485,17 +512,28 @@ fr:
           sdh_statut_sportif_informations_statuts_precedents:
             label: Sport Data Hub || API Statut sportif || Historique informations statut sportif
     sessions:
+      new:
+        page_title: Se connecter
+      create_from_magic_link:
+        page_title: ""
+      dev_login:
+        page_title: ""
       create_from_oauth:
+        page_title: ""
         not_found:
           title: "Votre compte ne semble pas être rattaché à une habilitation API Particulier."
           description: "Veuillez vérifier que l'e-mail %{email} utilisé ici correspond à l'e-mail utilisé lors de votre demande d'habilitation API Particulier \n\n
             Si vous êtes un nouvel utilisateur, veuillez déposer une demande en suivant le lien suivant : https://datapass.api.gouv.fr/api-particulier\n
             Après validation de celle-ci, vous pourrez vous connecter au compte API Particulier."
       failure:
+        page_title: ""
         unknown: Une erreur inconnue est survenue, veuillez contacter le support.
       after_logout:
+        page_title: ""
         success: Déconnexion réussie.
     documentation:
+      developers:
+        page_title: Espace développeur
       index:
         card_swagger_link: 🕹 Swagger
         card_swagger_description: Spécifications techniques de chacune des API&nbsp;:&nbsp;<br/>- Paramètres d’appels<br/>- Détail de la réponse JSON<br/>- Codes erreurs
@@ -506,6 +544,34 @@ fr:
         link_preprod: 🧪 Environnement de test
         link_kit: 🚀 Kit de mise en production
         link_migration: 🔄 Guide de migration V.3
+    stats:
+      index:
+        page_title: Statistiques
+    users:
+      profile:
+        page_title: Mon compte
+    authorization_requests:
+      index:
+        page_title: Mes demandes
+    transfer_tokens:
+      new:
+        page_title: ""
+    prolong_token_wizard:
+      start:
+        page_title: ""
+      show:
+        page_title: ""
+      finished:
+        page_title: ""
+    public_token_magic_links:
+      show:
+        page_title: ""
+    changelogs:
+      index:
+        page_title: Nouveautés
+    reporters:
+      index:
+        page_title: ""
   beta:
     label: Version beta
     title: Cette API est disponible dans une version non-définitive


### PR DESCRIPTION
RGAA 8.5, 8.6 — `<title>` dynamique par page.

Helper `full_page_title` en deux couches : `content_for(:page_title)` pour les pages dynamiques (endpoint, cas d'usage, blog post, demande d'habilitation), clé i18n `controller.action.page_title` pour les pages statiques (`""` = site name seul). **Si ni l'un ni l'autre n'est défini, raise en local/test** — il est structurellement impossible d'oublier un titre sans le voir exploser en développement.

Closes [API-6951](https://linear.app/pole-api/issue/API-6951)