### PR TITLE
feat(a11y): plan du site RGAA 12.1

### DIFF
--- a/site/app/controllers/api_entreprise/pages_controller.rb
+++ b/site/app/controllers/api_entreprise/pages_controller.rb
@@ -31,6 +31,11 @@ class APIEntreprise::PagesController < APIEntrepriseController
     render 'shared/pages/accessibility'
   end
 
+  def sitemap
+    @sitemap_sections = YAML.load_file(Rails.root.join('config/sitemap.yml'))['api_entreprise']
+    render 'shared/pages/sitemap'
+  end
+
   def redoc
     render 'shared/pages/redoc'
   end

--- a/site/app/controllers/api_particulier/pages_controller.rb
+++ b/site/app/controllers/api_particulier/pages_controller.rb
@@ -47,6 +47,11 @@ class APIParticulier::PagesController < APIParticulierController
     render 'shared/pages/accessibility'
   end
 
+  def sitemap
+    @sitemap_sections = YAML.load_file(Rails.root.join('config/sitemap.yml'))['api_particulier']
+    render 'shared/pages/sitemap'
+  end
+
   private
 
   def page_layout

--- a/site/app/views/shared/api_entreprise/_footer.html.erb
+++ b/site/app/views/shared/api_entreprise/_footer.html.erb
@@ -27,7 +27,7 @@
     <div class="fr-footer__bottom">
       <ul class="fr-footer__bottom-list">
         <li class="fr-footer__bottom-item">
-          <a class="fr-footer__bottom-link" href="#">Plan du site</a>
+          <a class="fr-footer__bottom-link" href="<%= sitemap_path %>">Plan du site</a>
         </li>
         <li class="fr-footer__bottom-item">
           <a class="fr-footer__bottom-link" href="<%= accessibilite_path %>">Accessibilité: non conforme</a>

--- a/site/app/views/shared/api_particulier/_footer.html.erb
+++ b/site/app/views/shared/api_particulier/_footer.html.erb
@@ -27,7 +27,7 @@
     <div class="fr-footer__bottom">
       <ul class="fr-footer__bottom-list">
         <li class="fr-footer__bottom-item">
-          <a class="fr-footer__bottom-link" href="#">Plan du site</a>
+          <a class="fr-footer__bottom-link" href="<%= api_particulier_sitemap_path %>">Plan du site</a>
         </li>
         <li class="fr-footer__bottom-item">
           <a class="fr-footer__bottom-link" href="<%= accessibilite_path %>">Accessibilité: non conforme</a>

--- a/site/app/views/shared/pages/sitemap.html.erb
+++ b/site/app/views/shared/pages/sitemap.html.erb
@@ -1,0 +1,14 @@
+<h1>Plan du site</h1>
+
+<% @sitemap_sections.each do |section| %>
+  <section>
+    <h2><%= section['section'] %></h2>
+    <ul>
+      <% section['pages'].each do |page| %>
+        <li>
+          <%= link_to page['title'], public_send("#{page['route']}_path") %>
+        </li>
+      <% end %>
+    </ul>
+  </section>
+<% end %>

--- a/site/config/routes/api_entreprise.rb
+++ b/site/config/routes/api_entreprise.rb
@@ -81,5 +81,6 @@ constraints(APIEntrepriseDomainConstraint.new) do
     get '/cgu', to: 'pages#cgu', as: :cgu
     get '/donnees_personnelles', to: 'pages#donnees_personnelles', as: :donnees_personnelles
     get '/accessibilite', to: 'pages#accessibility', as: :accessibilite
+    get '/plan-du-site', to: 'pages#sitemap', as: :sitemap
   end
 end

--- a/site/config/routes/api_particulier.rb
+++ b/site/config/routes/api_particulier.rb
@@ -82,6 +82,7 @@ constraints(APIParticulierDomainConstraint.new) do
     get '/cgu', to: 'pages#cgu', as: :cgu
     get '/donnees_personnelles', to: 'pages#donnees_personnelles', as: :donnees_personnelles
     get '/accessibilite', to: 'pages#accessibility', as: :accessibilite
+    get '/plan-du-site', to: 'pages#sitemap', as: :sitemap
 
     get '/datapass', to: 'reporters#index', as: :dashboard_reporter
   end

--- a/site/config/sitemap.yml
+++ b/site/config/sitemap.yml
@@ -1,0 +1,75 @@
+api_entreprise:
+  - section: Découvrir
+    pages:
+      - route: root
+        title: Accueil
+      - route: endpoints
+        title: Catalogue des API
+      - route: cas_usages
+        title: Cas d'usages
+      - route: faq_index
+        title: FAQ & contact
+      - route: changelogs
+        title: Nouveautés
+      - route: developers
+        title: Espace développeur
+      - route: current_status
+        title: Statut des API
+      - route: newsletter
+        title: Lettre d'information
+      - route: stats
+        title: Statistiques
+  - section: Mon espace
+    pages:
+      - route: login
+        title: Se connecter
+  - section: Informations légales
+    pages:
+      - route: accessibilite
+        title: Accessibilité
+      - route: cgu
+        title: Conditions générales d'utilisation
+      - route: mentions
+        title: Mentions légales
+      - route: donnees_personnelles
+        title: Données personnelles
+      - route: sitemap
+        title: Plan du site
+
+api_particulier:
+  - section: Découvrir
+    pages:
+      - route: api_particulier
+        title: Accueil
+      - route: api_particulier_endpoints
+        title: Catalogue des API
+      - route: api_particulier_cas_usages
+        title: Cas d'usages & modalités d'appel
+      - route: api_particulier_faq_index
+        title: FAQ & contact
+      - route: api_particulier_changelogs
+        title: Nouveautés
+      - route: api_particulier_developers
+        title: Espace développeur
+      - route: api_particulier_current_status
+        title: Statut des API
+      - route: api_particulier_newsletter
+        title: Lettre d'information
+      - route: api_particulier_stats
+        title: Statistiques
+  - section: Mon espace
+    pages:
+      - route: api_particulier_login
+        title: Se connecter
+  - section: Informations légales
+    pages:
+      - route: api_particulier_accessibilite
+        title: Accessibilité
+      - route: api_particulier_cgu
+        title: Conditions générales d'utilisation
+      - route: api_particulier_mentions
+        title: Mentions légales
+      - route: api_particulier_donnees_personnelles
+        title: Données personnelles
+      - route: api_particulier_sitemap
+        title: Plan du site

--- a/site/spec/features/sitemap_spec.rb
+++ b/site/spec/features/sitemap_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe 'Sitemap page' do
+  context 'when on API Entreprise', app: :api_entreprise do
+    it 'renders every link without error' do
+      expect { visit sitemap_path }.not_to raise_error
+
+      expect(page).to have_text('Plan du site')
+    end
+  end
+
+  context 'when on API Particulier', app: :api_particulier do
+    it 'renders every link without error' do
+      expect { visit api_particulier_sitemap_path }.not_to raise_error
+
+      expect(page).to have_text('Plan du site')
+    end
+  end
+end


### PR DESCRIPTION
RGAA 12.1 — plan du site fonctionnel (le lien footer pointait vers \`href=\"#\"\`).

\`config/sitemap.yml\` source de vérité unique (sections + chemins + titres), rendu par une vue partagée, protégé par un spec qui valide chaque chemin contre le routeur Rails — impossible d'ajouter une page sans route sans casser la CI.

Closes [API-6732](https://linear.app/pole-api/issue/API-6732)

<img width="1200" height="982" alt="sitemap-screenshot" src="https://github.com/user-attachments/assets/31a0538f-852c-44ba-a27e-38f2263983e0" />
