### PR TITLE
feat(site): display user internal id on /compte

### DIFF
--- a/site/app/views/shared/users/_user.html.erb
+++ b/site/app/views/shared/users/_user.html.erb
@@ -32,6 +32,10 @@
     <div class="fr-col-12 fr-mb-3w">
       <ul class="list-unstyled user-general-infos">
         <li>
+          <%= icon('fr-icon-user-line') %>
+          <%= t('.internal_id', id: user.id).html_safe %>
+        </li>
+        <li>
           <%= icon('fr-icon-mail-line') %>
           <%= user.email %>
         </li>

--- a/site/config/locales/fr.yml
+++ b/site/config/locales/fr.yml
@@ -234,6 +234,7 @@ fr:
         links:
           authorization_requests: Vos habilitations
         title: "Vos&nbsp;informations"
+        internal_id: "Identifiant interne&nbsp;: %{id}"
         transfer_account:
           title: "Votre équipe évolue ? Vous quittez votre service ? Transmettez vos habilitations à une autre personne&nbsp;:"
           subtitle_if_demandeur: "Habilitations où je suis demandeur&nbsp;:"


### PR DESCRIPTION
Surface the user's internal UUID above their email on the account page so support can quickly identify a user when debugging from their report.