### PR TITLE
Add CNous v4 boursier test datasets with INE scenarios

### DIFF
--- a/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/200_boursier_commune_accentuee_minnie_mouse.yaml
+++ b/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/200_boursier_commune_accentuee_minnie_mouse.yaml
@@ -1,0 +1,39 @@
+---
+description: 'Boursière avec commune accentuée et tirets - Minnie Mouse - Marsannay-la-Côte BSB'
+params:
+  ine: '0987654321F'
+status: 200
+payload: |-
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": true,
+        "est_radie": false,
+        "date_radiation": null
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "2026-09-20",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Marsannay-la-Côte",
+        "nom_etablissement": "BSB"
+      },
+      "echelon_bourse": {
+        "echelon": "6",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "minnie@mouse.fr",
+      "identite": {
+        "nom": "MOUSE",
+        "prenoms": [
+          "MINNIE"
+        ],
+        "date_naissance": "2001-02-05",
+        "nom_commune_naissance": "Dole",
+        "sexe": "F"
+      }
+    },
+    "links": {},
+    "meta": {}
+  }

--- a/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/200_boursier_commune_naissance_typo_mickey_mouse.yaml
+++ b/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/200_boursier_commune_naissance_typo_mickey_mouse.yaml
@@ -1,0 +1,39 @@
+---
+description: 'Boursier avec commune de naissance mal orthographiée (Bordeau) - Mickey Mouse - Dijon IAE'
+params:
+  ine: '0987654321E'
+status: 200
+payload: |-
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": true,
+        "est_radie": false,
+        "date_radiation": null
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "2026-09-10",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Dijon",
+        "nom_etablissement": "IAE"
+      },
+      "echelon_bourse": {
+        "echelon": "6",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "mickey@mouse.fr",
+      "identite": {
+        "nom": "MOUSE",
+        "prenoms": [
+          "MICKEY"
+        ],
+        "date_naissance": "2009-12-30",
+        "nom_commune_naissance": "Bordeau",
+        "sexe": "M"
+      }
+    },
+    "links": {},
+    "meta": {}
+  }

--- a/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/200_boursier_daisy_duck.yaml
+++ b/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/200_boursier_daisy_duck.yaml
@@ -1,0 +1,39 @@
+---
+description: 'Boursière - Daisy Duck - Saint-Apollinaire BSB'
+params:
+  ine: '0987654321D'
+status: 200
+payload: |-
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": true,
+        "est_radie": false,
+        "date_radiation": null
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "2026-09-15",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Saint-Apollinaire",
+        "nom_etablissement": "BSB"
+      },
+      "echelon_bourse": {
+        "echelon": "6",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "daisy@duck.com",
+      "identite": {
+        "nom": "DUCK",
+        "prenoms": [
+          "DAISY"
+        ],
+        "date_naissance": "2002-08-17",
+        "nom_commune_naissance": "Aix-en-Provence",
+        "sexe": "F"
+      }
+    },
+    "links": {},
+    "meta": {}
+  }

--- a/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/200_boursier_hors_dijon_donald_duck.yaml
+++ b/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/200_boursier_hors_dijon_donald_duck.yaml
@@ -1,0 +1,39 @@
+---
+description: 'Boursier hors Dijon (Toulouse) - Donald Duck - Toulouse Baudelaire'
+params:
+  ine: '0987654321H'
+status: 200
+payload: |-
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": true,
+        "est_radie": false,
+        "date_radiation": null
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "2026-09-25",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Toulouse",
+        "nom_etablissement": "Baudelaire"
+      },
+      "echelon_bourse": {
+        "echelon": "6",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "donald@duck.fr",
+      "identite": {
+        "nom": "DUCK",
+        "prenoms": [
+          "DONALD"
+        ],
+        "date_naissance": "2001-05-18",
+        "nom_commune_naissance": "Rennes",
+        "sexe": "M"
+      }
+    },
+    "links": {},
+    "meta": {}
+  }

--- a/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/200_boursier_naissance_1947_balthazar_picsou.yaml
+++ b/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/200_boursier_naissance_1947_balthazar_picsou.yaml
@@ -1,0 +1,39 @@
+---
+description: 'Boursier avec date de naissance atypique (1947) - Balthazar Picsou - Dijon IAE'
+params:
+  ine: '0987654321G'
+status: 200
+payload: |-
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": true,
+        "est_radie": false,
+        "date_radiation": null
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "2026-09-05",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Dijon",
+        "nom_etablissement": "IAE"
+      },
+      "echelon_bourse": {
+        "echelon": "6",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "balthazar@piscou.com",
+      "identite": {
+        "nom": "PICSOU",
+        "prenoms": [
+          "BALTHAZAR"
+        ],
+        "date_naissance": "1947-11-14",
+        "nom_commune_naissance": "Dijon",
+        "sexe": "M"
+      }
+    },
+    "links": {},
+    "meta": {}
+  }

--- a/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/200_boursier_pat_hibulaire.yaml
+++ b/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/200_boursier_pat_hibulaire.yaml
@@ -1,0 +1,39 @@
+---
+description: 'Boursier - Pat Hibulaire - Dijon BSB'
+params:
+  ine: '0987654321I'
+status: 200
+payload: |-
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": true,
+        "est_radie": false,
+        "date_radiation": null
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "2026-09-15",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Dijon",
+        "nom_etablissement": "BSB"
+      },
+      "echelon_bourse": {
+        "echelon": "6",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "pat@hibulaire.com",
+      "identite": {
+        "nom": "PAT",
+        "prenoms": [
+          "HIBULAIRE"
+        ],
+        "date_naissance": "2006-06-30",
+        "nom_commune_naissance": "La Rochelle",
+        "sexe": "M"
+      }
+    },
+    "links": {},
+    "meta": {}
+  }

--- a/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/200_boursier_prenom_compose_espace_anne_marie_robert.yaml
+++ b/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/200_boursier_prenom_compose_espace_anne_marie_robert.yaml
@@ -1,0 +1,39 @@
+---
+description: 'Boursière avec prénom composé avec espace - Anne Marie Robert - Dijon Carnot'
+params:
+  ine: '0987654321K'
+status: 200
+payload: |-
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": true,
+        "est_radie": false,
+        "date_radiation": null
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "2026-09-01",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Dijon",
+        "nom_etablissement": "Carnot"
+      },
+      "echelon_bourse": {
+        "echelon": "6",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "annemarie@michel.com",
+      "identite": {
+        "nom": "ROBERT",
+        "prenoms": [
+          "ANNE MARIE"
+        ],
+        "date_naissance": "2006-06-26",
+        "nom_commune_naissance": "Marseille",
+        "sexe": "F"
+      }
+    },
+    "links": {},
+    "meta": {}
+  }

--- a/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/200_boursier_prenom_compose_tiret_jean_michel_robert.yaml
+++ b/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/200_boursier_prenom_compose_tiret_jean_michel_robert.yaml
@@ -1,0 +1,39 @@
+---
+description: 'Boursier avec prénom composé avec tiret - Jean-Michel Robert - Dijon Carnot'
+params:
+  ine: '0987654321J'
+status: 200
+payload: |-
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": true,
+        "est_radie": false,
+        "date_radiation": null
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "2026-09-01",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Dijon",
+        "nom_etablissement": "Carnot"
+      },
+      "echelon_bourse": {
+        "echelon": "6",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "robet@jean-michel.com",
+      "identite": {
+        "nom": "ROBERT",
+        "prenoms": [
+          "JEAN-MICHEL"
+        ],
+        "date_naissance": "2003-01-08",
+        "nom_commune_naissance": "Colmar",
+        "sexe": "M"
+      }
+    },
+    "links": {},
+    "meta": {}
+  }

--- a/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/200_boursier_regional_provisoire_loulou_duck.yaml
+++ b/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/200_boursier_regional_provisoire_loulou_duck.yaml
@@ -1,0 +1,39 @@
+---
+description: 'Boursier avec échelon régional provisoire et commune accentuée - Loulou Duck - Fontaine-Lès-Dijon Carnot'
+params:
+  ine: '0987654321C'
+status: 200
+payload: |-
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": true,
+        "est_radie": false,
+        "date_radiation": null
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "2026-10-01",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Fontaine-Lès-Dijon",
+        "nom_etablissement": "Carnot"
+      },
+      "echelon_bourse": {
+        "echelon": "6",
+        "echelon_bourse_regionale_provisoire": true
+      },
+      "email": "loulou@duck.com",
+      "identite": {
+        "nom": "DUCK",
+        "prenoms": [
+          "LOULOU"
+        ],
+        "date_naissance": "2001-06-21",
+        "nom_commune_naissance": "Strasbourg",
+        "sexe": "M"
+      }
+    },
+    "links": {},
+    "meta": {}
+  }

--- a/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/200_boursier_riri_duck.yaml
+++ b/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/200_boursier_riri_duck.yaml
@@ -1,0 +1,39 @@
+---
+description: 'Boursier standard - Riri Duck - Dijon Carnot'
+params:
+  ine: '0987654321A'
+status: 200
+payload: |-
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": true,
+        "est_radie": false,
+        "date_radiation": null
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "2026-09-01",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Dijon",
+        "nom_etablissement": "Carnot"
+      },
+      "echelon_bourse": {
+        "echelon": "6",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "riri@duck.com",
+      "identite": {
+        "nom": "DUCK",
+        "prenoms": [
+          "RIRI"
+        ],
+        "date_naissance": "2004-03-11",
+        "nom_commune_naissance": "Morez",
+        "sexe": "M"
+      }
+    },
+    "links": {},
+    "meta": {}
+  }

--- a/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/200_non_boursier_fifi_duck.yaml
+++ b/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/200_non_boursier_fifi_duck.yaml
@@ -1,0 +1,39 @@
+---
+description: 'Non boursier avec INE - Fifi Duck - Dijon Carnot'
+params:
+  ine: '0987654321B'
+status: 200
+payload: |-
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": false,
+        "est_radie": false,
+        "date_radiation": null
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "2026-09-01",
+        "duree": null
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Dijon",
+        "nom_etablissement": "Carnot"
+      },
+      "echelon_bourse": {
+        "echelon": "6",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "fifi@duck.com",
+      "identite": {
+        "nom": "DUCK",
+        "prenoms": [
+          "FIFI"
+        ],
+        "date_naissance": "2003-11-06",
+        "nom_commune_naissance": "Ahuy",
+        "sexe": "M"
+      }
+    },
+    "links": {},
+    "meta": {}
+  }

--- a/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/200_non_boursier_fifi_duck.yaml
+++ b/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/200_non_boursier_fifi_duck.yaml
@@ -1,7 +1,7 @@
 ---
 description: 'Non boursier avec INE - Fifi Duck - Dijon Carnot'
 params:
-  ine: '0987654321B'
+  ine: '0987654321L'
 status: 200
 payload: |-
   {
@@ -13,7 +13,7 @@ payload: |-
       },
       "periode_versement_bourse": {
         "date_rentree": "2026-09-01",
-        "duree": null
+        "duree": 0
       },
       "etablissement_etudes": {
         "nom_commune": "Dijon",

--- a/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/README.md
+++ b/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/README.md
@@ -51,8 +51,10 @@
         "sexe": "M"
       }
     },
-    "links": {},
-    "meta": {}
+    "links": {
+    },
+    "meta": {
+    }
   }
   ```
 
@@ -123,8 +125,10 @@
         "sexe": "M"
       }
     },
-    "links": {},
-    "meta": {}
+    "links": {
+    },
+    "meta": {
+    }
   }
   ```
 
@@ -137,6 +141,809 @@
   ```bash
   curl -H "Authorization: Bearer $token" \
     -G -d 'recipient=13002526500013' -d 'ine=1234567890A' -d 'campaignYear=2022' \
+    --url "https://staging.particulier.api.gouv.fr/v4/cnous/etudiant_boursier/ine"
+  ```
+
+  </p>
+  </details>
+* [200_boursier_commune_accentuee_minnie_mouse.yaml](200_boursier_commune_accentuee_minnie_mouse.yaml)
+
+  Status `200`
+
+  Boursière avec commune accentuée et tirets - Minnie Mouse - Marsannay-la-Côte BSB
+
+  <details><summary>Paramètres</summary>
+  <p>
+
+  ```json
+  {
+    "ine": "0987654321F"
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Réponse API</summary>
+  <p>
+
+  ```json
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": true,
+        "est_radie": false,
+        "date_radiation": null
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "2026-09-20",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Marsannay-la-Côte",
+        "nom_etablissement": "BSB"
+      },
+      "echelon_bourse": {
+        "echelon": "6",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "minnie@mouse.fr",
+      "identite": {
+        "nom": "MOUSE",
+        "prenoms": [
+          "MINNIE"
+        ],
+        "date_naissance": "2001-02-05",
+        "nom_commune_naissance": "Dole",
+        "sexe": "F"
+      }
+    },
+    "links": {
+    },
+    "meta": {
+    }
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Commande cURL</summary>
+  <p>
+
+  ```bash
+  curl -H "Authorization: Bearer $token" \
+    -G -d 'recipient=13002526500013' -d 'ine=0987654321F' \
+    --url "https://staging.particulier.api.gouv.fr/v4/cnous/etudiant_boursier/ine"
+  ```
+
+  </p>
+  </details>
+* [200_boursier_commune_naissance_typo_mickey_mouse.yaml](200_boursier_commune_naissance_typo_mickey_mouse.yaml)
+
+  Status `200`
+
+  Boursier avec commune de naissance mal orthographiée (Bordeau) - Mickey Mouse - Dijon IAE
+
+  <details><summary>Paramètres</summary>
+  <p>
+
+  ```json
+  {
+    "ine": "0987654321E"
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Réponse API</summary>
+  <p>
+
+  ```json
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": true,
+        "est_radie": false,
+        "date_radiation": null
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "2026-09-10",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Dijon",
+        "nom_etablissement": "IAE"
+      },
+      "echelon_bourse": {
+        "echelon": "6",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "mickey@mouse.fr",
+      "identite": {
+        "nom": "MOUSE",
+        "prenoms": [
+          "MICKEY"
+        ],
+        "date_naissance": "2009-12-30",
+        "nom_commune_naissance": "Bordeau",
+        "sexe": "M"
+      }
+    },
+    "links": {
+    },
+    "meta": {
+    }
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Commande cURL</summary>
+  <p>
+
+  ```bash
+  curl -H "Authorization: Bearer $token" \
+    -G -d 'recipient=13002526500013' -d 'ine=0987654321E' \
+    --url "https://staging.particulier.api.gouv.fr/v4/cnous/etudiant_boursier/ine"
+  ```
+
+  </p>
+  </details>
+* [200_boursier_daisy_duck.yaml](200_boursier_daisy_duck.yaml)
+
+  Status `200`
+
+  Boursière - Daisy Duck - Saint-Apollinaire BSB
+
+  <details><summary>Paramètres</summary>
+  <p>
+
+  ```json
+  {
+    "ine": "0987654321D"
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Réponse API</summary>
+  <p>
+
+  ```json
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": true,
+        "est_radie": false,
+        "date_radiation": null
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "2026-09-15",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Saint-Apollinaire",
+        "nom_etablissement": "BSB"
+      },
+      "echelon_bourse": {
+        "echelon": "6",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "daisy@duck.com",
+      "identite": {
+        "nom": "DUCK",
+        "prenoms": [
+          "DAISY"
+        ],
+        "date_naissance": "2002-08-17",
+        "nom_commune_naissance": "Aix-en-Provence",
+        "sexe": "F"
+      }
+    },
+    "links": {
+    },
+    "meta": {
+    }
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Commande cURL</summary>
+  <p>
+
+  ```bash
+  curl -H "Authorization: Bearer $token" \
+    -G -d 'recipient=13002526500013' -d 'ine=0987654321D' \
+    --url "https://staging.particulier.api.gouv.fr/v4/cnous/etudiant_boursier/ine"
+  ```
+
+  </p>
+  </details>
+* [200_boursier_hors_dijon_donald_duck.yaml](200_boursier_hors_dijon_donald_duck.yaml)
+
+  Status `200`
+
+  Boursier hors Dijon (Toulouse) - Donald Duck - Toulouse Baudelaire
+
+  <details><summary>Paramètres</summary>
+  <p>
+
+  ```json
+  {
+    "ine": "0987654321H"
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Réponse API</summary>
+  <p>
+
+  ```json
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": true,
+        "est_radie": false,
+        "date_radiation": null
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "2026-09-25",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Toulouse",
+        "nom_etablissement": "Baudelaire"
+      },
+      "echelon_bourse": {
+        "echelon": "6",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "donald@duck.fr",
+      "identite": {
+        "nom": "DUCK",
+        "prenoms": [
+          "DONALD"
+        ],
+        "date_naissance": "2001-05-18",
+        "nom_commune_naissance": "Rennes",
+        "sexe": "M"
+      }
+    },
+    "links": {
+    },
+    "meta": {
+    }
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Commande cURL</summary>
+  <p>
+
+  ```bash
+  curl -H "Authorization: Bearer $token" \
+    -G -d 'recipient=13002526500013' -d 'ine=0987654321H' \
+    --url "https://staging.particulier.api.gouv.fr/v4/cnous/etudiant_boursier/ine"
+  ```
+
+  </p>
+  </details>
+* [200_boursier_naissance_1947_balthazar_picsou.yaml](200_boursier_naissance_1947_balthazar_picsou.yaml)
+
+  Status `200`
+
+  Boursier avec date de naissance atypique (1947) - Balthazar Picsou - Dijon IAE
+
+  <details><summary>Paramètres</summary>
+  <p>
+
+  ```json
+  {
+    "ine": "0987654321G"
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Réponse API</summary>
+  <p>
+
+  ```json
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": true,
+        "est_radie": false,
+        "date_radiation": null
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "2026-09-05",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Dijon",
+        "nom_etablissement": "IAE"
+      },
+      "echelon_bourse": {
+        "echelon": "6",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "balthazar@piscou.com",
+      "identite": {
+        "nom": "PICSOU",
+        "prenoms": [
+          "BALTHAZAR"
+        ],
+        "date_naissance": "1947-11-14",
+        "nom_commune_naissance": "Dijon",
+        "sexe": "M"
+      }
+    },
+    "links": {
+    },
+    "meta": {
+    }
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Commande cURL</summary>
+  <p>
+
+  ```bash
+  curl -H "Authorization: Bearer $token" \
+    -G -d 'recipient=13002526500013' -d 'ine=0987654321G' \
+    --url "https://staging.particulier.api.gouv.fr/v4/cnous/etudiant_boursier/ine"
+  ```
+
+  </p>
+  </details>
+* [200_boursier_pat_hibulaire.yaml](200_boursier_pat_hibulaire.yaml)
+
+  Status `200`
+
+  Boursier - Pat Hibulaire - Dijon BSB
+
+  <details><summary>Paramètres</summary>
+  <p>
+
+  ```json
+  {
+    "ine": "0987654321I"
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Réponse API</summary>
+  <p>
+
+  ```json
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": true,
+        "est_radie": false,
+        "date_radiation": null
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "2026-09-15",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Dijon",
+        "nom_etablissement": "BSB"
+      },
+      "echelon_bourse": {
+        "echelon": "6",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "pat@hibulaire.com",
+      "identite": {
+        "nom": "PAT",
+        "prenoms": [
+          "HIBULAIRE"
+        ],
+        "date_naissance": "2006-06-30",
+        "nom_commune_naissance": "La Rochelle",
+        "sexe": "M"
+      }
+    },
+    "links": {
+    },
+    "meta": {
+    }
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Commande cURL</summary>
+  <p>
+
+  ```bash
+  curl -H "Authorization: Bearer $token" \
+    -G -d 'recipient=13002526500013' -d 'ine=0987654321I' \
+    --url "https://staging.particulier.api.gouv.fr/v4/cnous/etudiant_boursier/ine"
+  ```
+
+  </p>
+  </details>
+* [200_boursier_prenom_compose_espace_anne_marie_robert.yaml](200_boursier_prenom_compose_espace_anne_marie_robert.yaml)
+
+  Status `200`
+
+  Boursière avec prénom composé avec espace - Anne Marie Robert - Dijon Carnot
+
+  <details><summary>Paramètres</summary>
+  <p>
+
+  ```json
+  {
+    "ine": "0987654321K"
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Réponse API</summary>
+  <p>
+
+  ```json
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": true,
+        "est_radie": false,
+        "date_radiation": null
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "2026-09-01",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Dijon",
+        "nom_etablissement": "Carnot"
+      },
+      "echelon_bourse": {
+        "echelon": "6",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "annemarie@michel.com",
+      "identite": {
+        "nom": "ROBERT",
+        "prenoms": [
+          "ANNE MARIE"
+        ],
+        "date_naissance": "2006-06-26",
+        "nom_commune_naissance": "Marseille",
+        "sexe": "F"
+      }
+    },
+    "links": {
+    },
+    "meta": {
+    }
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Commande cURL</summary>
+  <p>
+
+  ```bash
+  curl -H "Authorization: Bearer $token" \
+    -G -d 'recipient=13002526500013' -d 'ine=0987654321K' \
+    --url "https://staging.particulier.api.gouv.fr/v4/cnous/etudiant_boursier/ine"
+  ```
+
+  </p>
+  </details>
+* [200_boursier_prenom_compose_tiret_jean_michel_robert.yaml](200_boursier_prenom_compose_tiret_jean_michel_robert.yaml)
+
+  Status `200`
+
+  Boursier avec prénom composé avec tiret - Jean-Michel Robert - Dijon Carnot
+
+  <details><summary>Paramètres</summary>
+  <p>
+
+  ```json
+  {
+    "ine": "0987654321J"
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Réponse API</summary>
+  <p>
+
+  ```json
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": true,
+        "est_radie": false,
+        "date_radiation": null
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "2026-09-01",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Dijon",
+        "nom_etablissement": "Carnot"
+      },
+      "echelon_bourse": {
+        "echelon": "6",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "robet@jean-michel.com",
+      "identite": {
+        "nom": "ROBERT",
+        "prenoms": [
+          "JEAN-MICHEL"
+        ],
+        "date_naissance": "2003-01-08",
+        "nom_commune_naissance": "Colmar",
+        "sexe": "M"
+      }
+    },
+    "links": {
+    },
+    "meta": {
+    }
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Commande cURL</summary>
+  <p>
+
+  ```bash
+  curl -H "Authorization: Bearer $token" \
+    -G -d 'recipient=13002526500013' -d 'ine=0987654321J' \
+    --url "https://staging.particulier.api.gouv.fr/v4/cnous/etudiant_boursier/ine"
+  ```
+
+  </p>
+  </details>
+* [200_boursier_regional_provisoire_loulou_duck.yaml](200_boursier_regional_provisoire_loulou_duck.yaml)
+
+  Status `200`
+
+  Boursier avec échelon régional provisoire et commune accentuée - Loulou Duck - Fontaine-Lès-Dijon Carnot
+
+  <details><summary>Paramètres</summary>
+  <p>
+
+  ```json
+  {
+    "ine": "0987654321C"
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Réponse API</summary>
+  <p>
+
+  ```json
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": true,
+        "est_radie": false,
+        "date_radiation": null
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "2026-10-01",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Fontaine-Lès-Dijon",
+        "nom_etablissement": "Carnot"
+      },
+      "echelon_bourse": {
+        "echelon": "6",
+        "echelon_bourse_regionale_provisoire": true
+      },
+      "email": "loulou@duck.com",
+      "identite": {
+        "nom": "DUCK",
+        "prenoms": [
+          "LOULOU"
+        ],
+        "date_naissance": "2001-06-21",
+        "nom_commune_naissance": "Strasbourg",
+        "sexe": "M"
+      }
+    },
+    "links": {
+    },
+    "meta": {
+    }
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Commande cURL</summary>
+  <p>
+
+  ```bash
+  curl -H "Authorization: Bearer $token" \
+    -G -d 'recipient=13002526500013' -d 'ine=0987654321C' \
+    --url "https://staging.particulier.api.gouv.fr/v4/cnous/etudiant_boursier/ine"
+  ```
+
+  </p>
+  </details>
+* [200_boursier_riri_duck.yaml](200_boursier_riri_duck.yaml)
+
+  Status `200`
+
+  Boursier standard - Riri Duck - Dijon Carnot
+
+  <details><summary>Paramètres</summary>
+  <p>
+
+  ```json
+  {
+    "ine": "0987654321A"
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Réponse API</summary>
+  <p>
+
+  ```json
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": true,
+        "est_radie": false,
+        "date_radiation": null
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "2026-09-01",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Dijon",
+        "nom_etablissement": "Carnot"
+      },
+      "echelon_bourse": {
+        "echelon": "6",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "riri@duck.com",
+      "identite": {
+        "nom": "DUCK",
+        "prenoms": [
+          "RIRI"
+        ],
+        "date_naissance": "2004-03-11",
+        "nom_commune_naissance": "Morez",
+        "sexe": "M"
+      }
+    },
+    "links": {
+    },
+    "meta": {
+    }
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Commande cURL</summary>
+  <p>
+
+  ```bash
+  curl -H "Authorization: Bearer $token" \
+    -G -d 'recipient=13002526500013' -d 'ine=0987654321A' \
+    --url "https://staging.particulier.api.gouv.fr/v4/cnous/etudiant_boursier/ine"
+  ```
+
+  </p>
+  </details>
+* [200_non_boursier_fifi_duck.yaml](200_non_boursier_fifi_duck.yaml)
+
+  Status `200`
+
+  Non boursier avec INE - Fifi Duck - Dijon Carnot
+
+  <details><summary>Paramètres</summary>
+  <p>
+
+  ```json
+  {
+    "ine": "0987654321L"
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Réponse API</summary>
+  <p>
+
+  ```json
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": false,
+        "est_radie": false,
+        "date_radiation": null
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "2026-09-01",
+        "duree": 0
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Dijon",
+        "nom_etablissement": "Carnot"
+      },
+      "echelon_bourse": {
+        "echelon": "6",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "fifi@duck.com",
+      "identite": {
+        "nom": "DUCK",
+        "prenoms": [
+          "FIFI"
+        ],
+        "date_naissance": "2003-11-06",
+        "nom_commune_naissance": "Ahuy",
+        "sexe": "M"
+      }
+    },
+    "links": {
+    },
+    "meta": {
+    }
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Commande cURL</summary>
+  <p>
+
+  ```bash
+  curl -H "Authorization: Bearer $token" \
+    -G -d 'recipient=13002526500013' -d 'ine=0987654321L' \
     --url "https://staging.particulier.api.gouv.fr/v4/cnous/etudiant_boursier/ine"
   ```
 
@@ -194,8 +1001,10 @@
         "sexe": "F"
       }
     },
-    "links": {},
-    "meta": {}
+    "links": {
+    },
+    "meta": {
+    }
   }
   ```
 

--- a/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/summary.csv
+++ b/mocks/payloads/api_particulier_v4_cnous_etudiant_boursier_with_ine/summary.csv
@@ -65,6 +65,369 @@ Titre,Description,Paramètres,Status,Réponse
   ""links"": {},
   ""meta"": {}
 }"
+,Boursière avec commune accentuée et tirets - Minnie Mouse - Marsannay-la-Côte BSB,"{""ine"":""0987654321F""}",200,"{
+  ""data"": {
+    ""statut_boursier"": {
+      ""est_boursier"": true,
+      ""est_radie"": false,
+      ""date_radiation"": null
+    },
+    ""periode_versement_bourse"": {
+      ""date_rentree"": ""2026-09-20"",
+      ""duree"": 12
+    },
+    ""etablissement_etudes"": {
+      ""nom_commune"": ""Marsannay-la-Côte"",
+      ""nom_etablissement"": ""BSB""
+    },
+    ""echelon_bourse"": {
+      ""echelon"": ""6"",
+      ""echelon_bourse_regionale_provisoire"": false
+    },
+    ""email"": ""minnie@mouse.fr"",
+    ""identite"": {
+      ""nom"": ""MOUSE"",
+      ""prenoms"": [
+        ""MINNIE""
+      ],
+      ""date_naissance"": ""2001-02-05"",
+      ""nom_commune_naissance"": ""Dole"",
+      ""sexe"": ""F""
+    }
+  },
+  ""links"": {},
+  ""meta"": {}
+}"
+,Boursier avec commune de naissance mal orthographiée (Bordeau) - Mickey Mouse - Dijon IAE,"{""ine"":""0987654321E""}",200,"{
+  ""data"": {
+    ""statut_boursier"": {
+      ""est_boursier"": true,
+      ""est_radie"": false,
+      ""date_radiation"": null
+    },
+    ""periode_versement_bourse"": {
+      ""date_rentree"": ""2026-09-10"",
+      ""duree"": 12
+    },
+    ""etablissement_etudes"": {
+      ""nom_commune"": ""Dijon"",
+      ""nom_etablissement"": ""IAE""
+    },
+    ""echelon_bourse"": {
+      ""echelon"": ""6"",
+      ""echelon_bourse_regionale_provisoire"": false
+    },
+    ""email"": ""mickey@mouse.fr"",
+    ""identite"": {
+      ""nom"": ""MOUSE"",
+      ""prenoms"": [
+        ""MICKEY""
+      ],
+      ""date_naissance"": ""2009-12-30"",
+      ""nom_commune_naissance"": ""Bordeau"",
+      ""sexe"": ""M""
+    }
+  },
+  ""links"": {},
+  ""meta"": {}
+}"
+,Boursière - Daisy Duck - Saint-Apollinaire BSB,"{""ine"":""0987654321D""}",200,"{
+  ""data"": {
+    ""statut_boursier"": {
+      ""est_boursier"": true,
+      ""est_radie"": false,
+      ""date_radiation"": null
+    },
+    ""periode_versement_bourse"": {
+      ""date_rentree"": ""2026-09-15"",
+      ""duree"": 12
+    },
+    ""etablissement_etudes"": {
+      ""nom_commune"": ""Saint-Apollinaire"",
+      ""nom_etablissement"": ""BSB""
+    },
+    ""echelon_bourse"": {
+      ""echelon"": ""6"",
+      ""echelon_bourse_regionale_provisoire"": false
+    },
+    ""email"": ""daisy@duck.com"",
+    ""identite"": {
+      ""nom"": ""DUCK"",
+      ""prenoms"": [
+        ""DAISY""
+      ],
+      ""date_naissance"": ""2002-08-17"",
+      ""nom_commune_naissance"": ""Aix-en-Provence"",
+      ""sexe"": ""F""
+    }
+  },
+  ""links"": {},
+  ""meta"": {}
+}"
+,Boursier hors Dijon (Toulouse) - Donald Duck - Toulouse Baudelaire,"{""ine"":""0987654321H""}",200,"{
+  ""data"": {
+    ""statut_boursier"": {
+      ""est_boursier"": true,
+      ""est_radie"": false,
+      ""date_radiation"": null
+    },
+    ""periode_versement_bourse"": {
+      ""date_rentree"": ""2026-09-25"",
+      ""duree"": 12
+    },
+    ""etablissement_etudes"": {
+      ""nom_commune"": ""Toulouse"",
+      ""nom_etablissement"": ""Baudelaire""
+    },
+    ""echelon_bourse"": {
+      ""echelon"": ""6"",
+      ""echelon_bourse_regionale_provisoire"": false
+    },
+    ""email"": ""donald@duck.fr"",
+    ""identite"": {
+      ""nom"": ""DUCK"",
+      ""prenoms"": [
+        ""DONALD""
+      ],
+      ""date_naissance"": ""2001-05-18"",
+      ""nom_commune_naissance"": ""Rennes"",
+      ""sexe"": ""M""
+    }
+  },
+  ""links"": {},
+  ""meta"": {}
+}"
+,Boursier avec date de naissance atypique (1947) - Balthazar Picsou - Dijon IAE,"{""ine"":""0987654321G""}",200,"{
+  ""data"": {
+    ""statut_boursier"": {
+      ""est_boursier"": true,
+      ""est_radie"": false,
+      ""date_radiation"": null
+    },
+    ""periode_versement_bourse"": {
+      ""date_rentree"": ""2026-09-05"",
+      ""duree"": 12
+    },
+    ""etablissement_etudes"": {
+      ""nom_commune"": ""Dijon"",
+      ""nom_etablissement"": ""IAE""
+    },
+    ""echelon_bourse"": {
+      ""echelon"": ""6"",
+      ""echelon_bourse_regionale_provisoire"": false
+    },
+    ""email"": ""balthazar@piscou.com"",
+    ""identite"": {
+      ""nom"": ""PICSOU"",
+      ""prenoms"": [
+        ""BALTHAZAR""
+      ],
+      ""date_naissance"": ""1947-11-14"",
+      ""nom_commune_naissance"": ""Dijon"",
+      ""sexe"": ""M""
+    }
+  },
+  ""links"": {},
+  ""meta"": {}
+}"
+,Boursier - Pat Hibulaire - Dijon BSB,"{""ine"":""0987654321I""}",200,"{
+  ""data"": {
+    ""statut_boursier"": {
+      ""est_boursier"": true,
+      ""est_radie"": false,
+      ""date_radiation"": null
+    },
+    ""periode_versement_bourse"": {
+      ""date_rentree"": ""2026-09-15"",
+      ""duree"": 12
+    },
+    ""etablissement_etudes"": {
+      ""nom_commune"": ""Dijon"",
+      ""nom_etablissement"": ""BSB""
+    },
+    ""echelon_bourse"": {
+      ""echelon"": ""6"",
+      ""echelon_bourse_regionale_provisoire"": false
+    },
+    ""email"": ""pat@hibulaire.com"",
+    ""identite"": {
+      ""nom"": ""PAT"",
+      ""prenoms"": [
+        ""HIBULAIRE""
+      ],
+      ""date_naissance"": ""2006-06-30"",
+      ""nom_commune_naissance"": ""La Rochelle"",
+      ""sexe"": ""M""
+    }
+  },
+  ""links"": {},
+  ""meta"": {}
+}"
+,Boursière avec prénom composé avec espace - Anne Marie Robert - Dijon Carnot,"{""ine"":""0987654321K""}",200,"{
+  ""data"": {
+    ""statut_boursier"": {
+      ""est_boursier"": true,
+      ""est_radie"": false,
+      ""date_radiation"": null
+    },
+    ""periode_versement_bourse"": {
+      ""date_rentree"": ""2026-09-01"",
+      ""duree"": 12
+    },
+    ""etablissement_etudes"": {
+      ""nom_commune"": ""Dijon"",
+      ""nom_etablissement"": ""Carnot""
+    },
+    ""echelon_bourse"": {
+      ""echelon"": ""6"",
+      ""echelon_bourse_regionale_provisoire"": false
+    },
+    ""email"": ""annemarie@michel.com"",
+    ""identite"": {
+      ""nom"": ""ROBERT"",
+      ""prenoms"": [
+        ""ANNE MARIE""
+      ],
+      ""date_naissance"": ""2006-06-26"",
+      ""nom_commune_naissance"": ""Marseille"",
+      ""sexe"": ""F""
+    }
+  },
+  ""links"": {},
+  ""meta"": {}
+}"
+,Boursier avec prénom composé avec tiret - Jean-Michel Robert - Dijon Carnot,"{""ine"":""0987654321J""}",200,"{
+  ""data"": {
+    ""statut_boursier"": {
+      ""est_boursier"": true,
+      ""est_radie"": false,
+      ""date_radiation"": null
+    },
+    ""periode_versement_bourse"": {
+      ""date_rentree"": ""2026-09-01"",
+      ""duree"": 12
+    },
+    ""etablissement_etudes"": {
+      ""nom_commune"": ""Dijon"",
+      ""nom_etablissement"": ""Carnot""
+    },
+    ""echelon_bourse"": {
+      ""echelon"": ""6"",
+      ""echelon_bourse_regionale_provisoire"": false
+    },
+    ""email"": ""robet@jean-michel.com"",
+    ""identite"": {
+      ""nom"": ""ROBERT"",
+      ""prenoms"": [
+        ""JEAN-MICHEL""
+      ],
+      ""date_naissance"": ""2003-01-08"",
+      ""nom_commune_naissance"": ""Colmar"",
+      ""sexe"": ""M""
+    }
+  },
+  ""links"": {},
+  ""meta"": {}
+}"
+,Boursier avec échelon régional provisoire et commune accentuée - Loulou Duck - Fontaine-Lès-Dijon Carnot,"{""ine"":""0987654321C""}",200,"{
+  ""data"": {
+    ""statut_boursier"": {
+      ""est_boursier"": true,
+      ""est_radie"": false,
+      ""date_radiation"": null
+    },
+    ""periode_versement_bourse"": {
+      ""date_rentree"": ""2026-10-01"",
+      ""duree"": 12
+    },
+    ""etablissement_etudes"": {
+      ""nom_commune"": ""Fontaine-Lès-Dijon"",
+      ""nom_etablissement"": ""Carnot""
+    },
+    ""echelon_bourse"": {
+      ""echelon"": ""6"",
+      ""echelon_bourse_regionale_provisoire"": true
+    },
+    ""email"": ""loulou@duck.com"",
+    ""identite"": {
+      ""nom"": ""DUCK"",
+      ""prenoms"": [
+        ""LOULOU""
+      ],
+      ""date_naissance"": ""2001-06-21"",
+      ""nom_commune_naissance"": ""Strasbourg"",
+      ""sexe"": ""M""
+    }
+  },
+  ""links"": {},
+  ""meta"": {}
+}"
+,Boursier standard - Riri Duck - Dijon Carnot,"{""ine"":""0987654321A""}",200,"{
+  ""data"": {
+    ""statut_boursier"": {
+      ""est_boursier"": true,
+      ""est_radie"": false,
+      ""date_radiation"": null
+    },
+    ""periode_versement_bourse"": {
+      ""date_rentree"": ""2026-09-01"",
+      ""duree"": 12
+    },
+    ""etablissement_etudes"": {
+      ""nom_commune"": ""Dijon"",
+      ""nom_etablissement"": ""Carnot""
+    },
+    ""echelon_bourse"": {
+      ""echelon"": ""6"",
+      ""echelon_bourse_regionale_provisoire"": false
+    },
+    ""email"": ""riri@duck.com"",
+    ""identite"": {
+      ""nom"": ""DUCK"",
+      ""prenoms"": [
+        ""RIRI""
+      ],
+      ""date_naissance"": ""2004-03-11"",
+      ""nom_commune_naissance"": ""Morez"",
+      ""sexe"": ""M""
+    }
+  },
+  ""links"": {},
+  ""meta"": {}
+}"
+,Non boursier avec INE - Fifi Duck - Dijon Carnot,"{""ine"":""0987654321L""}",200,"{
+  ""data"": {
+    ""statut_boursier"": {
+      ""est_boursier"": false,
+      ""est_radie"": false,
+      ""date_radiation"": null
+    },
+    ""periode_versement_bourse"": {
+      ""date_rentree"": ""2026-09-01"",
+      ""duree"": 0
+    },
+    ""etablissement_etudes"": {
+      ""nom_commune"": ""Dijon"",
+      ""nom_etablissement"": ""Carnot""
+    },
+    ""echelon_bourse"": {
+      ""echelon"": ""6"",
+      ""echelon_bourse_regionale_provisoire"": false
+    },
+    ""email"": ""fifi@duck.com"",
+    ""identite"": {
+      ""nom"": ""DUCK"",
+      ""prenoms"": [
+        ""FIFI""
+      ],
+      ""date_naissance"": ""2003-11-06"",
+      ""nom_commune_naissance"": ""Ahuy"",
+      ""sexe"": ""M""
+    }
+  },
+  ""links"": {},
+  ""meta"": {}
+}"
 ,Boursier radié,"{""ine"":""0987654321B""}",200,"{
   ""data"": {
     ""statut_boursier"": {


### PR DESCRIPTION
This PR adds new test datasets for the API Particulier CNous v4 endpoint:
api_particulier_v4_cnous_etudiant_boursier_with_ine.

## Purpose
Improve test coverage for student scholarship (boursier) scenarios using INE-based identification.

## Added test cases
This PR introduces 11 new YAML payloads covering multiple edge cases:

- Boursier / non-boursier scenarios
- Commune variations (accented / typo / regional)
- Birthplace edge cases
- Name variations:
  - Simple names (Riri Duck, Daisy Duck)
  - Compound first names (space and hyphen)
- Regional / provisional scholarship cases
- Out-of-area scenario
- Historical birth year edge case
- Negative case (non-boursier)

## Test structure
Each YAML file defines:
- request parameters (INE-based input scenario)
- expected HTTP status (200)
- mocked API response payload

## Validation
- All payloads follow existing CNous v4 mock format
- Compatible with staging mock server
- No modification of generated README or summary files (auto-generated)

## Related endpoint
/api_particulier/v4/cnous/etudiants-boursiers-with-ine