### PR TITLE
Add explorer-api-fournisseur skill

### DIFF
--- a/.claude/skills/explorer-api-fournisseur/SKILL.md
+++ b/.claude/skills/explorer-api-fournisseur/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: explorer-api-fournisseur
+description: >-
+  Explorer et analyser une API externe (fournisseur de données) en vue de
+  l'intégrer au catalogue API Entreprise / API Particulier. Use when the user
+  veut explorer/analyser/cadrer une nouvelle API à intégrer, étudier un swagger
+  ou une doc fournisseur, comprendre les payloads/données d'une API tierce,
+  préparer une fiche endpoint dans commons/endpoints, ou produire un document
+  d'exploration + une liste de questions pour le dev fournisseur. Triggers :
+  « explore cette API », « analyse ce swagger », « qu'est-ce qu'on peut exposer »,
+  « intégrer l'API X », « doc d'exploration », « questions pour le fournisseur ».
+---
+
+# Explorer une API fournisseur à intégrer
+
+Objectif : transformer un accès à une API tierce (swagger + doc métier + clé de
+test) en **4 livrables** exploitables par l'équipe API Entreprise / API
+Particulier :
+
+1. **Document d'exploration** (high level, en `.md` puis `.pdf` pour le PO) :
+   ce que renvoie l'API, taux de remplissage réels, recommandations
+   d'exposition par cas d'usage.
+2. **Document de questions** (fichier `.txt`, bullet points, vouvoiement) à
+   destination du dev fournisseur — exploitable aussi bien dans un mail que dans
+   Tchap : tout ce qui bloque ou reste flou.
+3. **Matière pour la fiche endpoint** dans `commons/endpoints/` (périmètre,
+   ouverture, format, paramètres, mots-clés, FAQ).
+4. **Pré-cadrage technique** (brouillon, pas un plan de production) : contrat
+   cible pressenti, points d'attention SIADE, artefacts probablement concernés.
+
+Principe directeur : **ne pas se contenter du swagger**. Tester réellement
+l'API, mesurer le remplissage des champs sur un échantillon, et croiser avec les
+**cas d'usage** d'API Entreprise pour décider quoi exposer.
+
+## Déroulé
+
+Suivre ces étapes dans l'ordre. Ne pas sauter l'étape 2 (tests réels) : le
+swagger ment souvent (champs vides en prod, types optionnels toujours nuls,
+endpoints non autorisés pour la clé…).
+
+### 1. Réunir les entrées
+
+**Demander à l'utilisateur de déposer dans un dossier dédié
+(`sandbox/api/<NOM-API>/`) tous les documents amont** — a minima le **swagger /
+OpenAPI**. Travailler à partir de ce dossier.
+
+Ce dont l'exploration a besoin (ne pas inventer ce qui manque, demander) :
+
+- **Swagger / OpenAPI** du fournisseur (obligatoire).
+- **Produit cible** : API Entreprise ou API Particulier. Pour API Particulier,
+  préciser la modalité envisagée si elle est connue : Identité pivot,
+  FranceConnect, identifiant métier, ou combinaison.
+- **Doc métier** : à quoi sert la donnée, contexte réglementaire, vocabulaire du
+  domaine. Si l'utilisateur « n'y connaît rien », prévoir un **encart
+  pédagogique** dans le doc d'exploration.
+- **Besoins usagers** : demander s'il existe un **recensement des besoins**
+  (quel acteur demande quoi, pour quel cas d'usage, sous quelle base légale).
+  C'est ce qui transforme la recommandation « quoi exposer » de générique en
+  concrète, et qui permet de positionner l'API par rapport à l'existant
+  (complément vs doublon). À utiliser en étape 4.
+- **Accès de test** : tout ce qu'il faut pour appeler l'API réellement et être
+  **autonome** — URL de base (souvent absente du swagger), auth (clé/token,
+  tunnel SSH, mTLS…), identifiants de test valides. Les **modalités techniques
+  sont à l'appréciation du dev fournisseur** : lui demander de fournir ce qui
+  rend les appels possibles, sans présumer du moyen.
+- **Secret** : ne jamais afficher un token ; le consommer via `$(cat fichier)`
+  ou une variable d'env, et ne pas le committer.
+
+### 2. Tester l'API
+
+Vérifier l'accès puis récupérer un échantillon. Utiliser `scripts/probe_api.sh`
+(un appel : statut + corps joli) pour dégrossir, puis `scripts/sample_api.sh`
+pour constituer un échantillon (50–150 entités).
+
+```bash
+scripts/probe_api.sh "<URL>" "X-API-Key: $(cat .token)"
+```
+
+**Obtenir des clés d'appel valides** : pour API Entreprise, tirer un échantillon
+de **SIRET/SIREN réels** de l'API publique annuaire
+(`recherche-entreprises.api.gouv.fr/search`), filtrable par `tranche_effectif_salarie`,
+`etat_administratif`, `nature_juridique`, etc. — c'est la source la plus rapide
+pour un échantillon représentatif. Ne pas inventer d'identifiants.
+
+**Boucler proprement** : `scripts/sample_api.sh` ouvre **une seule** connexion
+réutilisable (gère le cas tunnel SOCKS/SSH pour les API derrière allowlist IP),
+boucle sur une liste d'ids, journalise `id,endpoint,http,rows` en CSV et sauve
+les payloads non vides. Préférer ce script à des appels un par un (l'allowlist IP
+et l'absence d'URL de base dans le swagger sont la norme, pas l'exception).
+
+Vérifier systématiquement :
+
+- l'endpoint répond `200` (et `401` sans token, pour confirmer l'auth) ;
+- quels endpoints sont **autorisés pour notre clé** (un `403`/`401` cible un
+  scope manquant, pas forcément une panne) ;
+- **chaque famille d'endpoint au moins une fois** : noter les `500` / non
+  implémentés en DEV (un endpoint au swagger n'est pas un endpoint qui marche —
+  ex. vues secteur/agrégées souvent cassées en démo) ;
+- les limites des endpoints batch (taille max de lot, instabilité).
+- pour API Particulier : la modalité d'appel réelle (Identité pivot,
+  FranceConnect, identifiant métier), les paramètres obligatoires, la tolérance
+  du matching et les cas où une personne non retrouvée renvoie un `404`
+  fonctionnel.
+
+### 3. Disséquer le modèle de données
+
+Sur l'endpoint de **détail** principal, documenter **chaque champ** : type,
+description, exemple, et **taux de remplissage mesuré** sur l'échantillon
+(`scripts/field_stats.py`).
+
+```bash
+scripts/field_stats.py /tmp/echantillon/*.json
+scripts/field_stats.py --format markdown --enum-limit 20 /tmp/echantillon/*.json > stats_champs.md
+```
+
+Couvrir :
+
+- champs racine + **sous-objets** + objets contenus dans les listes (adresse,
+  personnes/dirigeants, documents, événements…) ;
+- **fichiers / documents** attachés (types, métadonnées, mode de
+  téléchargement) ;
+- **événements / historisation** si l'API en expose ;
+- **valeurs d'énumération** et fréquences observées (`type`, `statut`,
+  `etat`, `categorie`, etc.) ;
+- **diversité inter-entités** (détection des fixtures) : un champ rempli à 100 %
+  mais avec **une seule valeur distincte** sur 50-150 entités différentes est un
+  signal d'alerte. `field_stats.py` affiche le nombre de valeurs distinctes ; si
+  les données ne varient quasiment pas d'une entité à l'autre, **suspecter un
+  environnement à fixtures** (le DEV rejoue des profils canned) et **exiger une
+  recette avec vraies données** avant tout engagement — le remplissage mesuré
+  n'est alors pas représentatif ;
+- **cohérence / qualité interne** (distinct du remplissage) : formats
+  incohérents d'un même champ (ex. code sur 2 vs 5 caractères), libellés qui ne
+  correspondent pas au code, champ au **nom trompeur** (ex. « code_postal »
+  contenant un département), valeurs d'un champ qui changent de type ou de
+  comportement entre endpoints. Ces incohérences deviennent des questions
+  fournisseur ;
+- les **pièges du jeu de test** : données anonymisées, champs systématiquement
+  vides en DEV (schéma présent mais non alimenté), placeholders.
+
+### 4. Croiser avec les cas d'usage
+
+Décider **quoi exposer** selon l'usage côté API Entreprise / Particulier, pas
+selon ce que l'API offre « par défaut ». Lire `references/cas-usage-et-fiche.md`
+pour les cas d'usage récurrents et le mapping donnée → usage. **Si un
+recensement des besoins usagers a été fourni (étape 1)**, le croiser
+explicitement : tableau besoin → couverture par l'API (exposé / prévu / absent),
+et positionner l'API par rapport à l'existant (complément ciblé vs doublon vs
+réponse au besoin dominant). Comparer avec une **fiche existante proche** dans
+`commons/endpoints/` (réutiliser ses partis pris : ouverture, structure).
+Attention aux versions **dépréciées** : se caler sur la fiche la plus récente.
+
+### 5. Identifier les bloquants d'intégration
+
+Vérifier explicitement (pièges les plus coûteux quand découverts tard) :
+
+- **Clé d'appel** : peut-on interroger par **SIREN/SIRET** ? C'est la clé
+  d'entrée d'API Entreprise. Si l'API n'indexe que par son id interne →
+  **bloquant**, à remonter au fournisseur.
+- **Modalité API Particulier** : peut-on interroger par Identité pivot,
+  FranceConnect ou identifiant métier ? Quels paramètres ont le plus de poids
+  dans l'identification et comment interpréter un `404` ?
+- **Ouverture** : données publiques vs protégées vs open data (pré-remplissage).
+  Repérer le gating des données personnelles (RGPD).
+- **Rate limiting & sécurité** : quotas, filtrage IP, mTLS, rotation de clé.
+- **Robustesse** : préférer **1 endpoint API Entreprise = 1 appel fournisseur**
+  (dégradation partielle plutôt que panne totale) ; éviter d'agréger plusieurs
+  appels amont derrière un endpoint.
+- **Contrat cible provisoire** : pressentir ce qui irait dans `data`, `links`
+  et `meta`, les erreurs fournisseur importantes, les règles de cache/ping, et
+  les artefacts SIADE probablement concernés. Rester au niveau débroussaillage :
+  ne pas écrire le plan de production complet.
+
+### 6. Produire les livrables
+
+Rédiger tous les livrables en **français correct, avec accents, en UTF-8**.
+
+- **Doc d'exploration** : suivre le plan de
+  `references/plan-doc-exploration.md`. Rédiger en `.md`, puis générer le PDF en
+  utilisant un **skill de conversion PDF s'il en existe un** ; sinon, l'outillage
+  local (pandoc/weasyprint). Si la conversion PDF bloque, le `.md` suffit. Pour
+  un envoi au PO, privilégier un **PDF unique auto-portant** qui bundle le doc
+  d'exploration **+ ses annexes** (stats, pré-cadrage, questions, payloads), avec
+  sauts de page entre sections.
+- **Doc de questions** : suivre `references/questions-checklist.md`. Fichier
+  **`.txt`** en **bullet points** clairs, **vouvoiement** (exploitable en mail
+  comme dans Tchap). Questions classées par priorité, **bloquants en tête**.
+- **Fiche endpoint** : rassembler les champs listés dans
+  `references/cas-usage-et-fiche.md` (s'appuyer sur les `template.*.example` de
+  `commons/endpoints/`). Le skill `edit-endpoint` peut prendre le relais pour
+  l'écriture effective.
+- **Pré-cadrage technique** : produire une section ou un fichier court. **Séparer
+  deux registres** : (a) un **design recommandé et assumé** (« si le fournisseur
+  est propre, voilà ce que je conseille » — endpoints, maille, format de réponse,
+  ordre de mise en œuvre, avec le pourquoi de chaque choix) ; (b) les
+  **questions ouvertes** qui restent à confirmer. Ne pas se contenter de lister
+  des arbitrages : **trancher**, puis isoler ce qui reste incertain. Couvrir :
+  endpoints pressentis, paramètre(s) d'appel, découpage `data` / `links` /
+  `meta`, erreurs à mapper, besoin éventuel de document download, et liste
+  indicative des zones du dépôt à regarder ensuite (`siade`, `commons/endpoints`,
+  mocks, SDK clients si signature publique).
+
+## Conventions
+
+- Travailler dans `sandbox/api/<NOM-API>/` (documents amont déposés par
+  l'utilisateur + livrables au même endroit).
+- Rédiger les livrables en **français correct avec accents** (UTF-8).
+- Conserver des noms de livrables stables quand c'est possible :
+  `exploration.md`, `questions_fournisseur.txt`, `stats_champs.md`,
+  `pre_cadrage_technique.md`, `payloads_anonymises/`, et le bundle pour le PO
+  `dossier_<NOM-API>.pdf`.
+- Ne jamais committer le token ni des payloads bruts contenant des données
+  réelles non anonymisées.
+- Anonymiser tout payload d'exemple inséré dans un livrable (masquer SIRET,
+  tronquer les textes longs, réduire les listes).

--- a/.claude/skills/explorer-api-fournisseur/references/cas-usage-et-fiche.md
+++ b/.claude/skills/explorer-api-fournisseur/references/cas-usage-et-fiche.md
@@ -1,0 +1,103 @@
+# Cas d'usage & fiche endpoint
+
+## Cas d'usage récurrents (qui pilotent « quoi exposer »)
+
+API Entreprise / Particulier sert des **administrations** qui instruisent des
+dossiers. La donnée n'a de valeur que rapportée à un usage. Les grands cas :
+
+- **Marchés publics** : vérifier existence, identité, capacité, **probité** d'un
+  candidat (état, comptes à jour, certifications, attestations de vigilance).
+- **Subventions** : instruire une demande (identité, objet, dirigeants,
+  comptes, agréments).
+- **Pré-remplissage de démarche** : récupérer des infos publiques pour éviter la
+  ressaisie usager (souvent un endpoint **open data** sans données personnelles).
+- **Contrôle / conformité** : signaux de sérieux (retards de dépôt de comptes,
+  dissolution, financements sensibles).
+- **Instruction de droits ou démarches particuliers** : vérifier un statut, une
+  éligibilité ou une situation à partir d'une Identité pivot, de FranceConnect ou
+  d'un identifiant métier. Ici, la qualité du matching est aussi importante que
+  la donnée renvoyée.
+
+Pour chaque champ de l'API, se demander : **quel cas d'usage le consomme ?** Si
+aucun → ne pas l'exposer (bruit technique). Exposer sous condition les données
+personnelles (gating RGPD) et les données sensibles.
+
+## Croiser avec les besoins usagers fournis
+
+Si un **recensement des besoins** existe (cf. entrées du skill : quel acteur
+demande quoi, base légale), ne pas se contenter des cas d'usage génériques :
+produire un **tableau besoin → couverture par l'API** (exposé / prévu mais non
+dispo / absent), puis **positionner l'API** :
+
+- répond-elle au **besoin dominant**, ou n'est-ce qu'un **complément ciblé** à
+  côté de ce qui est déjà servi (éviter de survendre) ?
+- y a-t-il **doublon** avec une donnée existante du catalogue (ex. deux notions
+  d'effectif de sources différentes) → à arbitrer et documenter.
+
+Ce croisement change la recommandation et la priorisation : il faut le faire
+quand la matière est disponible.
+
+## Comparer à l'existant
+
+Avant de recommander une structure, lire une fiche proche dans
+`commons/endpoints/api_entreprise/` (ou `api_particulier/`). Réutiliser ses
+partis pris :
+
+- **niveaux d'ouverture** : une fiche `protected` (données complètes, backoffice
+  instructeur) + éventuellement une fiche `open_data` (`public`, pré-remplissage,
+  sans PII) ;
+- **clé d'appel** (`call_id`) : SIREN / SIRET / RNA… ;
+- **modalités API Particulier** : Identité pivot, FranceConnect, identifiant
+  métier, et explication des paramètres qui sécurisent le matching ;
+- découpage des endpoints.
+
+Repérer les fiches **dépréciées** (`old_endpoint_uids`, mention v3 vs v4) pour
+se caler sur la version courante, pas l'ancienne.
+
+## Champs d'une fiche à rassembler pendant l'exploration
+
+Référence complète : `commons/endpoints/template.entreprise.yml.example` (et
+`.particulier.`). Le skill `edit-endpoint` écrit la fiche ; l'exploration doit
+fournir la matière. À ce stade, il s'agit d'un brouillon de cadrage, pas d'une
+fiche prête à intégrer en production :
+
+- `uid`, `path` (= path du swagger), `controller` (côté siade).
+- `perimeter` : `entity_type_description` (entités couvertes),
+  `geographical_scope_description` (métropole, DROM-COM, exclusions),
+  `updating_rules_description` (fréquence + source de mise à jour),
+  `entities`.
+- `call_id` : la **clé d'appel** (point critique — cf. SIREN/SIRET).
+- `provider_uids` : identifiant fournisseur.
+- `keywords` : termes de recherche métier.
+- `data.description` : nature/format des données délivrées (markdown GFM).
+- `opening` : `public` ou `protected`.
+- `format` : ex. « Donnée structurée JSON », « URL vers documents PDF ».
+- `parameters` : paramètres d'appel.
+- `faq` : questions fréquentes (ex. « mes infos ne sont pas à jour ? » → où les
+  corriger).
+- `swagger` : titre, description, tags, `attributes` (réponse JSON) ou
+  `document_url_properties` (PDF).
+
+## Contrat cible provisoire
+
+Séparer deux registres : un **design recommandé et assumé** (« si le fournisseur
+est propre, voilà ce que je conseille » — endpoints, maille, format de réponse,
+ordre de mise en œuvre, avec le pourquoi) **et** les **questions ouvertes** qui
+restent à confirmer. Trancher, ne pas se contenter de lister des arbitrages.
+
+Pour préparer la suite sans faire le travail d'intégration complet, relever :
+
+- le ou les endpoint(s) publics pressentis, avec leur paramètre d'appel ;
+- le mapping fournisseur brut → `data`, `links`, `meta` ;
+- les champs qui semblent devoir rester internes ou en `meta` technique ;
+- les erreurs fonctionnelles à distinguer des erreurs fournisseur ;
+- les besoins de document download, cache, ping, ou maintenance à éclaircir ;
+- les zones du dépôt probablement concernées plus tard : `siade`,
+  `commons/endpoints`, mocks, et SDK clients si la signature publique change.
+
+## Rappel SDK clients
+
+Toute itération sur une signature d'API publique implique de régénérer les SDK
+`clients/ruby` et `clients/node` puis une release SemVer (cf. CLAUDE.md racine).
+À mentionner dans les recommandations seulement comme point d'attention futur :
+l'exploration ne régénère pas les SDK.

--- a/.claude/skills/explorer-api-fournisseur/references/plan-doc-exploration.md
+++ b/.claude/skills/explorer-api-fournisseur/references/plan-doc-exploration.md
@@ -1,0 +1,89 @@
+# Plan du document d'exploration
+
+Document high level destiné au PO (et à l'équipe). Rédigé en `.md`, converti en
+`.pdf` simple si l'outillage local le permet. Si la conversion PDF bloque, le
+`.md` suffit. Rester factuel : distinguer ce qui est **mesuré** (échantillon
+réel) de ce qui est **supposé**.
+
+## En-tête
+
+Titre, destinataire (ex. PO API Entreprise), auteur, date, source (nom de l'API
++ environnement testé + URL de base).
+
+## Encart pédagogique (si domaine peu connu du lecteur)
+
+Expliquer le métier en quelques paragraphes : qu'est-ce que l'entité manipulée,
+les types/catégories, le vocabulaire, les obligations réglementaires qui
+expliquent certains champs. À insérer tôt dans le document.
+
+## 1. Contexte & méthode
+
+- Environnement testé, anonymisation éventuelle des données de test.
+- Taille de l'échantillon analysé, comment les ids ont été obtenus.
+- Pagination / volumétrie totale disponible.
+- Produit cible envisagé : API Entreprise ou API Particulier. Pour API
+  Particulier, préciser la modalité testée ou supposée : Identité pivot,
+  FranceConnect, identifiant métier.
+
+## 2. Vue d'ensemble de l'API
+
+Tableau des endpoints (méthode, path, usage). Distinguer endpoints « liste »
+(résumé léger) des endpoints « détail » (payload riche). Noter les endpoints
+non autorisés pour la clé.
+
+## 3. Détail du payload de l'endpoint principal
+
+- **Tableau champ par champ** : nom, type, description, **taux de remplissage
+  mesuré**, remarque. C'est le cœur du document.
+- Sous-sections pour les **sous-objets** (adresse normalisée/géocodée,
+  personnes/dirigeants, documents, événements, etc.) avec un exemple JSON.
+- Tableau des **valeurs d'énumération** importantes (types, états…) avec leur
+  fréquence.
+- Pour les listes : cardinalité observée (liste vide, 1 élément, plusieurs
+  éléments) et champs réellement remplis dans les éléments.
+
+## 4. Fichiers / documents
+
+Métadonnées disponibles, **types de documents** et leur fréquence, mode de
+téléchargement (binaire, URL), intérêt de chaque type.
+
+## 5. Événements / historisation (si applicable)
+
+Ce que trace l'API (modifications, snapshots avant/après), champs clés.
+
+## 6. Limitations & points d'attention
+
+Lister les **bloquants en tête** (encadré visible). Typiquement : pas d'accès
+par SIREN/SIRET, champs vides en DEV, scope manquant, limites de batch, données
+anonymisées, champs jamais remplis.
+
+## 7. Contrat cible provisoire
+
+Pré-cadrage technique, sans écrire le plan de production complet :
+
+- endpoint(s) API Entreprise / Particulier pressentis ;
+- paramètre(s) d'appel : SIREN, SIRET, RNA, Identité pivot, FranceConnect,
+  identifiant métier ;
+- découpage probable `data` / `links` / `meta` ;
+- documents à exposer en URL ou en binaire, si applicable ;
+- erreurs fournisseur à mapper : non trouvé fonctionnel, indisponibilité,
+  timeout, réponse inexploitable ;
+- règles à clarifier plus tard : cache, ping, maintenance, SDK clients si la
+  signature publique évolue.
+
+## 8. Recommandations pour API Entreprise / Particulier
+
+- **8.0 Préalable bloquant** s'il y en a un (ex. clé d'appel SIREN/SIRET,
+  impossibilité de matcher une identité, identifiant interne inaccessible).
+- **8.1 Cadre & découpage** : comparer à une fiche existante du catalogue,
+  poser le principe 1 endpoint = 1 appel fournisseur, niveaux d'ouverture
+  (protected / open_data).
+- **Mapping cas d'usage → données** (tableau).
+- **Ce qu'on expose / sous condition / ne pas exposer** (justifié).
+- **Points de vigilance** de mise en œuvre (RGPD, clé d'appel, fraîcheur,
+  robustesse, mise à jour des SDK clients).
+
+## Annexe — exemples de payloads (anonymisés)
+
+Un exemple par type d'endpoint (détail, événements, liste). Masquer SIRET,
+tronquer les textes longs, réduire les listes en indiquant les totaux.

--- a/.claude/skills/explorer-api-fournisseur/references/questions-checklist.md
+++ b/.claude/skills/explorer-api-fournisseur/references/questions-checklist.md
@@ -1,0 +1,91 @@
+# Checklist des questions au dev fournisseur
+
+Catégories à balayer. Garder uniquement les questions pertinentes pour l'API en
+cours. **Mettre les bloquants en tête.**
+
+Format du livrable : fichier **`.txt`**, **bullet points** clairs, regroupés par
+thème, **vouvoiement** — exploitable aussi bien dans un mail que dans Tchap (pas
+de `#`, `**`, backticks). Formuler les questions ci-dessous au vouvoiement.
+
+## Clé d'appel (souvent BLOQUANT)
+
+- Peut-on récupérer une entité par **SIRET / SIREN** ? Sinon quelle est la clé
+  d'appel (identifiant interne uniquement ?) et la méthode recommandée ?
+- Existe-t-il un endpoint de recherche ? Est-il autorisé pour notre clé ?
+  Permet-il un **match exact** (vs plein texte) ?
+
+## Modalités API Particulier (si concerné)
+
+- L'API peut-elle être appelée avec une Identité pivot ? Quels champs sont
+  obligatoires et lesquels améliorent fortement le matching ?
+- L'API peut-elle être appelée via FranceConnect ? Si oui, quelles données du
+  jeton sont utilisées pour identifier la personne ?
+- Existe-t-il un identifiant métier plus fiable que l'identité ? Comment est-il
+  obtenu par un usager ou une administration ?
+- Comment distinguer une personne réellement non trouvée d'une identité
+  insuffisamment précise ou ambiguë ?
+- Quels exemples de personnes de test couvrent les cas limites utiles :
+  homonymie, naissance à l'étranger, changement de nom, dossier récent,
+  bénéficiaire non éligible ?
+
+## Données métier / champs
+
+- Quels champs vides en environnement de test sont **réellement alimentés en
+  prod** ? Source et fréquence de mise à jour ?
+- Comment sont calculés les champs dérivés / indicateurs ?
+- Énumérations : liste exhaustive des valeurs possibles d'un champ « type » /
+  « état » ?
+- Garantie de présence : quels champs sont toujours là vs `null`/absents ?
+- Les listes peuvent-elles être vides ? Quelle cardinalité maximale réaliste
+  faut-il prévoir pour les listes de documents, personnes, établissements ou
+  événements ?
+
+## Données de test / fixtures (si environnement DEV)
+
+- L'environnement de test renvoie-t-il de **vraies données** par entité, ou un
+  jeu de **fixtures** rejoué (mêmes valeurs quel que soit l'identifiant) ?
+- Existe-t-il une **recette/préprod avec données réelles** (sous habilitation)
+  pour valider la forme et le remplissage exacts avant la prod ?
+
+## Cohérence / qualité des données (incohérences constatées)
+
+- Champs dont le **format varie** (ex. un code tantôt sur 2, tantôt sur 5
+  caractères) : quelle est la règle et la nomenclature de référence ?
+- **Libellés** qui ne correspondent pas au code associé : bug ou comportement
+  attendu ?
+- Champs au **nom trompeur** (ex. un « code postal » contenant un département) :
+  pouvez-vous confirmer le contenu réel et/ou clarifier le nom ?
+- Champs dont le **type ou le comportement change** d'un endpoint à l'autre
+  (ex. même champ `null` ici, `0` là) : est-ce normal ?
+- Champs **non documentés** présents dans les réponses : à quoi servent-ils,
+  faut-il les ignorer ?
+
+## Données personnelles / sensibles
+
+- Les données personnelles (dirigeants…) sont-elles réelles en prod ?
+- Comportement exact du flag de confidentialité (objet vidé, partiel, masqué) ?
+
+## Documents / fichiers
+
+- Durée de validité des identifiants / URLs de fichiers ? Purge / expiration ?
+- Formats, types de documents, fiabilité de présence ?
+
+## Endpoints & accès
+
+- Périmètre prod : couverture complète ? Volumétrie réelle vs environnement de
+  test ?
+- Endpoints réservés (ex. vue dédiée à un consommateur) : peut-on y accéder ?
+- Quels codes HTTP et formats d'erreur sont renvoyés pour : non trouvé,
+  mauvais paramètre, droits insuffisants, indisponibilité, timeout, réponse
+  partielle ?
+
+## Sécurité & exploitation (à anticiper côté intégration)
+
+- Rate limiting (req/s, quotas par clé, burst) ? Seuils par endpoint ?
+- Contrôle d'accès : filtrage IP / allow-list, mTLS ? IP sortantes à déclarer ?
+- Gestion des clés (rotation, révocation, durée de vie) ?
+- SLA / disponibilité, fenêtres de maintenance ?
+- Environnement de **recette avec données réelles** (sous habilitation) pour
+  valider la forme exacte des payloads avant prod ?
+- Contraintes utiles au pré-cadrage : timeout recommandé, latence habituelle,
+  cache autorisé ou interdit, route de supervision/ping disponible ?

--- a/.claude/skills/explorer-api-fournisseur/scripts/field_stats.py
+++ b/.claude/skills/explorer-api-fournisseur/scripts/field_stats.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""Taux de remplissage des champs sur un échantillon de payloads JSON.
+
+Mesure, pour chaque champ (chemin aplati), la part d'entités où il est
+renseigné (non null, non chaîne vide, non liste/dict vide). Indispensable pour
+distinguer un champ « théorique » (présent au schéma, toujours vide) d'un champ
+réellement exploitable.
+
+Affiche aussi le nombre de **valeurs distinctes** par champ scalaire : un champ
+rempli à 100 % mais avec 1 seule valeur distincte sur un échantillon de
+plusieurs entités est un signal d'**environnement à fixtures** (données canned,
+non représentatives) — exiger alors une recette avec vraies données.
+
+Usage:
+  field_stats.py fichiers.json...           # un objet par fichier
+  field_stats.py --key data.items liste.json # une liste sous une clé
+  field_stats.py --format markdown *.json > stats_champs.md
+  field_stats.py --format csv *.json > stats_champs.csv
+  cat liste.json | field_stats.py -          # liste JSON sur stdin
+"""
+import argparse
+import csv
+import json
+import sys
+from collections import Counter, defaultdict
+
+
+SCALAR_TYPES = (str, int, float, bool)
+ENUM_NAME_HINTS = (
+    "type",
+    "statut",
+    "status",
+    "etat",
+    "state",
+    "categorie",
+    "category",
+    "code",
+    "nature",
+    "qualite",
+    "role",
+)
+
+
+def is_filled(v):
+    if v is None:
+        return False
+    if isinstance(v, (str, list, dict)) and len(v) == 0:
+        return False
+    return True
+
+
+def is_scalar(v):
+    return v is None or isinstance(v, SCALAR_TYPES)
+
+
+def type_name(v):
+    if v is None:
+        return "null"
+    if isinstance(v, bool):
+        return "boolean"
+    if isinstance(v, int) and not isinstance(v, bool):
+        return "integer"
+    if isinstance(v, float):
+        return "number"
+    if isinstance(v, str):
+        return "string"
+    if isinstance(v, list):
+        return "array"
+    if isinstance(v, dict):
+        return "object"
+    return type(v).__name__
+
+
+def example_value(values):
+    for value in values:
+        if not is_filled(value):
+            continue
+        if isinstance(value, SCALAR_TYPES):
+            text = str(value)
+        else:
+            text = json.dumps(value, ensure_ascii=False, sort_keys=True)
+        return text[:117] + "..." if len(text) > 120 else text
+    return ""
+
+
+def get_by_key(data, key):
+    current = data
+    for part in key.split("."):
+        if not isinstance(current, dict) or part not in current:
+            raise KeyError(f"Clé introuvable: {key}")
+        current = current[part]
+    return current
+
+
+def walk(obj, prefix, out, list_lengths):
+    if prefix:
+        out[prefix].append(obj)
+
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            p = f"{prefix}.{k}" if prefix else k
+            walk(v, p, out, list_lengths)
+    elif isinstance(obj, list):
+        if prefix:
+            list_lengths[prefix].append(len(obj))
+        for item in obj:
+            walk(item, f"{prefix}[]", out, list_lengths)
+
+
+def nearest_list_path(path):
+    idx = path.rfind("[]")
+    if idx == -1:
+        return None
+    return path[:idx]
+
+
+def load_json(path):
+    if path == "-":
+        return json.load(sys.stdin)
+    with open(path) as f:
+        return json.load(f)
+
+
+def coerce_records(data, key):
+    if key:
+        data = get_by_key(data, key)
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        return [data]
+    raise TypeError("Le JSON racine doit être un objet ou une liste.")
+
+
+def load_records(paths, key):
+    records = []
+    for path in paths or ["-"]:
+        records.extend(coerce_records(load_json(path), key))
+    return records
+
+
+def build_stats(records):
+    n = len(records)
+    if n == 0:
+        raise ValueError("Aucun enregistrement.")
+
+    record_seen = Counter()
+    record_filled = Counter()
+    item_seen = Counter()
+    item_filled = Counter()
+    values_by_path = defaultdict(list)
+    list_lengths = defaultdict(list)
+    types_by_path = defaultdict(Counter)
+    enum_values = defaultdict(Counter)
+
+    for r in records:
+        per_record = defaultdict(list)
+        walk(r, "", per_record, list_lengths)
+        for path, values in per_record.items():
+            record_seen[path] += 1
+            values_by_path[path].extend(values)
+            for value in values:
+                types_by_path[path][type_name(value)] += 1
+                if is_scalar(value) and is_filled(value):
+                    enum_values[path][str(value)] += 1
+            if any(is_filled(value) for value in values):
+                record_filled[path] += 1
+
+    for path, values in values_by_path.items():
+        item_seen[path] = len(values)
+        item_filled[path] = sum(1 for value in values if is_filled(value))
+
+    return {
+        "n": n,
+        "record_seen": record_seen,
+        "record_filled": record_filled,
+        "item_seen": item_seen,
+        "item_filled": item_filled,
+        "values_by_path": values_by_path,
+        "list_lengths": list_lengths,
+        "types_by_path": types_by_path,
+        "enum_values": enum_values,
+    }
+
+
+def row_for_path(path, stats, enum_limit):
+    n = stats["n"]
+    values = stats["values_by_path"][path]
+    record_filled = stats["record_filled"][path]
+    filled_pct = 100 * record_filled / n
+    list_values = stats["list_lengths"].get(path, [])
+    list_min = min(list_values) if list_values else ""
+    list_max = max(list_values) if list_values else ""
+    list_avg = f"{sum(list_values) / len(list_values):.1f}" if list_values else ""
+    list_path = nearest_list_path(path)
+    item_total = sum(stats["list_lengths"].get(list_path, [])) if list_path else ""
+    item_filled = stats["item_filled"][path] if list_path else ""
+    item_pct = (100 * item_filled / item_total) if item_total else ""
+    enum = enum_summary(path, stats["enum_values"][path], enum_limit)
+
+    return {
+        "path": path,
+        "types": ", ".join(sorted(stats["types_by_path"][path])),
+        "present_records": stats["record_seen"][path],
+        "filled_records": record_filled,
+        "total_records": n,
+        "filled_pct": f"{filled_pct:.0f}%",
+        "distinct": len(stats["enum_values"][path]),
+        "item_filled": item_filled,
+        "item_total": item_total,
+        "item_filled_pct": f"{item_pct:.0f}%" if item_pct != "" else "",
+        "list_min": list_min,
+        "list_max": list_max,
+        "list_avg": list_avg,
+        "example": example_value(values),
+        "enum_values": enum,
+    }
+
+
+def enum_summary(path, counts, enum_limit):
+    if not counts:
+        return ""
+    looks_like_enum = any(hint in path.lower().split(".")[-1] for hint in ENUM_NAME_HINTS)
+    has_repeated_values = len(counts) < sum(counts.values())
+    if not looks_like_enum and (len(counts) > enum_limit or not has_repeated_values):
+        return ""
+    values = counts.most_common(enum_limit)
+    suffix = "..." if len(counts) > enum_limit else ""
+    return ", ".join(f"{value} ({count})" for value, count in values) + suffix
+
+
+def fixture_warning(rows, n):
+    if n < 10:
+        return ""
+    suspects = [r["path"] for r in rows if r["distinct"] == 1 and r["filled_records"] == n]
+    if not suspects:
+        return ""
+    head = ", ".join(suspects[:8]) + ("…" if len(suspects) > 8 else "")
+    return (
+        f"\n⚠️  {len(suspects)} champ(s) remplis à 100 % avec 1 SEULE valeur "
+        f"distincte sur {n} enregistrements : {head}\n"
+        "    → suspecter des données de fixtures (canned), non représentatives. "
+        "Exiger une recette avec vraies données.\n"
+    )
+
+
+def render_text(stats, enum_limit):
+    rows = [row_for_path(path, stats, enum_limit) for path in sorted(stats["values_by_path"])]
+    width = max(len(row["path"]) for row in rows)
+    print(f"n = {stats['n']} enregistrements\n")
+    for row in rows:
+        suffixes = []
+        if row["item_total"] != "":
+            suffixes.append(f"items {row['item_filled_pct']} ({row['item_filled']}/{row['item_total']})")
+        if row["list_avg"] != "":
+            suffixes.append(f"liste min/max/moy {row['list_min']}/{row['list_max']}/{row['list_avg']}")
+        if row["enum_values"]:
+            suffixes.append(f"valeurs: {row['enum_values']}")
+        suffix = "  |  " + " ; ".join(suffixes) if suffixes else ""
+        distinct = f" d={row['distinct']}" if row["distinct"] else ""
+        print(
+            f"{row['path']:<{width}}  {row['filled_pct']:>4} "
+            f"({row['filled_records']}/{row['total_records']}){distinct}  "
+            f"{row['types']}{suffix}"
+        )
+    warning = fixture_warning(rows, stats["n"])
+    if warning:
+        print(warning)
+
+
+def render_markdown(stats, enum_limit):
+    rows = [row_for_path(path, stats, enum_limit) for path in sorted(stats["values_by_path"])]
+    print(f"n = {stats['n']} enregistrements\n")
+    warning = fixture_warning(rows, stats["n"])
+    if warning:
+        print("> " + warning.strip().replace("\n", "\n> ") + "\n")
+    print("| Champ | Type(s) | Remplissage | Distinct | Items | Cardinalité liste | Exemple | Valeurs observées |")
+    print("|---|---|---:|---:|---:|---:|---|---|")
+    for row in rows:
+        items = ""
+        if row["item_total"] != "":
+            items = f"{row['item_filled_pct']} ({row['item_filled']}/{row['item_total']})"
+        cardinality = ""
+        if row["list_avg"] != "":
+            cardinality = f"{row['list_min']}/{row['list_max']}/{row['list_avg']}"
+        print(
+            "| {path} | {types} | {filled_pct} ({filled_records}/{total_records}) | "
+            "{distinct} | {items} | {cardinality} | {example} | {enum_values} |".format(
+                **{key: markdown_cell(value) for key, value in row.items()},
+                items=items,
+                cardinality=cardinality,
+            )
+        )
+
+
+def markdown_cell(value):
+    return str(value).replace("\n", " ").replace("|", "\\|")
+
+
+def render_csv(stats, enum_limit):
+    rows = [row_for_path(path, stats, enum_limit) for path in sorted(stats["values_by_path"])]
+    fieldnames = [
+        "path",
+        "types",
+        "present_records",
+        "filled_records",
+        "total_records",
+        "filled_pct",
+        "distinct",
+        "item_filled",
+        "item_total",
+        "item_filled_pct",
+        "list_min",
+        "list_max",
+        "list_avg",
+        "example",
+        "enum_values",
+    ]
+    writer = csv.DictWriter(sys.stdout, fieldnames=fieldnames)
+    writer.writeheader()
+    writer.writerows(rows)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("files", nargs="*", help="Fichiers JSON à analyser, ou '-' pour stdin.")
+    parser.add_argument("--key", help="Clé contenant la liste à analyser, notation pointée acceptée.")
+    parser.add_argument("--format", choices=("text", "markdown", "csv"), default="text")
+    parser.add_argument("--enum-limit", type=int, default=10, help="Nombre max de valeurs d'énumération affichées.")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    try:
+        stats = build_stats(load_records(args.files, args.key))
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as e:
+        print(str(e), file=sys.stderr)
+        sys.exit(1)
+
+    if args.format == "markdown":
+        render_markdown(stats, args.enum_limit)
+    elif args.format == "csv":
+        render_csv(stats, args.enum_limit)
+    else:
+        render_text(stats, args.enum_limit)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/explorer-api-fournisseur/scripts/probe_api.sh
+++ b/.claude/skills/explorer-api-fournisseur/scripts/probe_api.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Sonde un endpoint d'API : statut HTTP + corps joliment formaté.
+# Ne jamais mettre le token en dur : le passer via $(cat .token) ou une variable.
+#
+# Usage:
+#   probe_api.sh [--timeout SEC] [--show-headers] [--save-dir DIR] <URL> [HEADER ...] [-d <BODY>] [-X <METHOD>]
+#
+# Exemples:
+#   probe_api.sh "https://api.exemple/v1/ressource/123" "X-API-Key: $(cat .token)"
+#   probe_api.sh "https://api.exemple/v1/search" "X-API-Key: $(cat .token)" \
+#     "Content-Type: application/json" -X POST -d '{"q":"foo"}'
+#   probe_api.sh --show-headers --save-dir sandbox/api/demo/probes \
+#     "https://api.exemple/v1/ressource/123" "Authorization: Bearer $(cat .token)"
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 [--timeout SEC] [--show-headers] [--save-dir DIR] <URL> [HEADER ...] [-d BODY] [-X METHOD]" >&2
+  exit 2
+fi
+
+URL=""
+ARGS=()
+TIMEOUT="20"
+SHOW_HEADERS=false
+SAVE_DIR=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --timeout) TIMEOUT="$2"; shift 2 ;;
+    --show-headers) SHOW_HEADERS=true; shift ;;
+    --save-dir|--save) SAVE_DIR="$2"; shift 2 ;;
+    -d) ARGS+=(--data "$2"); shift 2 ;;
+    -X) ARGS+=(-X "$2"); shift 2 ;;
+    *)
+      if [ -z "$URL" ]; then
+        URL="$1"
+      else
+        ARGS+=(-H "$1")
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$URL" ]; then
+  echo "URL manquante" >&2
+  exit 2
+fi
+
+BODY_FILE="$(mktemp)"
+HEADERS_FILE="$(mktemp)"
+trap 'rm -f "$BODY_FILE" "$HEADERS_FILE"' EXIT
+
+set +e
+META="$(curl -sS --max-time "$TIMEOUT" -D "$HEADERS_FILE" -o "$BODY_FILE" \
+  -w '%{http_code} %{time_total} %{size_download} %{content_type}' \
+  "${ARGS[@]}" "$URL")"
+CURL_STATUS=$?
+set -e
+
+if [ "$CURL_STATUS" -ne 0 ]; then
+  echo "curl a échoué (exit $CURL_STATUS) pour $URL" >&2
+  exit "$CURL_STATUS"
+fi
+
+read -r CODE TIME_TOTAL SIZE_DOWNLOAD CONTENT_TYPE <<< "$META"
+
+echo "HTTP $CODE  $URL"
+echo "time=${TIME_TOTAL}s size=${SIZE_DOWNLOAD}B content_type=${CONTENT_TYPE:-unknown}"
+echo "---"
+if [ "$SHOW_HEADERS" = true ]; then
+  sed -n '1,40p' "$HEADERS_FILE"
+  echo "---"
+fi
+if command -v python3 >/dev/null && python3 -c "import json,sys; json.load(open('$BODY_FILE'))" 2>/dev/null; then
+  python3 -m json.tool "$BODY_FILE"
+else
+  head -c 2000 "$BODY_FILE"; echo
+fi
+
+if [ -n "$SAVE_DIR" ]; then
+  mkdir -p "$SAVE_DIR"
+  STAMP="$(date +%Y%m%dT%H%M%S)"
+  cp "$BODY_FILE" "$SAVE_DIR/${STAMP}_body.txt"
+  cp "$HEADERS_FILE" "$SAVE_DIR/${STAMP}_headers.txt"
+  {
+    echo "url=$URL"
+    echo "http_code=$CODE"
+    echo "time_total=$TIME_TOTAL"
+    echo "size_download=$SIZE_DOWNLOAD"
+    echo "content_type=${CONTENT_TYPE:-unknown}"
+  } > "$SAVE_DIR/${STAMP}_meta.txt"
+  echo "---"
+  echo "Sauvegardé dans $SAVE_DIR/${STAMP}_{body,headers,meta}.txt"
+fi

--- a/.claude/skills/explorer-api-fournisseur/scripts/sample_api.sh
+++ b/.claude/skills/explorer-api-fournisseur/scripts/sample_api.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Échantillonnage d'une API fournisseur sur une liste d'identifiants.
+#
+# Ouvre UNE seule connexion réutilisable (option tunnel SOCKS/SSH pour les API
+# derrière allowlist IP), boucle sur les ids et sur un ou plusieurs templates
+# d'endpoint, journalise id,endpoint,http,rows en CSV et sauve les réponses 200
+# non vides. Préférer ce script à des appels un par un.
+#
+# Usage :
+#   sample_api.sh --base-url URL --ids FICHIER --endpoint 'TEMPLATE' [...] \
+#                 [--auth 'Header: valeur'] [--ssh-host HOST] \
+#                 [--out DIR] [--max N] [--max-time SEC]
+#
+# - FICHIER : un identifiant par ligne (ex. SIRET/SIREN tirés de
+#   recherche-entreprises.api.gouv.fr).
+# - TEMPLATE : chemin contenant le placeholder {id}, ex. '/v0/turnover-stock/{id}'.
+#   Répétable (--endpoint A --endpoint B).
+# - --auth : en-tête d'authentification, ex. "Authorization: Bearer $(cat .token)"
+#   (passer le secret via $(cat ...), ne pas l'écrire en clair).
+# - --ssh-host : si fourni, tunnel SOCKS5 dynamique via cet host (allowlist IP).
+# - --out : dossier de sortie (défaut: payloads_raw). --max : nb max d'ids.
+#
+# Exemple :
+#   sample_api.sh --base-url https://api-demo.example.gouv.fr \
+#     --ids sirets.txt --ssh-host watchdoge \
+#     --auth "Authorization: Bearer $(cat .token)" \
+#     --endpoint '/v0/turnover-stock/{id}' --endpoint '/v0/pyramide-stock/{id}'
+
+base_url="" ids_file="" auth="" ssh_host="" out="payloads_raw"
+max=100 max_time=20
+endpoints=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base-url) base_url="$2"; shift 2 ;;
+    --ids)      ids_file="$2"; shift 2 ;;
+    --auth)     auth="$2"; shift 2 ;;
+    --ssh-host) ssh_host="$2"; shift 2 ;;
+    --endpoint) endpoints+=("$2"); shift 2 ;;
+    --out)      out="$2"; shift 2 ;;
+    --max)      max="$2"; shift 2 ;;
+    --max-time) max_time="$2"; shift 2 ;;
+    *) echo "Option inconnue: $1" >&2; exit 64 ;;
+  esac
+done
+
+[[ -n "$base_url" && -n "$ids_file" && ${#endpoints[@]} -gt 0 ]] || {
+  echo "usage: $0 --base-url URL --ids FICHIER --endpoint 'TEMPLATE' [...] [--auth H] [--ssh-host HOST] [--out DIR] [--max N]" >&2
+  exit 64
+}
+[[ -r "$ids_file" ]] || { echo "Fichier d'ids introuvable: $ids_file" >&2; exit 66; }
+
+label() { echo "$1" | sed -E 's#\{id\}##; s#^/+##; s#/+$##; s#[/{}]+#_#g; s#_+#_#g; s#^_##; s#_$##'; }
+
+rm -rf "$out"; mkdir -p "$out"
+log="$(dirname "$out")/sample_log.csv"; [[ "$(dirname "$out")" == "." ]] && log="sample_log.csv"
+echo "id,endpoint,http,rows" > "$log"
+
+curl_args=(-sS --max-time "$max_time" -H "Accept: application/json")
+[[ -n "$auth" ]] && curl_args+=(-H "$auth")
+
+socks=""
+if [[ -n "$ssh_host" ]]; then
+  port="$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')"
+  sock="$(mktemp -u -t sample-ssh.XXXXXX)"
+  cleanup() { [[ -S "$sock" ]] && ssh -S "$sock" -O exit "$ssh_host" >/dev/null 2>&1 || true; }
+  trap cleanup EXIT INT TERM
+  echo "Tunnel SOCKS5 via $ssh_host (127.0.0.1:$port)" >&2
+  ssh -fN -M -S "$sock" -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 \
+      -D "127.0.0.1:$port" "$ssh_host"
+  socks="127.0.0.1:$port"
+fi
+
+n=0
+while read -r id; do
+  id="$(echo "$id" | tr -d '\r\n ')"
+  [[ -n "$id" ]] || continue
+  n=$((n+1)); [[ $n -gt $max ]] && break
+  for tpl in "${endpoints[@]}"; do
+    lbl="$(label "$tpl")"; mkdir -p "$out/$lbl"
+    path="${tpl//\{id\}/$id}"
+    [[ -n "$socks" ]] && net=(--socks5-hostname "$socks") || net=()
+    resp="$(curl "${curl_args[@]}" "${net[@]}" -w $'\n%{http_code}' "${base_url%/}${path}" || true)"
+    code="${resp##*$'\n'}"; body="${resp%$'\n'*}"
+    rows=0
+    if [[ "$code" == "200" ]]; then
+      rows="$(printf '%s' "$body" | jq 'if type=="array" then length elif type=="object" then 1 else 0 end' 2>/dev/null || echo 0)"
+      [[ "$rows" -gt 0 ]] && printf '%s' "$body" > "$out/$lbl/$id.json"
+    fi
+    echo "$id,$lbl,$code,$rows" >> "$log"
+  done
+  printf '\r%d ids traités' "$n" >&2
+done < "$ids_file"
+echo >&2
+echo "Terminé. Payloads: $out/  Logs: $log" >&2


### PR DESCRIPTION
Skill guiding the exploration of a data-provider API toward 4 deliverables (exploration doc, supplier questions, endpoint-sheet material, technical pre-framing).

Hardened by a first real run (ISE GIP-MDS API):
- sample_api.sh: generic sampling (reusable connection, SOCKS/SSH tunnel for IP allowlists, CSV log, non-empty payloads saved);
- field_stats.py: distinct-values column + fixture alert (a field filled 100% but with a single distinct value flags canned/fixture data);
- fixture detection, internal-consistency checks, calling every endpoint family, user-needs inventory as an input, opinionated pre-framing (recommended design vs open questions);
- conventions: write with accents in UTF-8, single bundled PDF for the PO.