### PR TITLE
Drop page_size=1 from TVA tabular API request

### DIFF
--- a/siade/app/interactors/dgfip/tva/make_request.rb
+++ b/siade/app/interactors/dgfip/tva/make_request.rb
@@ -14,8 +14,7 @@ class DGFIP::TVA::MakeRequest < MakeRequest::Get
 
   def request_params
     {
-      vat_no__exact: tva_number_without_fr,
-      page_size: 1
+      vat_no__exact: tva_number_without_fr
     }
   end
 

--- a/siade/spec/interactors/dgfip/tva/make_request_spec.rb
+++ b/siade/spec/interactors/dgfip/tva/make_request_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe DGFIP::TVA::MakeRequest, type: :make_request do
     let(:tva_number) { 'FR72217500016' }
     let!(:stubbed_request) do
       stub_request(:get, "#{DGFIP::TVA::MakeRequest::BASE_URL}/api/resources/#{DGFIP::TVA::MakeRequest::RESOURCE_ID}/data/")
-        .with(query: { 'vat_no__exact' => '72217500016', 'page_size' => '1' })
+        .with(query: { 'vat_no__exact' => '72217500016' })
         .to_return(status: 200, body: { data: [{ vat_no: '72217500016' }], meta: { total: 1 } }.to_json)
     end
 


### PR DESCRIPTION
The data.gouv tabular API has an off-by-one bug where page_size=1 returns meta.total=0 and an empty data array, even when the filtered row exists (confirmed against the source ODS dataset). Any page_size>=2 returns the row correctly, and so does omitting the param.

Since vat_no__exact matches at most one row, drop page_size entirely rather than papering over the upstream bug with an arbitrary value.