### PR TITLE
Force XML response from DJEPVA api-association provider

### DIFF
--- a/siade/app/interactors/mi/associations/make_request.rb
+++ b/siade/app/interactors/mi/associations/make_request.rb
@@ -27,6 +27,7 @@ class MI::Associations::MakeRequest < MakeRequest::Get
 
   def extra_headers(request)
     super
+    request['Accept'] = 'application/xml'
     request['X-Gravitee-Api-Key'] = mi_gravitee_api_key
   end
 

--- a/siade/spec/fixtures/cassettes/mi/associations/documents/no_documents_key.yml
+++ b/siade/spec/fixtures/cassettes/mi/associations/documents/no_documents_key.yml
@@ -10,7 +10,7 @@ http_interactions:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
-      - "*/*"
+      - application/xml
       User-Agent:
       - Ruby
       Content-Type:
@@ -56,7 +56,7 @@ http_interactions:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
-      - "*/*"
+      - application/xml
       User-Agent:
       - Ruby
   response:

--- a/siade/spec/fixtures/cassettes/mi/associations/documents/with_documents.yml
+++ b/siade/spec/fixtures/cassettes/mi/associations/documents/with_documents.yml
@@ -10,7 +10,7 @@ http_interactions:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
-      - "*/*"
+      - application/xml
       User-Agent:
       - Ruby
       Content-Type:

--- a/siade/spec/fixtures/cassettes/mi/associations/with_rna_not_found.yml
+++ b/siade/spec/fixtures/cassettes/mi/associations/with_rna_not_found.yml
@@ -10,7 +10,7 @@ http_interactions:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
-      - "*/*"
+      - application/xml
       User-Agent:
       - Ruby
       Content-Type:

--- a/siade/spec/fixtures/cassettes/mi/associations/with_valid_rna.yml
+++ b/siade/spec/fixtures/cassettes/mi/associations/with_valid_rna.yml
@@ -10,7 +10,7 @@ http_interactions:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
-      - "*/*"
+      - application/xml
       User-Agent:
       - Ruby
       Content-Type:

--- a/siade/spec/fixtures/cassettes/mi/associations/with_valid_siret.yml
+++ b/siade/spec/fixtures/cassettes/mi/associations/with_valid_siret.yml
@@ -10,7 +10,7 @@ http_interactions:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
-      - "*/*"
+      - application/xml
       User-Agent:
       - Ruby
       Content-Type:


### PR DESCRIPTION
DJEPVA (Le Compte Asso, MENJ gateway) silently switched its default response format from XML to JSON. We sent no Accept header, so the provider served its new JSON default. Our parser only understands XML (Ox.load expecting an <asso> root), so every response raised Ox::ParseError and surfaced as the generic "réponse invalide et inconnue" error (code 29999), both on the api-association endpoint and on the DJEPVA ping, which share the MI::Associations interactor chain.

Sending `Accept: application/xml` makes the gateway serve XML again (verified live against production), restoring the format our parser expects without rewriting the whole MI::Associations chain.

VCR cassettes are matched on request headers, so the recorded Accept header is aligned from `*/*` to `application/xml` to keep them matching.