### PR TITLE
Bust stale tabular API cache with rolling issued_date filter

### DIFF
--- a/siade/app/interactors/dgfip/tva/make_request.rb
+++ b/siade/app/interactors/dgfip/tva/make_request.rb
@@ -14,7 +14,8 @@ class DGFIP::TVA::MakeRequest < MakeRequest::Get
 
   def request_params
     {
-      vat_no__exact: tva_number_without_fr
+      vat_no__exact: tva_number_without_fr,
+      issued_date__greater: cache_busting_date
     }
   end
 
@@ -22,5 +23,10 @@ class DGFIP::TVA::MakeRequest < MakeRequest::Get
 
   def tva_number_without_fr
     context.tva_number[2..]
+  end
+
+  def cache_busting_date
+    two_day_bucket = Time.now.to_i / (86_400 * 2)
+    (Date.new(1000, 1, 1) + two_day_bucket).iso8601
   end
 end

--- a/siade/spec/interactors/dgfip/tva/make_request_spec.rb
+++ b/siade/spec/interactors/dgfip/tva/make_request_spec.rb
@@ -6,9 +6,16 @@ RSpec.describe DGFIP::TVA::MakeRequest, type: :make_request do
     let(:tva_number) { 'FR72217500016' }
     let!(:stubbed_request) do
       stub_request(:get, "#{DGFIP::TVA::MakeRequest::BASE_URL}/api/resources/#{DGFIP::TVA::MakeRequest::RESOURCE_ID}/data/")
-        .with(query: { 'vat_no__exact' => '72217500016' })
+        .with(query: { 'vat_no__exact' => '72217500016', 'issued_date__greater' => issued_date_greater })
         .to_return(status: 200, body: { data: [{ vat_no: '72217500016' }], meta: { total: 1 } }.to_json)
     end
+    let(:issued_date_greater) do
+      (Date.new(1000, 1, 1) + (Time.now.to_i / (86_400 * 2))).iso8601
+    end
+
+    before { Timecop.freeze(Time.utc(2026, 6, 26)) }
+
+    after { Timecop.return }
 
     it_behaves_like 'a make request with working mocking_params'
 


### PR DESCRIPTION
Dropping page_size=1 (commit 709fbdef) did not fix the TVA lookups: the data.gouv tabular API serves a stale cache. The dataset is refreshed daily, but once a refresh has run a fixed query keeps matching the previous (outdated) cache entry, so we never see the updated row.

Add an always-true `issued_date__greater` filter whose value rolls every two days (Time.now bucketed by 86400*2). This changes the cache key often enough to follow the daily refresh while staying stable within a window so caching still helps. The date is anchored at 1000-01-01 + bucket days, keeping it far enough in the past to never filter out the matched row.