### PR TITLE
Fix multiple errors on DJEPVA

### DIFF
--- a/siade/app/interactors/mi/associations/validate_response.rb
+++ b/siade/app/interactors/mi/associations/validate_response.rb
@@ -22,7 +22,17 @@ class MI::Associations::ValidateResponse < ValidateResponse
   def check_body_integrity!
     temporary_error! if xml_body_as_hash.nil?
   rescue Ox::ParseError
+    handle_non_xml_body!
+  end
+
+  def handle_non_xml_body!
+    return resource_not_found!(id_param) if json_not_found?
+
     unknown_provider_response!
+  end
+
+  def json_not_found?
+    valid_json? && body.match?(/not found/i)
   end
 
   def valid_association?

--- a/siade/app/interactors/mi/associations/validate_response.rb
+++ b/siade/app/interactors/mi/associations/validate_response.rb
@@ -68,7 +68,8 @@ class MI::Associations::ValidateResponse < ValidateResponse
 
     monitor_association_without_rna(id_param) if xml_body_as_hash[:asso][:identite][:regime] == 'loi1901'
 
-    %w[9220 9230 9260].include?(code_categorie_juridique)
+    code_categorie_juridique.to_s.start_with?('922') ||
+      %w[9230 9260].include?(code_categorie_juridique)
   end
 
   def not_found_in_body?

--- a/siade/app/interactors/mi/associations/validate_response.rb
+++ b/siade/app/interactors/mi/associations/validate_response.rb
@@ -2,6 +2,8 @@ class MI::Associations::ValidateResponse < ValidateResponse
   declares_no_specific_errors!
 
   def call
+    internal_server_error! if http_internal_error?
+
     check_body_integrity!
 
     resource_not_found!(id_param) if not_found_in_body? || !valid_association?

--- a/siade/spec/interactors/mi/associations/validate_response_spec.rb
+++ b/siade/spec/interactors/mi/associations/validate_response_spec.rb
@@ -17,6 +17,15 @@ RSpec.describe MI::Associations::ValidateResponse, type: :validate_response do
       its(:errors) { is_expected.to include(instance_of(ProviderUnknownError)) }
     end
 
+    describe 'when the provider returns an internal server error' do
+      let(:code) { '500' }
+      let(:body) { 'internal server error' }
+
+      it { is_expected.to be_a_failure }
+
+      its(:errors) { is_expected.to include(instance_of(ProviderInternalServerError)) }
+    end
+
     context 'with a valid code' do
       let(:code) { '200' }
 

--- a/siade/spec/interactors/mi/associations/validate_response_spec.rb
+++ b/siade/spec/interactors/mi/associations/validate_response_spec.rb
@@ -134,6 +134,22 @@ RSpec.describe MI::Associations::ValidateResponse, type: :validate_response do
 
         its(:errors) { is_expected.to include(instance_of(ProviderUnknownError)) }
       end
+
+      context 'with a JSON not found body returned by the provider' do
+        let(:body) { '{"message":"Rna W555555555 not found in rna"}' }
+
+        it { is_expected.to be_a_failure }
+
+        its(:errors) { is_expected.to include(instance_of(NotFoundError)) }
+      end
+
+      context 'with an unexpected JSON body' do
+        let(:body) { '{"message":"internal error"}' }
+
+        it { is_expected.to be_a_failure }
+
+        its(:errors) { is_expected.to include(instance_of(ProviderUnknownError)) }
+      end
     end
 
     describe 'non regression test: error message not found' do

--- a/siade/spec/interactors/mi/associations/validate_response_spec.rb
+++ b/siade/spec/interactors/mi/associations/validate_response_spec.rb
@@ -93,11 +93,22 @@ RSpec.describe MI::Associations::ValidateResponse, type: :validate_response do
               '</asso>'
           end
 
-          %w[9220 9230 9260].each do |code_asso|
-            let(:code_asso) { code_asso }
-            it { is_expected.to be_a_success }
+          %w[9220 9221 9222 9223 9224 9230 9260].each do |code|
+            context "when forme juridique is #{code}" do
+              let(:code_asso) { code }
 
-            its(:errors) { is_expected.to be_empty }
+              it { is_expected.to be_a_success }
+
+              its(:errors) { is_expected.to be_empty }
+            end
+          end
+
+          context 'when forme juridique is not an association (e.g. SCOP)' do
+            let(:code_asso) { '5658' }
+
+            it { is_expected.to be_a_failure }
+
+            its(:errors) { is_expected.to include(instance_of(NotFoundError)) }
           end
         end
       end


### PR DESCRIPTION
Since 2 days ago a lot of things change, analyze some new responses from the API to map to some new structures, qualified some non-unknown provider errors.