### PR TITLE
Harden flaky DGFIP::TVA::MakeRequest spec against time bucket drift

### DIFF
--- a/siade/spec/interactors/dgfip/tva/make_request_spec.rb
+++ b/siade/spec/interactors/dgfip/tva/make_request_spec.rb
@@ -4,16 +4,16 @@ RSpec.describe DGFIP::TVA::MakeRequest, type: :make_request do
 
     let(:params) { { siren: '217500016' } }
     let(:tva_number) { 'FR72217500016' }
+    let(:issued_date_greater) do
+      (Date.new(1000, 1, 1) + (Time.now.to_i / (86_400 * 2))).iso8601
+    end
     let!(:stubbed_request) do
+      Timecop.freeze(Time.utc(2026, 6, 26))
+
       stub_request(:get, "#{DGFIP::TVA::MakeRequest::BASE_URL}/api/resources/#{DGFIP::TVA::MakeRequest::RESOURCE_ID}/data/")
         .with(query: { 'vat_no__exact' => '72217500016', 'issued_date__greater' => issued_date_greater })
         .to_return(status: 200, body: { data: [{ vat_no: '72217500016' }], meta: { total: 1 } }.to_json)
     end
-    let(:issued_date_greater) do
-      (Date.new(1000, 1, 1) + (Time.now.to_i / (86_400 * 2))).iso8601
-    end
-
-    before { Timecop.freeze(Time.utc(2026, 6, 26)) }
 
     after { Timecop.return }
 


### PR DESCRIPTION
The stub for the tabular API encodes `issued_date__greater`, a cache-busting param derived from a 2-day bucket of `Time.now`. The production code computes the same bucket from `Time.now` at request time.

`let!(:stubbed_request)` registered its before-hook before the `before { Timecop.freeze }` hook, so the stub was built against real wall-clock time while the request under test ran against the frozen 2026-06-26 clock. Whenever CI's real time and the frozen date fell in different 2-day buckets the query param mismatched, leaving the request unmatched (VCR UnhandledHTTPRequestError) — hence the intermittent failures.

Move the Timecop freeze ahead of the stub so both the stub and the request derive the bucket from the same frozen clock, making the match deterministic.