### PR TITLE
Redirect to requested page after login

### DIFF
--- a/site/app/controllers/concerns/authenticated_user_management.rb
+++ b/site/app/controllers/concerns/authenticated_user_management.rb
@@ -12,9 +12,15 @@ module AuthenticatedUserManagement
   def authenticate_user!
     return if user_signed_in?
 
+    store_return_to_location
+
     error_message(title: t('concerns.sessions_management.unauthorized.signed_out.error.title'))
 
     redirect_to login_path
+  end
+
+  def store_return_to_location
+    session[:return_to] = request.fullpath if request.get?
   end
 
   def logged_user_not_authorized

--- a/site/app/helpers/user_sessions_helper.rb
+++ b/site/app/helpers/user_sessions_helper.rb
@@ -6,12 +6,27 @@ module UserSessionsHelper
   end
 
   def sign_in_and_redirect(user)
+    return_to = sanitized_return_to_location
     start_user_session(user)
-    redirect_current_user_to_homepage
+
+    if return_to
+      redirect_to return_to
+    else
+      redirect_current_user_to_homepage
+    end
   end
 
   def redirect_current_user_to_homepage
     redirect_to authorization_requests_path
+  end
+
+  def sanitized_return_to_location
+    location = session[:return_to]
+    return if location.blank?
+    return unless location.start_with?('/')
+    return if location.start_with?('//')
+
+    location
   end
 
   def redirect_to_root

--- a/site/spec/controllers/api_entreprise/sessions_controller_spec.rb
+++ b/site/spec/controllers/api_entreprise/sessions_controller_spec.rb
@@ -69,6 +69,32 @@ RSpec.describe APIEntreprise::SessionsController do
 
         expect(session['omniauth.pc.id_token']).to eq('must-survive-for-logout')
       end
+
+      context 'when a return_to location was stored before login' do
+        it 'redirects to the originally requested page' do
+          session[:return_to] = '/compte/jetons/42'
+
+          get :create_from_oauth, params: { provider: valid_provider }
+
+          expect(response).to redirect_to('/compte/jetons/42')
+        end
+
+        it 'ignores a non-local return_to to prevent open redirects' do
+          session[:return_to] = 'https://evil.example.com/phishing'
+
+          get :create_from_oauth, params: { provider: valid_provider }
+
+          expect(response).to redirect_to(authorization_requests_path)
+        end
+
+        it 'ignores a protocol-relative return_to to prevent open redirects' do
+          session[:return_to] = '//evil.example.com/phishing'
+
+          get :create_from_oauth, params: { provider: valid_provider }
+
+          expect(response).to redirect_to(authorization_requests_path)
+        end
+      end
     end
 
     context 'with valid provider but missing omniauth data' do

--- a/site/spec/support/shared_examples/controllers/authenticated_users_controller.rb
+++ b/site/spec/support/shared_examples/controllers/authenticated_users_controller.rb
@@ -9,6 +9,20 @@ RSpec.shared_examples 'an authenticated users controller' do |options = {}|
     end
   end
 
+  describe 'when there is no current_user_id' do
+    it 'redirects to login path' do
+      get :index
+
+      expect(response).to redirect_to(send(login_path_helper))
+    end
+
+    it 'stores the requested location to return to it after login' do
+      get :index
+
+      expect(session[:return_to]).to eq(request.fullpath)
+    end
+  end
+
   describe 'when there is a current_user_id with an id which is not in database' do
     before do
       session[:current_user_id] = '1234567890'


### PR DESCRIPTION
When a signed-out user requested a protected page, authenticate_user!
redirected to the login screen but discarded the requested URL, so after
authenticating the user always landed on the authorization requests index
instead of the page they intended to reach.

Store the requested path (GET only) in session[:return_to] before bouncing
to login, then redirect there once the session is established in
sign_in_and_redirect (covering both the ProConnect OAuth callback and the
dev_login bypass). The captured location is read before start_user_session
rotates the session, so the value is naturally cleared by reset_session and
never leaks into the next request.

sanitized_return_to_location only accepts same-host absolute paths
(rejecting absolute URLs and protocol-relative "//host" targets) to avoid
turning the post-login redirect into an open redirect, even though the
source is the signed session cookie.

