### PR TITLE
Clarify that provider habilitations table is date-scoped

### DIFF
--- a/site/app/views/provider/dashboard/section_habilitations.html.erb
+++ b/site/app/views/provider/dashboard/section_habilitations.html.erb
@@ -21,6 +21,11 @@
       ] %>
 
     <p><%= t('.description') %></p>
+    <p class="fr-hint-text">
+      <%= t('.date_scope_hint',
+        from: @filter.date_from.strftime('%d/%m/%Y'),
+        to: @filter.date_to.strftime('%d/%m/%Y')) %>
+    </p>
 
     <%= form_with url: section_path, method: :get, data: { turbo_frame: 'dashboard_habilitations' }, class: 'fr-mb-2w' do %>
       <%= hidden_field_tag 'filter[date_from]', @filter.date_from&.iso8601 %>

--- a/site/config/locales/fr.yml
+++ b/site/config/locales/fr.yml
@@ -612,6 +612,7 @@ fr:
           one: "%{count} demande sur la période"
           other: "%{count} demandes sur la période"
         description: Ensemble des demandes et habilitations ayant accès aux données liées à votre source de données.
+        date_scope_hint: "Ne sont listées que les demandes soumises entre le %{from} et le %{to} (période sélectionnée ci-dessus)."
         status_filter: Filtrer par statut
         status_all: Tous les statuts
         charts:

--- a/site/spec/features/provider/habilitations_filter_spec.rb
+++ b/site/spec/features/provider/habilitations_filter_spec.rb
@@ -22,6 +22,13 @@ RSpec.describe 'Provider: habilitations status filter', app: :api_entreprise do
     expect(page).to have_text('Demande refusée')
   end
 
+  it 'states that the table only covers requests submitted within the selected date range' do
+    visit provider_dashboard_habilitations_path(provider_uid: 'insee',
+      filter: { date_from: '2026-01-01', date_to: '2026-02-15' })
+
+    expect(page).to have_text('Ne sont listées que les demandes soumises entre le 01/01/2026 et le 15/02/2026')
+  end
+
   it 'narrows the table to the selected status' do
     visit provider_dashboard_habilitations_path(provider_uid: 'insee', filter: { statuses: ['refused'] })
 


### PR DESCRIPTION
On the provider (FD) dashboard, the last "demandes et habilitations" table filters requests by first_submitted_at within the dashboard date range. Open requests (submitted, changes_requested) are typically old but still pending, so with the default short window they fall outside the range and the table looks empty when a provider filters on those statuses — reported as a bug (API-7022) since only validated requests, which are more recent, kept showing up.

The date scoping is intentional (the count is announced "sur la période"), so rather than change the filtering, spell it out: add a hint under the description stating the table only lists requests submitted between the selected date_from and date_to. This removes the surprise without altering the numbers, and points providers to widen the period to see older pending requests.