### PR TITLE
Remove agricultural lycées 2026-2027 availability estimate

### DIFF
--- a/commons/endpoints/api_particulier/education_nationale_statut_eleve.yml
+++ b/commons/endpoints/api_particulier/education_nationale_statut_eleve.yml
@@ -34,7 +34,7 @@ fiche:
 
         **Les établissements et formations suivants ne sont pas couverts par l'API** :
         - ❌ établissements privés hors contrat ;
-        - ❌ lycées agricoles (à venir pour l'année scolaire 2026-2027) ;
+        - ❌ lycées agricoles ;
         - ❌ instruction dans la famille ;
         - ❌ BTS et Classe préparatoire aux grandes écoles, diffusés par l'[API Statut étudiant](https://particulier.api.gouv.fr/catalogue/mesri/statut_etudiant).
       geographical_scope_description: &men_scolarite_geo |+

--- a/commons/endpoints/api_particulier/v2_education_nationale_statut_eleve.yml
+++ b/commons/endpoints/api_particulier/v2_education_nationale_statut_eleve.yml
@@ -28,7 +28,7 @@ fiche:
 
         **Les établissements et formations suivants ne sont pas couverts par l'API** :
         - ❌ établissements privés hors contrat ;
-        - ❌ lycées agricoles (à venir pour l'année scolaire 2026-2027) ;
+        - ❌ lycées agricoles ;
         - ❌ instruction dans la famille ;
         - ❌ BTS et Classe préparatoire aux grandes écoles, diffusés par l'[API Statut étudiant](https://particulier.api.gouv.fr/catalogue/mesri/statut_etudiant).
       geographical_scope_description:  |+


### PR DESCRIPTION
Le FD n'est pas sûr que les données des lycées agricoles seront intégrées pour l'année scolaire 2026-2027. Dans le doute, on retire la date jusqu'à un "go" du FD, pour ne pas afficher une échéance non garantie aux utilisateurs de l'API statut élève.