### PR TITLE
Reset blacklisted_at when regenerating a banned token

### DIFF
--- a/site/app/interactors/admin/tokens/regenerate_token.rb
+++ b/site/app/interactors/admin/tokens/regenerate_token.rb
@@ -13,6 +13,7 @@ class Admin::Tokens::RegenerateToken < ApplicationInteractor
 
   def create_new_token
     copy = token.dup
+    copy.blacklisted_at = nil
     copy.iat = Time.zone.now.to_i
     copy.save
     copy

--- a/site/spec/organizers/admin/tokens/ban_spec.rb
+++ b/site/spec/organizers/admin/tokens/ban_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe Admin::Tokens::Ban, type: :organizer do
         expect(new_token.iat).to be_within(5).of(Time.zone.now.to_i)
       end
 
+      it 'does not blacklist the newly generated token' do
+        subject
+        new_token = Token.where.not(id: token.id).order(created_at: :desc).first
+        expect(new_token.blacklisted_at).to be_nil
+      end
+
       it 'sends emails to demandeur and contact technique' do
         expect { subject }.to have_enqueued_job(ActionMailer::MailDeliveryJob).at_least(2).times
       end


### PR DESCRIPTION
When banning a token with regeneration, the Ban organizer runs BanToken (which sets blacklisted_at on the original token) then RegenerateToken, which builds the replacement via token.dup. dup copies every attribute including the freshly-set blacklisted_at, so the regenerated token was born banned and would expire at the exact same moment as the token it was meant to replace, defeating the purpose of regeneration.

Explicitly clear blacklisted_at on the duplicate so the new token is actually active.