### PR TITLE
Dedicated error when the recipient is not delegated (API-6615)

### DIFF
--- a/siade/app/controllers/concerns/handle_editor_delegation.rb
+++ b/siade/app/controllers/concerns/handle_editor_delegation.rb
@@ -16,15 +16,14 @@ module HandleEditorDelegation
 
   def verify_editor_delegation!
     if request.env[UserResolutionMiddleware::DELEGATION_AMBIGUOUS_ENV_KEY]
-      render_ambiguous_delegation
+      render_generic_errors_serializer(AmbiguousDelegationError, status: :unprocessable_content)
       return
     end
 
-    raise HandleTokens::NotAuthorizedError unless request.env[UserResolutionMiddleware::DELEGATION_ENV_KEY]
-  end
+    return if request.env[UserResolutionMiddleware::DELEGATION_ENV_KEY]
 
-  def render_ambiguous_delegation
-    render json: ErrorsSerializer.new([AmbiguousDelegationError.new], format: error_format).as_json,
-      status: :unprocessable_content
+    raise HandleTokens::NotAuthorizedError if params[:recipient].blank?
+
+    render_generic_errors_serializer(DelegationSiretMismatchError, status: :forbidden)
   end
 end

--- a/siade/app/errors/delegation_siret_mismatch_error.rb
+++ b/siade/app/errors/delegation_siret_mismatch_error.rb
@@ -1,0 +1,5 @@
+class DelegationSiretMismatchError < ForbiddenError
+  def code
+    '00213'
+  end
+end

--- a/siade/config/errors.yml
+++ b/siade/config/errors.yml
@@ -136,6 +136,10 @@
   source:
     parameter: 'delegation_id'
 
+- code: '00213'
+  title: 'Accès refusé'
+  detail: "Le SIREN/SIRET appelé ne correspond pas au SIRET de l'habilitation déléguée. Une délégation ne permet d'interroger que les données de l'organisation ayant délégué son habilitation."
+
 - code: '00301'
   title: 'Entité non traitable'
   detail: "Le numéro de siren n'est pas correctement formatté"

--- a/siade/config/errors.yml
+++ b/siade/config/errors.yml
@@ -138,7 +138,9 @@
 
 - code: '00213'
   title: 'Accès refusé'
-  detail: "Le SIREN/SIRET appelé ne correspond pas au SIRET de l'habilitation déléguée. Une délégation ne permet d'interroger que les données de l'organisation ayant délégué son habilitation."
+  detail: "Le paramètre recipient ne correspond à aucune habilitation déléguée à cet éditeur. Une délégation ne permet d'appeler que pour le compte de l'organisation ayant délégué son habilitation."
+  source:
+    parameter: 'recipient'
 
 - code: '00301'
   title: 'Entité non traitable'

--- a/siade/spec/errors/delegation_siret_mismatch_error_spec.rb
+++ b/siade/spec/errors/delegation_siret_mismatch_error_spec.rb
@@ -1,0 +1,3 @@
+RSpec.describe DelegationSiretMismatchError, type: :error do
+  it_behaves_like 'a valid error'
+end

--- a/siade/spec/requests/editor_delegation_spec.rb
+++ b/siade/spec/requests/editor_delegation_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Editor delegation', api: :entreprise do
       EditorDelegation.create!(editor:, authorization_request:)
     end
 
-    it 'allows the request' do
+    it 'allows querying a third-party SIREN on behalf of the delegated recipient' do
       get url, params:, headers: headers_params
 
       expect(response).not_to have_http_status(:forbidden)
@@ -117,10 +117,24 @@ RSpec.describe 'Editor delegation', api: :entreprise do
       EditorDelegation.create!(editor:, authorization_request: other_ar)
     end
 
-    it 'returns 403' do
+    it 'returns 403 with the delegation recipient mismatch error' do
       get url, params:, headers: headers_params
 
       expect(response).to have_http_status(:forbidden)
+      expect(response.parsed_body['errors'].first['code']).to eq('00213')
+    end
+  end
+
+  context 'without a recipient param' do
+    before do
+      EditorDelegation.create!(editor:, authorization_request:)
+    end
+
+    it 'is rejected by the recipient format validation before any delegation logic' do
+      get url, params: params.except(:recipient), headers: headers_params
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.parsed_body['errors'].first['code']).not_to eq('00213')
     end
   end
 
@@ -129,10 +143,11 @@ RSpec.describe 'Editor delegation', api: :entreprise do
       EditorDelegation.create!(editor:, authorization_request:, revoked_at: 1.day.ago)
     end
 
-    it 'returns 403' do
+    it 'returns 403 with the delegation recipient mismatch error' do
       get url, params:, headers: headers_params
 
       expect(response).to have_http_status(:forbidden)
+      expect(response.parsed_body['errors'].first['code']).to eq('00213')
     end
   end
 


### PR DESCRIPTION
When an editor token's `recipient` resolves to no active delegation, render the dedicated 00213 (403) instead of the generic privileges error. The called SIREN/SIRET stays free — querying third parties on the delegating org's behalf is the point of the API.

- Rework after review: v1 wrongly bound the check to the URL identifier (inverse of 372bb77f)
- The recipient→delegation binding itself already lives in `EditorDelegationResolver` (S1/S2)

Closes API-6615 → https://linear.app/pole-api/issue/API-6615/s3-enforcement-par-siret-dans-les-controleurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)