### PR TITLE
Emit token_type on user_access instrumentation

### DIFF
--- a/siade/app/controllers/concerns/handle_tokens.rb
+++ b/siade/app/controllers/concerns/handle_tokens.rb
@@ -68,7 +68,8 @@ module HandleTokens
       user: current_user.logstash_id,
       jti: current_user.token_id,
       iat: current_user.iat,
-      authorization_request_id: current_user.authorization_request_id
+      authorization_request_id: current_user.authorization_request_id,
+      token_type: current_user.token_type
     )
   end
 

--- a/siade/app/lib/jwt_user.rb
+++ b/siade/app/lib/jwt_user.rb
@@ -32,6 +32,13 @@ class JwtUser
     @editor_id.present?
   end
 
+  def token_type
+    return 'editor_token' if editor?
+    return 'france_connect' if id == self.class.france_connect_id
+
+    nil
+  end
+
   def with_delegation(authorization_request_id:, scopes:, allowed_ips:, rate_limit_per_minute:)
     self.class.new(
       uid: id,

--- a/siade/spec/acceptances/logstasher_custom_fields_spec.rb
+++ b/siade/spec/acceptances/logstasher_custom_fields_spec.rb
@@ -339,7 +339,9 @@ RSpec.describe 'logstasher custom fields', type: :controller do
             'user_access' => hash_including(
               user: yes_jwt_user.logstash_id,
               jti: yes_jwt_user.token_id,
-              iat: yes_jwt_user.iat
+              iat: yes_jwt_user.iat,
+              authorization_request_id: yes_jwt_user.authorization_request_id,
+              token_type: nil
             )
           ),
           anything

--- a/siade/spec/lib/jwt_user_spec.rb
+++ b/siade/spec/lib/jwt_user_spec.rb
@@ -147,6 +147,32 @@ RSpec.describe JwtUser do
     end
   end
 
+  describe '#token_type' do
+    context 'with a classic token' do
+      let(:jwt_user) { described_class.new(**jwt_payload) }
+
+      it 'returns nil, so existing token_id-based queries stay valid' do
+        expect(jwt_user.token_type).to be_nil
+      end
+    end
+
+    context 'with an editor token' do
+      let(:jwt_user) { described_class.new(**jwt_payload, editor_id: SecureRandom.uuid) }
+
+      it 'returns editor_token' do
+        expect(jwt_user.token_type).to eq('editor_token')
+      end
+    end
+
+    context 'with a FranceConnect user' do
+      let(:jwt_user) { described_class.new(**jwt_payload, uid: described_class.france_connect_id) }
+
+      it 'returns france_connect' do
+        expect(jwt_user.token_type).to eq('france_connect')
+      end
+    end
+  end
+
   describe '#has_custom_rate_limit?' do
     context 'with rate_limit_per_minute set' do
       let(:jwt_user) { described_class.new(**jwt_payload, rate_limit_per_minute: 100) }


### PR DESCRIPTION
access_logs must distinguish token kinds so editor_tokens, france_connect and future oauth2 calls stop being invisible to the consumption views (which today only work for classic tokens joined through `tokens`).

token_type follows a retro-compatible convention: NULL means classic token (token_id -> tokens.id), so existing token_id-based queries keep working without change and ~800M historical rows need no backfill. Only the new kinds are explicit: 'editor_token', 'france_connect' (oauth2 later).

The resolution lives on JwtUser rather than a private controller helper: the user already knows whether it is an editor (editor_id) or the FranceConnect sentinel id, so it is trivially unit-testable without controller machinery.

Closes https://linear.app/pole-api/issue/API-6617