### PR TITLE
Replace éditeur datapass form with a Typeform questionnaire

### DIFF
--- a/site/app/models/abstract_fiche_pratique.rb
+++ b/site/app/models/abstract_fiche_pratique.rb
@@ -33,8 +33,8 @@ class AbstractFichePratique
     fiche_pratique
   end
 
-  def datapass_url
-    ERB.new(request_access[:link_datapass]).result(binding)
+  def request_access_url
+    ERB.new(request_access[:url]).result(binding)
   end
 
   def endpoints

--- a/site/app/views/shared/cas_usages/_show.html.erb
+++ b/site/app/views/shared/cas_usages/_show.html.erb
@@ -57,16 +57,19 @@
     
     <% if @fiche_pratique.request_access.present? %>
       <section class="request_access fr-background-default-white">
-        <h2 id="request-access" class="request_access--title"><%= t('.request_access.title') %></h2>
+        <h2 id="request-access" class="request_access--title"><%= @fiche_pratique.request_access[:title] || t('.request_access.title') %></h2>
         <div class="request_access--content">
-          <p class="fr-text--lg"><%= t('.request_access.description') %>
+          <p class="fr-text--lg"><%= @fiche_pratique.request_access[:description] || t('.request_access.description') %>
           </p>
-          <a href="<%= @fiche_pratique.datapass_url %>" class="fr-btn fr-mt-5v fr-mb-4w" target='_blank' rel="noopener noreferrer">
-            <%= t('.request_access.link')%><span class="fr-text--bold fr-ml-1v"><%= @fiche_pratique.name %></span><span class="fr-sr-only">(nouvelle fenêtre)</span>
+          <a href="<%= @fiche_pratique.request_access_url %>" class="fr-btn fr-mt-5v fr-mb-4w" target='_blank' rel="noopener noreferrer">
+            <%= @fiche_pratique.request_access[:link] || t('.request_access.link') %><span class="fr-text--bold fr-ml-1v"><%= @fiche_pratique.name %></span><span class="fr-sr-only">(nouvelle fenêtre)</span>
           </a>
-          <p class="fr-mb-0-5v">
-            <%= t('.request_access.sub_description') %>
-          </p>
+          <% sub_description = @fiche_pratique.request_access.fetch(:sub_description) { t('.request_access.sub_description') } %>
+          <% if sub_description.present? %>
+            <p class="fr-mb-0-5v">
+              <%= sub_description %>
+            </p>
+          <% end %>
         </div>
         <div class="request_access--content"><%= markdown_to_html(@fiche_pratique.request_access[:content]) %></div>
       </section>

--- a/site/config/locales/api_entreprise/fiches_pratiques_entries.fr.yml
+++ b/site/config/locales/api_entreprise/fiches_pratiques_entries.fr.yml
@@ -139,7 +139,7 @@ fr:
             {:.fr-highlight.fr-highlight--caution}
             > ⚠️ Les données protégées doivent uniquement être utilisées par un agent habilité ou après authentification de l'usager. Elles ne doivent pas être diffusées en ligne ou à des tiers non-autorisés.
         request_access:
-          link_datapass: "<%= datapass_base_url %>/demandes/api-entreprise/nouveau?use_case=socle_de_base"
+          url: "<%= datapass_base_url %>/demandes/api-entreprise/nouveau?use_case=socle_de_base"
           content: "**💡 Votre service concerne les marchés publics ? la délivrance d'aides ou de subventions ?**
             Des cas d'usages spécifiques existent et permettent d'accéder au socle de données de base ainsi qu'à d'autres données protégées : consultez [nos cas d'usages sur simplifions.data.gouv.fr](https://simplifions.data.gouv.fr/solutions/bouquet-api-entreprise){:target=\"_blank\"}."
 
@@ -214,5 +214,8 @@ fr:
             _Vous êtes un éditeur proposant une solution de portail de gestion relation usager et ne figurez pas sur cette liste ?_ Veuillez nous contacter à cette adresse e-mail : [support@entreprise.api.gouv.fr](mailto:support@entreprise.api.gouv.fr).
 
         request_access:
-          link_datapass: "<%= datapass_base_url %>/formulaires/api-entreprise-editeur/demande/nouveau"
+          url: "https://form.typeform.com/to/aDFr3Cg9"
+          description: "Ce cas d’utilisation correspond à votre besoin ? Complétez le questionnaire de qualification éditeurs pour effectuer votre demande d'habilitation :"
+          link: "Compléter le questionnaire"
+          sub_description: ''
           content: "Pour vérifier votre éligibilité, le pôle juridique a besoin de comprendre quelles sont vos activités et le contexte dans lequel l'accès délivré sera utilisé. **Pour accélérer le traitement de votre demande, veillez à bien répondre à l'ensemble des questions posées**."


### PR DESCRIPTION
For legal reasons (Code des relations entre le public et l'administration), a software editor must no longer be able to fill in a DataPass authorization form directly. On the /fiches/editeur page, the DataPass editor form link is replaced by the Typeform qualification questionnaire, and the "DataPass" wording of the request-access section is removed for this fiche.

The request_access section now supports per-fiche overrides (title, description, link label, sub_description) falling back to the shared global locale, so socle_de_base keeps its DataPass flow untouched while editeur gets its own Typeform-oriented copy. The fiche-level url key and the model helper are renamed (link_datapass -> url, datapass_url -> request_access_url) since the destination is no longer necessarily DataPass.

Closes https://linear.app/pole-api/issue/API-7061/suppression-du-formulaire-editeurs-datapass-au-profit-dun-grist