### PR TITLE
Show endpoint version in admin api_requests selector

### DIFF
--- a/site/app/facade/api_request_facade.rb
+++ b/site/app/facade/api_request_facade.rb
@@ -23,7 +23,7 @@ class APIRequestFacade
 
   def endpoints_grouped_by_tag
     endpoints.group_by { |e| e.open_api_definition&.dig('tags')&.first || 'Autre' }
-      .transform_values { |eps| eps.map { |e| [e.title, e.uid] } }
+      .transform_values { |eps| eps.map { |e| [e.title_with_version, e.uid] } }
   end
 
   def selected_endpoint

--- a/site/app/services/open_api_endpoint.rb
+++ b/site/app/services/open_api_endpoint.rb
@@ -9,11 +9,21 @@ class OpenAPIEndpoint
 
   def uid = path
 
+  def version
+    path[%r{\A/(v\d+)/}, 1]
+  end
+
   def title
     summary = open_api_definition['summary']
     return path if summary.blank?
 
     format_title(summary)
+  end
+
+  def title_with_version
+    return title if version.blank?
+
+    "#{title} (#{version})"
   end
 
   private

--- a/site/spec/services/open_api_endpoint_spec.rb
+++ b/site/spec/services/open_api_endpoint_spec.rb
@@ -13,6 +13,50 @@ RSpec.describe OpenAPIEndpoint do
     end
   end
 
+  describe '#version' do
+    it 'extracts the version segment from the path' do
+      endpoint = described_class.new(
+        path: '/v4/dgfip/unites_legales/{siren}/liasses_fiscales/{year}',
+        open_api_definition: { 'summary' => 'Liasses fiscales' },
+        api: 'api_entreprise'
+      )
+
+      expect(endpoint.version).to eq('v4')
+    end
+
+    it 'returns nil when the path has no version segment' do
+      endpoint = described_class.new(
+        path: '/unversioned/endpoint',
+        open_api_definition: { 'summary' => 'Test' },
+        api: 'api_entreprise'
+      )
+
+      expect(endpoint.version).to be_nil
+    end
+  end
+
+  describe '#title_with_version' do
+    it 'appends the version to the title' do
+      endpoint = described_class.new(
+        path: '/v4/dgfip/unites_legales/{siren}/liasses_fiscales/{year}',
+        open_api_definition: { 'summary' => 'Liasses fiscales' },
+        api: 'api_entreprise'
+      )
+
+      expect(endpoint.title_with_version).to eq('Liasses fiscales (v4)')
+    end
+
+    it 'returns the title unchanged when there is no version' do
+      endpoint = described_class.new(
+        path: '/unversioned/endpoint',
+        open_api_definition: { 'summary' => 'Liasses fiscales' },
+        api: 'api_entreprise'
+      )
+
+      expect(endpoint.title_with_version).to eq('Liasses fiscales')
+    end
+  end
+
   describe '#title' do
     context 'when summary contains bracket notation' do
       it 'formats title with method in parentheses' do


### PR DESCRIPTION
Several endpoints share the same title across versions (e.g. "Liasses fiscales" exists in v3 and v4), making the /admin/api_requests selector ambiguous. Append the version extracted from the path so admins can tell duplicated entries apart.