### PR TITLE
Sync API Entreprise/API Particulier fiches to data.gouv.fr

### DIFF
--- a/commons/endpoints/_swagger_shared/inpi_rne.yml
+++ b/commons/endpoints/_swagger_shared/inpi_rne.yml
@@ -754,9 +754,7 @@ inpi_rne:
 
   actes_bilans:
     title: "Actes et bilans"
-    description: |
-      Liste des actes et bilans d'une unité légale inscrite au répertoire national des entreprises (RNE).
-      Seuls les actes et bilans publiques sont distribués. L'INPI peut potentiellement posséder des actes et bilans "partiellement confidentiels".
+    description: 'Liste des actes et bilans d''une unité légale inscrite au répertoire national des entreprises (RNE). Seuls les actes et bilans publiques sont distribués. L''INPI peut potentiellement posséder des actes et bilans "partiellement confidentiels".'
     tags:
       - "Informations générales"
     attributes:

--- a/commons/endpoints/api_entreprise/14_dgfip_attestation_fiscale.yml
+++ b/commons/endpoints/api_entreprise/14_dgfip_attestation_fiscale.yml
@@ -167,6 +167,7 @@ fiche:
       À part l'ajout des champs précédents, rien n'a changé. Cette montée en version n'est pas dûe à une évolution de l'API de la DGFIP, par conséquent, la version précédente est maintenue par API&nbsp;Entreprise.
   - uid: 'dgfip/v3/attestations_fiscales'
     datagouv_uid: '672cf6b2a474f2d73502b5d4'
+    sync_with_datagouv: false
     position: 9002
     new_endpoint_uids:
       - 'dgfip/attestations_fiscales'

--- a/commons/endpoints/api_entreprise/15_urssaf_attestation_vigilance.yml
+++ b/commons/endpoints/api_entreprise/15_urssaf_attestation_vigilance.yml
@@ -245,6 +245,7 @@ fiche:
             example: 86400
   - uid: 'urssaf/v3/attestation_vigilance'
     datagouv_uid: '672cf6b36452c7d61849433f'
+    sync_with_datagouv: false
     position: 9001
     ping_url: 'https://entreprise.api.gouv.fr/ping/urssaf/attestation_sociale'
     new_endpoint_uids:

--- a/commons/endpoints/api_entreprise/1_insee_etablissements.yml
+++ b/commons/endpoints/api_entreprise/1_insee_etablissements.yml
@@ -2,6 +2,7 @@
 fiche:
   - uid: 'insee/etablissements'
     datagouv_uid: '672cf6aece89cb14e31f0fba'
+    sync_with_datagouv: false
     socle_de_base:
       comment: |-
         Mêmes données que l'API open data, avec en plus les établissements en diffusion partielle. Backoffice instructeur uniquement.
@@ -146,6 +147,7 @@ fiche:
 
   - uid: 'insee/etablissements_diffusibles'
     datagouv_uid: '672cf6aece89cb14e31f0fba'
+    sync_with_datagouv: false
     socle_de_base:
       comment: |-
         Préremplir ou récupérer les informations d'un établissement et de son unité légale à partir de son SIRET&nbsp;: raison sociale, forme juridique, catégorie TPE/PME, tranche effectif, activité principale, date de création.

--- a/commons/endpoints/api_entreprise/22_qualibat_certifications_batiment.yml
+++ b/commons/endpoints/api_entreprise/22_qualibat_certifications_batiment.yml
@@ -2,6 +2,7 @@
 fiche:
   - uid: 'qualibat/v3/certifications_batiment'
     datagouv_uid: '672cf6b522535e70b5584c0e'
+    sync_with_datagouv: false
     path: '/v3/qualibat/etablissements/{siret}/certification_batiment'
     controller: 'api_entreprise/v3_and_more/qualibat/certifications_batiment'
     new_endpoint_uids:

--- a/commons/endpoints/api_entreprise/23_opqibi_certifications_ingenierie.yml
+++ b/commons/endpoints/api_entreprise/23_opqibi_certifications_ingenierie.yml
@@ -126,10 +126,7 @@ fiche:
           description: Numéro du présent certificat
           type: string
           example: 14 12 2819
-        description: 'Certification délivrée par l''association OPQIBI, attestant des différentes
-          qualifications d''ingénierie d''une unité légale.
-        
-          '
+        description: 'Certification délivrée par l''association OPQIBI, attestant des différentes qualifications d''ingénierie d''une unité légale.'
         tags:
         - Certifications professionnelles
         attributes:

--- a/commons/endpoints/api_entreprise/3_insee_adresse_etablissement.yml
+++ b/commons/endpoints/api_entreprise/3_insee_adresse_etablissement.yml
@@ -2,6 +2,7 @@
 fiche:
   - uid: 'insee/adresse_etablissements'
     datagouv_uid: '672cf6aece89cb14e31f0fba'
+    sync_with_datagouv: false
     socle_de_base:
       comment: |-
         Mêmes données que l'API open data, avec en plus les adresses en diffusion partielle. Backoffice instructeur uniquement.
@@ -106,6 +107,7 @@ fiche:
           > **Depuis 2023, les personnes morales sont concernées par la \"diffusion partielle\"**. Si elles ont exercé ce droit, vous n'avez pas le droit de pré-remplir leur données de localisation : géolocalisation, numéro et voie de l'adresse postale. La commune reste diffusible.
   - uid: 'insee/adresse_etablissements_diffusibles'
     datagouv_uid: '672cf6aece89cb14e31f0fba'
+    sync_with_datagouv: false
     socle_de_base:
       comment: |-
         Ces données sont également distribuées par l'API Données d'établissement.

--- a/commons/endpoints/api_entreprise/3_insee_siege_social.yml
+++ b/commons/endpoints/api_entreprise/3_insee_siege_social.yml
@@ -2,6 +2,7 @@
 fiche:
   - uid: 'insee/siege_social'
     datagouv_uid: '672cf6aece89cb14e31f0fba'
+    sync_with_datagouv: false
     socle_de_base:
       comment: |-
         Mêmes données que l'API open data, avec en plus les sièges en diffusion partielle. Backoffice instructeur uniquement.
@@ -151,6 +152,7 @@ fiche:
 
   - uid: 'insee/siege_social_diffusibles'
     datagouv_uid: '672cf6aece89cb14e31f0fba'
+    sync_with_datagouv: false
     socle_de_base:
       comment: |-
         À partir du Siren, récupérer les informations du siège social.

--- a/commons/endpoints/api_entreprise/3_insee_unites_legales.yml
+++ b/commons/endpoints/api_entreprise/3_insee_unites_legales.yml
@@ -2,6 +2,7 @@
 fiche:
   - uid: 'insee/unites_legales'
     datagouv_uid: '672cf6aece89cb14e31f0fba'
+    sync_with_datagouv: false
     socle_de_base:
       comment: |-
         Mêmes données que l'API open data, avec en plus les unités légales en diffusion partielle. Backoffice instructeur uniquement.
@@ -168,6 +169,7 @@ fiche:
 
   - uid: 'insee/unites_legales_diffusibles'
     datagouv_uid: '672cf6aece89cb14e31f0fba'
+    sync_with_datagouv: false
     socle_de_base:
       comment: |-
         Ces données sont également distribuées par l'API Données d'établissement.

--- a/commons/endpoints/api_entreprise/4_ministere_interieur_v4.yml
+++ b/commons/endpoints/api_entreprise/4_ministere_interieur_v4.yml
@@ -2,6 +2,7 @@
 fiche:
   - uid: 'djepva/associations'
     datagouv_uid: '672cf6af6d09c75cace6a62b'
+    sync_with_datagouv: false
     socle_de_base:
       comment: |-
         Informations complètes d'une association&nbsp;: identité, activités, agréments, représentants légaux, effectifs, données financières. Backoffice instructeur uniquement.
@@ -102,6 +103,7 @@ fiche:
           Vous pouvez l'orienter vers le [site officiel Le compte Asso](https://lecompteasso.associations.gouv.fr/declarer-un-changement-de-situation-de-mon-association/){:target="_blank"} où elle pourra déclarer son changement de situation.
   - uid: 'djepva/associations_open_data'
     datagouv_uid: '672cf6af6d09c75cace6a62b'
+    sync_with_datagouv: false
     socle_de_base:
       comment: |-
         Informations d'une association en open data utilisables pour pré-remplir une démarche sans authentification préalable.

--- a/commons/endpoints/api_entreprise/9_douanes_eori.yml
+++ b/commons/endpoints/api_entreprise/9_douanes_eori.yml
@@ -83,10 +83,7 @@ fiche:
     swagger:
       dgddi.eori:
         title: Immatriculation EORI
-        description: 'État du numéro EORI d''une entreprise indiquant si celle-ci est immatriculée
-          auprès des douanes dans le cadre de l’import/export en Union Européenne.
-        
-          '
+        description: 'État du numéro EORI d''une entreprise indiquant si celle-ci est immatriculée auprès des douanes dans le cadre de l’import/export en Union Européenne.'
         tags:
         - Informations générales
         attributes:

--- a/commons/endpoints/template.entreprise.yml.example
+++ b/commons/endpoints/template.entreprise.yml.example
@@ -2,6 +2,18 @@
 fiche:
   # L'UID sert à identifier cette entrée de manière unique, et est utilisé pour l'URL de la fiche métier
   - uid: 'provider/resource'
+    # Optionnel. Id de la fiche dataservice correspondante sur data.gouv.fr. Sert de clé de
+    # jointure avec le catalogue Simplifions pour afficher les cas d'usage de cette API sur
+    # sa fiche (site/app/stores/simplifions_store.rb, cas_usages_for_datagouv_uid côté Grist).
+    # N'est PAS utilisé par le sync vers data.gouv.fr lui-même (site/app/services/datagouv/),
+    # qui retrouve la fiche distante via son business_documentation_url.
+    datagouv_uid: '...'
+    # Optionnel. À renseigner uniquement quand plusieurs fiches (couple dépréciée/actuelle,
+    # regroupements INSEE Sirene/DJEPVA...) partagent le même dataservice data.gouv.fr : une
+    # seule fiche doit piloter le sync (site/app/services/datagouv/), les autres passent
+    # sync_with_datagouv: false pour ne pas se marcher dessus (create/update/delete concurrents
+    # sur la même fiche distante).
+    sync_with_datagouv: false
     # Optionnel. À renseigner uniquement si cette API fait partie du Socle de base DLNUF.
     # Omettre la clé si l'API n'en fait pas partie.
     socle_de_base:

--- a/commons/endpoints/template.particulier.yml.example
+++ b/commons/endpoints/template.particulier.yml.example
@@ -4,6 +4,17 @@ fiche:
   # On utilise en général <provider>/<resource>
   # N'importe quelle valeur fonctionne tant qu'elle est unique
   - uid: 'pole_emploi/situation'
+    # Optionnel. Id de la fiche dataservice correspondante sur data.gouv.fr. Sert de clé de
+    # jointure avec le catalogue Simplifions pour afficher les cas d'usage de cette API sur
+    # sa fiche (site/app/stores/simplifions_store.rb, cas_usages_for_datagouv_uid côté Grist).
+    # N'est PAS utilisé par le sync vers data.gouv.fr lui-même (site/app/services/datagouv/),
+    # qui retrouve la fiche distante via son business_documentation_url.
+    datagouv_uid: '...'
+    # Optionnel. À renseigner uniquement quand plusieurs fiches (couple dépréciée/actuelle...)
+    # partagent le même dataservice data.gouv.fr : une seule fiche doit piloter le sync
+    # (site/app/services/datagouv/), les autres passent sync_with_datagouv: false pour ne pas
+    # se marcher dessus (create/update/delete concurrents sur la même fiche distante).
+    sync_with_datagouv: false
     # Ne peut être que public ou protected
     opening: public
     # Le(s) paramètre(s) utilisé pour appeller l'endpoint

--- a/commons/swagger/openapi-entreprise.yaml
+++ b/commons/swagger/openapi-entreprise.yaml
@@ -4860,11 +4860,9 @@ paths:
           type: string
       security:
       - jwt_bearer_token: []
-      description: 'État du numéro EORI d''une entreprise indiquant si celle-ci est
+      description: État du numéro EORI d'une entreprise indiquant si celle-ci est
         immatriculée auprès des douanes dans le cadre de l’import/export en Union
         Européenne.
-
-        '
       responses:
         '401':
           description: Non autorisé
@@ -17455,9 +17453,9 @@ paths:
           type: string
       security:
       - jwt_bearer_token: []
-      description: |
-        Liste des actes et bilans d'une unité légale inscrite au répertoire national des entreprises (RNE).
-        Seuls les actes et bilans publiques sont distribués. L'INPI peut potentiellement posséder des actes et bilans "partiellement confidentiels".
+      description: Liste des actes et bilans d'une unité légale inscrite au répertoire
+        national des entreprises (RNE). Seuls les actes et bilans publiques sont distribués.
+        L'INPI peut potentiellement posséder des actes et bilans "partiellement confidentiels".
       responses:
         '401':
           description: Non autorisé
@@ -39595,10 +39593,8 @@ paths:
           type: string
       security:
       - jwt_bearer_token: []
-      description: 'Certification délivrée par l''association OPQIBI, attestant des
-        différentes qualifications d''ingénierie d''une unité légale.
-
-        '
+      description: Certification délivrée par l'association OPQIBI, attestant des
+        différentes qualifications d'ingénierie d'une unité légale.
       responses:
         '401':
           description: Non autorisé

--- a/site/app/clients/datagouv_api_client.rb
+++ b/site/app/clients/datagouv_api_client.rb
@@ -1,0 +1,53 @@
+require 'faraday'
+
+class DatagouvAPIClient
+  def list_dataservices(organization:)
+    dataservices = []
+    page = 1
+
+    loop do
+      response = http_connection.get("#{host}/api/1/dataservices/", { organization: organization, page: page, page_size: 100 }).body
+      dataservices.concat(response['data'])
+      break if response['next_page'].blank?
+
+      page += 1
+    end
+
+    dataservices
+  end
+
+  def create_dataservice(payload)
+    http_connection.post("#{host}/api/1/dataservices/", payload.to_json).body
+  end
+
+  def update_dataservice(id, payload)
+    http_connection.patch("#{host}/api/1/dataservices/#{id}/", payload.to_json).body
+  end
+
+  def delete_dataservice(id)
+    http_connection.delete("#{host}/api/1/dataservices/#{id}/")
+    nil
+  end
+
+  private
+
+  def host
+    AdminApientreprise.credentials[:datagouv_host]
+  end
+
+  def token
+    AdminApientreprise.credentials[:datagouv_api_token]
+  end
+
+  def http_connection(&block)
+    Faraday.new do |conn|
+      conn.headers['X-API-KEY'] = token
+      conn.headers['Content-Type'] = 'application/json'
+      conn.request :retry, max: 2
+      conn.response :raise_error
+      conn.response :json
+      conn.options.timeout = 5
+      yield(conn) if block
+    end
+  end
+end

--- a/site/app/jobs/datagouv/sync_fiches_job.rb
+++ b/site/app/jobs/datagouv/sync_fiches_job.rb
@@ -1,0 +1,39 @@
+module Datagouv
+  class SyncFichesJob < ApplicationJob
+    LOCK_NAMESPACE = 'datagouv_sync'.freeze
+
+    retry_on StandardError, wait: :polynomially_longer, attempts: 5
+
+    def perform
+      return unless acquire_lock!
+
+      begin
+        logger.info('Start syncing fiches with data.gouv.fr')
+
+        result = SyncRunner.new(endpoints).call
+
+        logger.info("End syncing fiches with data.gouv.fr (#{result ? 'success' : 'with failures'})")
+      ensure
+        release_lock!
+      end
+    end
+
+    private
+
+    def endpoints
+      APIEntreprise::Endpoint.all + APIParticulier::Endpoint.all
+    end
+
+    def logger
+      @logger ||= ActiveSupport::TaggedLogging.new(Logger.new(Rails.root.join('log/datagouv.log')))
+    end
+
+    def acquire_lock!
+      Rails.cache.write('datagouv_sync_in_progress', true, unless_exist: true, expires_in: 1.hour, namespace: LOCK_NAMESPACE)
+    end
+
+    def release_lock!
+      Rails.cache.delete('datagouv_sync_in_progress', namespace: LOCK_NAMESPACE)
+    end
+  end
+end

--- a/site/app/models/abstract_endpoint.rb
+++ b/site/app/models/abstract_endpoint.rb
@@ -20,7 +20,8 @@ class AbstractEndpoint
     :keywords,
     :api_cgu,
     :datagouv_uid,
-    :socle_de_base
+    :socle_de_base,
+    :sync_with_datagouv
 
   attr_writer :new_endpoint_uids, :old_endpoint_uids
 
@@ -92,6 +93,10 @@ class AbstractEndpoint
 
   def new_version?
     new_version.present? && new_version
+  end
+
+  def sync_with_datagouv?
+    sync_with_datagouv.nil? || sync_with_datagouv
   end
 
   def api_status

--- a/site/app/services/datagouv/dataservice_index.rb
+++ b/site/app/services/datagouv/dataservice_index.rb
@@ -1,0 +1,19 @@
+module Datagouv
+  class DataserviceIndex
+    def initialize(client: DatagouvAPIClient.new)
+      @dataservices = client.list_dataservices(organization: FichePayloadBuilder::ORGANIZATION_ID)
+    end
+
+    def find(endpoint)
+      by_business_url[FichePayloadBuilder.new(endpoint).business_documentation_url]
+    end
+
+    private
+
+    attr_reader :dataservices
+
+    def by_business_url
+      @by_business_url ||= dataservices.index_by { |dataservice| dataservice['business_documentation_url'] }
+    end
+  end
+end

--- a/site/app/services/datagouv/fiche_payload_builder.rb
+++ b/site/app/services/datagouv/fiche_payload_builder.rb
@@ -1,0 +1,135 @@
+module Datagouv
+  class FichePayloadBuilder
+    include Rails.application.routes.url_helpers
+
+    ORGANIZATION_ID = '57fe2a35c751df21e179df72'.freeze
+
+    API_CONFIG = {
+      'api_entreprise' => {
+        base_api_url: 'https://entreprise.api.gouv.fr',
+        business_documentation_url_helper: :endpoint_url,
+        technical_documentation_url_helper: :developers_openapi_url,
+        machine_documentation_url_helper: :openapi_without_deprecated_definition_url,
+        authorization_request_url: 'https://datapass.api.gouv.fr/api-entreprise',
+        display_name: 'Entreprise'
+      },
+      'api_particulier' => {
+        base_api_url: 'https://particulier.api.gouv.fr',
+        business_documentation_url_helper: :api_particulier_endpoint_url,
+        technical_documentation_url_helper: :api_particulier_developers_openapi_url,
+        machine_documentation_url_helper: :api_particulier_openapi_definition_url,
+        authorization_request_url: 'https://datapass.api.gouv.fr/api-particulier',
+        display_name: 'Particulier'
+      }
+    }.freeze
+
+    BASE_TAGS = {
+      'api_entreprise' => %w[api-entreprise administration administration-et-legislation],
+      'api_particulier' => %w[api-particulier administration administration-et-legislation]
+    }.freeze
+
+    def initialize(endpoint)
+      @endpoint = endpoint
+    end
+
+    def payload
+      base_payload.merge(rate_limiting_payload)
+    end
+
+    def creation_payload
+      payload.merge(organization: ORGANIZATION_ID)
+    end
+
+    def title
+      "API #{endpoint.title} - #{providers_name} | Bouquet API #{config[:display_name]}"
+    end
+
+    def business_documentation_url
+      public_send(config[:business_documentation_url_helper], uid: endpoint.uid, host: url_host, protocol: 'https')
+    end
+
+    private
+
+    attr_reader :endpoint
+
+    def base_payload
+      {
+        access_type: access_type,
+        base_api_url: config[:base_api_url],
+        business_documentation_url: business_documentation_url,
+        technical_documentation_url: technical_documentation_url,
+        machine_documentation_url: machine_documentation_url,
+        authorization_request_url: config[:authorization_request_url],
+        title: title,
+        description: description,
+        tags: tags
+      }
+    end
+
+    def config
+      API_CONFIG.fetch(endpoint.api)
+    end
+
+    def url_host
+      @url_host ||= URI(config[:base_api_url]).host
+    end
+
+    def access_type
+      endpoint.opening == 'public' ? 'open' : 'restricted'
+    end
+
+    def restricted?
+      access_type == 'restricted'
+    end
+
+    def technical_documentation_url
+      public_send(config[:technical_documentation_url_helper], anchor: endpoint.redoc_anchor, host: url_host, protocol: 'https')
+    end
+
+    def machine_documentation_url
+      public_send(config[:machine_documentation_url_helper], host: url_host, protocol: 'https')
+    end
+
+    def providers_name
+      return nil if endpoint.provider_uids.blank?
+
+      endpoint.providers.map(&:name).join(' & ')
+    end
+
+    def call_id_text
+      Array(endpoint.call_id).join(' / ')
+    end
+
+    def description
+      <<~MARKDOWN
+        > L'[#{title}](#{business_documentation_url}) permet d'obtenir les informations suivantes : **#{endpoint.description}**
+
+        ➡️ **Cette API fait partie du bouquet [API #{config[:display_name]}](#{config[:base_api_url]}/catalogue)** opéré par la direction interministérielle du numérique (DINUM). Ces données et l'API source proviennent de #{providers_name}.
+
+        - #{restricted? ? '🔐' : '✅'} **#{restricted? ? 'Uniquement accessible aux administrations et collectivités' : 'Accessible à tous'}**.
+        - ☎️ **Modalité d'appel** : #{call_id_text}.
+        - 📖 **[Documentation métier](#{business_documentation_url})**
+        - 📟 **[Documentation technique (swagger)](#{technical_documentation_url})**
+      MARKDOWN
+    end
+
+    def tags
+      (BASE_TAGS.fetch(endpoint.api) + Array(endpoint.provider_uids) + Array(endpoint.keywords)).map(&:parameterize).uniq.sort
+    end
+
+    def rate_limiting_payload
+      throttle = endpoint.throttle
+      return { rate_limiting: '' } unless throttle
+
+      { rate_limiting: "#{throttle[:limit]} requêtes / #{period_in_words(throttle[:period])}" }
+    end
+
+    def period_in_words(period)
+      case period
+      when 1 then 'seconde'
+      when 60 then 'minute'
+      else "#{period} secondes"
+      end
+    end
+  end
+end

--- a/site/app/services/datagouv/sync_fiche.rb
+++ b/site/app/services/datagouv/sync_fiche.rb
@@ -1,0 +1,81 @@
+module Datagouv
+  class SyncFiche
+    Result = Struct.new(:status, :uid, :remote_id, keyword_init: true)
+
+    def initialize(endpoint, index:, client: DatagouvAPIClient.new)
+      @endpoint = endpoint
+      @index = index
+      @client = client
+    end
+
+    def call
+      return skipped_result unless endpoint.sync_with_datagouv?
+      return deprecated_result if endpoint.deprecated?
+
+      sync_current
+    rescue Faraday::Error => e
+      failed_result(e)
+    end
+
+    private
+
+    attr_reader :endpoint, :index, :client
+
+    def skipped_result
+      result(:skipped)
+    end
+
+    def deprecated_result
+      remote = index.find(endpoint)
+      return result(:skipped_deprecated) if remote.nil?
+
+      delete_existing(remote['id'])
+      result(:deleted, remote_id: remote['id'])
+    end
+
+    def delete_existing(remote_id)
+      client.delete_dataservice(remote_id)
+    rescue Faraday::ResourceNotFound
+      nil
+    end
+
+    def sync_current
+      remote = index.find(endpoint)
+      return create if remote.nil?
+
+      sync_existing(remote)
+    end
+
+    def sync_existing(remote)
+      payload = builder.payload
+      return result(:unchanged, remote_id: remote['id']) if unchanged?(remote, payload)
+
+      client.update_dataservice(remote['id'], payload)
+      result(:updated, remote_id: remote['id'])
+    rescue Faraday::ResourceNotFound
+      create
+    end
+
+    def create
+      created = client.create_dataservice(builder.creation_payload)
+      result(:created, remote_id: created['id'])
+    end
+
+    def unchanged?(remote, payload)
+      payload.all? { |key, value| remote[key.to_s] == value }
+    end
+
+    def builder
+      @builder ||= FichePayloadBuilder.new(endpoint)
+    end
+
+    def failed_result(error)
+      Rails.logger.error("Datagouv::SyncFiche: #{endpoint.uid} failed - #{error.message}")
+      result(:failed)
+    end
+
+    def result(status, remote_id: nil)
+      Result.new(status: status, uid: endpoint.uid, remote_id: remote_id)
+    end
+  end
+end

--- a/site/app/services/datagouv/sync_runner.rb
+++ b/site/app/services/datagouv/sync_runner.rb
@@ -1,0 +1,37 @@
+module Datagouv
+  class SyncRunner
+    def initialize(endpoints)
+      @endpoints = endpoints
+    end
+
+    def call
+      index = build_index
+      return false if index.nil?
+
+      results = endpoints.map { |endpoint| sync_one(endpoint, index) }
+      results.none? { |result| result.status == :failed }
+    end
+
+    private
+
+    attr_reader :endpoints
+
+    def build_index
+      DataserviceIndex.new
+    rescue Faraday::Error => e
+      Rails.logger.error("Datagouv::SyncRunner: failed to list dataservices - #{e.message}")
+      nil
+    end
+
+    def sync_one(endpoint, index)
+      result = SyncFiche.new(endpoint, index: index).call
+      Rails.logger.info(log_message(result))
+      result
+    end
+
+    def log_message(result)
+      suffix = result.remote_id ? " (#{result.remote_id})" : ''
+      "Datagouv::SyncRunner: #{result.uid} -> #{result.status}#{suffix}"
+    end
+  end
+end

--- a/site/config/initializers/sync_fiches_with_datagouv.rb
+++ b/site/config/initializers/sync_fiches_with_datagouv.rb
@@ -1,0 +1,3 @@
+Rails.application.config.after_initialize do
+  Datagouv::SyncFichesJob.perform_later if Rails.env.production? || Rails.env.sandbox?
+end

--- a/site/spec/clients/datagouv_api_client_spec.rb
+++ b/site/spec/clients/datagouv_api_client_spec.rb
@@ -1,0 +1,133 @@
+require 'rails_helper'
+
+RSpec.describe DatagouvAPIClient do
+  subject(:client) { described_class.new }
+
+  let(:host) { 'https://datagouv.example.test' }
+  let(:token) { 'test-token' }
+
+  before do
+    allow(AdminApientreprise).to receive(:credentials).and_return(datagouv_host: host, datagouv_api_token: token)
+  end
+
+  describe '#list_dataservices' do
+    subject(:list_dataservices) { client.list_dataservices(organization: 'org-id') }
+
+    context 'when there is a single page of results' do
+      before do
+        stub_request(:get, "#{host}/api/1/dataservices/")
+          .with(query: { organization: 'org-id', page: 1, page_size: 100 }, headers: { 'X-API-KEY' => token })
+          .to_return(
+            status: 200,
+            headers: { 'Content-Type' => 'application/json' },
+            body: { 'data' => [{ 'id' => 'a' }, { 'id' => 'b' }], 'next_page' => nil }.to_json
+          )
+      end
+
+      it 'returns every dataservice from the response' do
+        expect(list_dataservices).to eq([{ 'id' => 'a' }, { 'id' => 'b' }])
+      end
+    end
+
+    context 'when there are multiple pages of results' do
+      before do
+        stub_request(:get, "#{host}/api/1/dataservices/")
+          .with(query: { organization: 'org-id', page: 1, page_size: 100 })
+          .to_return(
+            status: 200,
+            headers: { 'Content-Type' => 'application/json' },
+            body: { 'data' => [{ 'id' => 'a' }], 'next_page' => "#{host}/api/1/dataservices/?organization=org-id&page=2&page_size=100" }.to_json
+          )
+        stub_request(:get, "#{host}/api/1/dataservices/")
+          .with(query: { organization: 'org-id', page: 2, page_size: 100 })
+          .to_return(
+            status: 200,
+            headers: { 'Content-Type' => 'application/json' },
+            body: { 'data' => [{ 'id' => 'b' }], 'next_page' => nil }.to_json
+          )
+      end
+
+      it 'follows next_page and concatenates every page' do
+        expect(list_dataservices).to eq([{ 'id' => 'a' }, { 'id' => 'b' }])
+      end
+    end
+  end
+
+  describe '#create_dataservice' do
+    subject(:create_dataservice) { client.create_dataservice({ title: 'New fiche' }) }
+
+    context 'when the API accepts the payload' do
+      before do
+        stub_request(:post, "#{host}/api/1/dataservices/")
+          .with(body: { title: 'New fiche' }.to_json, headers: { 'X-API-KEY' => token })
+          .to_return(status: 201, headers: { 'Content-Type' => 'application/json' }, body: { 'id' => 'new-id', 'title' => 'New fiche' }.to_json)
+      end
+
+      it 'returns the created dataservice' do
+        expect(create_dataservice).to eq({ 'id' => 'new-id', 'title' => 'New fiche' })
+      end
+    end
+
+    context 'when the payload is invalid' do
+      before do
+        stub_request(:post, "#{host}/api/1/dataservices/").to_return(status: 400, body: '{}')
+      end
+
+      it 'raises Faraday::BadRequestError' do
+        expect { create_dataservice }.to raise_error(Faraday::BadRequestError)
+      end
+    end
+  end
+
+  describe '#update_dataservice' do
+    subject(:update_dataservice) { client.update_dataservice('abc123', { title: 'Updated' }) }
+
+    before do
+      stub_request(:patch, "#{host}/api/1/dataservices/abc123/")
+        .with(body: { title: 'Updated' }.to_json)
+        .to_return(status: 200, headers: { 'Content-Type' => 'application/json' }, body: { 'id' => 'abc123', 'title' => 'Updated' }.to_json)
+    end
+
+    it 'returns the updated dataservice' do
+      expect(update_dataservice).to eq({ 'id' => 'abc123', 'title' => 'Updated' })
+    end
+  end
+
+  describe '#delete_dataservice' do
+    subject(:delete_dataservice) { client.delete_dataservice('abc123') }
+
+    context 'when the dataservice exists' do
+      before do
+        stub_request(:delete, "#{host}/api/1/dataservices/abc123/").to_return(status: 204)
+      end
+
+      it 'does not raise' do
+        expect { delete_dataservice }.not_to raise_error
+      end
+    end
+
+    context 'when the dataservice is already gone' do
+      before do
+        stub_request(:delete, "#{host}/api/1/dataservices/abc123/").to_return(status: 404, body: '{}')
+      end
+
+      it 'raises Faraday::ResourceNotFound' do
+        expect { delete_dataservice }.to raise_error(Faraday::ResourceNotFound)
+      end
+    end
+  end
+
+  describe 'network failure' do
+    subject(:list_dataservices) { client.list_dataservices(organization: 'org-id') }
+
+    before do
+      stub_request(:get, "#{host}/api/1/dataservices/")
+        .with(query: { organization: 'org-id', page: 1, page_size: 100 })
+        .to_timeout
+    end
+
+    it 'raises a Faraday error' do
+      expect { list_dataservices }.to raise_error(Faraday::Error)
+    end
+  end
+end

--- a/site/spec/jobs/datagouv/sync_fiches_job_spec.rb
+++ b/site/spec/jobs/datagouv/sync_fiches_job_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.describe Datagouv::SyncFichesJob do
+  describe '#perform' do
+    subject(:perform) { described_class.new.perform }
+
+    let(:runner) { instance_double(Datagouv::SyncRunner, call: true) }
+
+    before { allow(Datagouv::SyncRunner).to receive(:new).and_return(runner) }
+
+    it 'builds SyncRunner with every endpoint from both catalogs' do
+      perform
+
+      expect(Datagouv::SyncRunner).to have_received(:new) do |endpoints|
+        expect(endpoints.size).to eq(APIEntreprise::Endpoint.all.size + APIParticulier::Endpoint.all.size)
+      end
+    end
+
+    it 'locks under a namespace that does not depend on the cache store default' do
+      allow(Rails.cache).to receive(:write).and_call_original
+
+      perform
+
+      expect(Rails.cache).to have_received(:write).with(
+        'datagouv_sync_in_progress', true, hash_including(namespace: described_class::LOCK_NAMESPACE)
+      )
+    end
+
+    it 'releases the lock after the sync completes' do
+      perform
+
+      expect(Rails.cache.exist?('datagouv_sync_in_progress', namespace: described_class::LOCK_NAMESPACE)).to be false
+    end
+
+    context 'when the lock is already held' do
+      before { Rails.cache.write('datagouv_sync_in_progress', true, namespace: described_class::LOCK_NAMESPACE) }
+
+      it 'does not run the sync' do
+        perform
+
+        expect(Datagouv::SyncRunner).not_to have_received(:new)
+      end
+    end
+
+    context 'when the sync runs' do
+      before { FileUtils.touch(Rails.root.join('log/datagouv.log').to_s) }
+
+      it 'logs the start and end of the sync to a dedicated file' do
+        expect {
+          perform
+        }.to(change { File.read(Rails.root.join('log/datagouv.log').to_s) })
+      end
+    end
+
+    context 'when the sync raises an unexpected error' do
+      before { allow(Datagouv::SyncRunner).to receive(:new).and_raise(KeyError, 'key not found: :datagouv_host') }
+
+      it 'lets the job raise so ActiveJob retries it' do
+        expect { perform }.to raise_error(KeyError)
+      end
+
+      it 'still releases the lock before re-raising' do
+        begin
+          perform
+        rescue KeyError
+          nil
+        end
+
+        expect(Rails.cache.exist?('datagouv_sync_in_progress', namespace: described_class::LOCK_NAMESPACE)).to be false
+      end
+    end
+  end
+end

--- a/site/spec/models/abstract_endpoint_spec.rb
+++ b/site/spec/models/abstract_endpoint_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe AbstractEndpoint do
+  describe '#sync_with_datagouv?' do
+    context 'when sync_with_datagouv is not set in the yml' do
+      subject(:endpoint) { APIEntreprise::Endpoint.find('inpi/rne/beneficiaires_effectifs') }
+
+      it 'defaults to true' do
+        expect(endpoint.sync_with_datagouv?).to be true
+      end
+    end
+
+    context 'when sync_with_datagouv is explicitly false' do
+      subject(:endpoint) { APIEntreprise::Endpoint.find('insee/etablissements') }
+
+      it 'is false' do
+        expect(endpoint.sync_with_datagouv?).to be false
+      end
+    end
+  end
+end

--- a/site/spec/services/datagouv/dataservice_index_spec.rb
+++ b/site/spec/services/datagouv/dataservice_index_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe Datagouv::DataserviceIndex do
+  subject(:index) { described_class.new(client: client) }
+
+  let(:client) { instance_double(DatagouvAPIClient, list_dataservices: dataservices) }
+  let(:endpoint) { APIEntreprise::Endpoint.find('dgfip/numero_tva') }
+  let(:business_url) { Datagouv::FichePayloadBuilder.new(endpoint).business_documentation_url }
+
+  context 'when a dataservice has the matching business_documentation_url' do
+    let(:dataservices) do
+      [
+        { 'id' => 'other-id', 'title' => 'Unrelated', 'business_documentation_url' => 'https://entreprise.api.gouv.fr/catalogue/other/uid' },
+        { 'id' => 'matched-id', 'title' => 'Something else entirely', 'business_documentation_url' => business_url }
+      ]
+    end
+
+    it 'finds it' do
+      expect(index.find(endpoint)).to eq(dataservices.last)
+    end
+  end
+
+  context 'when no dataservice matches the business_documentation_url' do
+    let(:dataservices) do
+      [{ 'id' => 'other-id', 'title' => 'Unrelated', 'business_documentation_url' => 'https://entreprise.api.gouv.fr/catalogue/other/uid' }]
+    end
+
+    it 'returns nil' do
+      expect(index.find(endpoint)).to be_nil
+    end
+  end
+
+  describe 'listing' do
+    let(:dataservices) { [] }
+
+    it 'lists dataservices for the DINUM organization' do
+      index
+
+      expect(client).to have_received(:list_dataservices).with(organization: Datagouv::FichePayloadBuilder::ORGANIZATION_ID)
+    end
+  end
+end

--- a/site/spec/services/datagouv/fiche_payload_builder_spec.rb
+++ b/site/spec/services/datagouv/fiche_payload_builder_spec.rb
@@ -1,0 +1,188 @@
+require 'rails_helper'
+
+RSpec.describe Datagouv::FichePayloadBuilder do
+  subject(:payload) { described_class.new(endpoint).payload }
+
+  context 'with a protected API Entreprise endpoint that has a throttle entry' do
+    let(:endpoint) { APIEntreprise::Endpoint.find('inpi/rne/beneficiaires_effectifs') }
+
+    it 'builds the full payload' do
+      expect(payload).to eq(
+        access_type: 'restricted',
+        base_api_url: 'https://entreprise.api.gouv.fr',
+        business_documentation_url: 'https://entreprise.api.gouv.fr/catalogue/inpi/rne/beneficiaires_effectifs',
+        technical_documentation_url: 'https://entreprise.api.gouv.fr/developpeurs/openapi#tag/Informations-generales/paths/~1v3~1inpi~1rne~1unites_legales~1%7Bsiren%7D~1beneficiaires_effectifs/get',
+        machine_documentation_url: 'https://entreprise.api.gouv.fr/open-api-without-deprecated-paths.yml',
+        authorization_request_url: 'https://datapass.api.gouv.fr/api-entreprise',
+        title: 'API Bénéficiaires effectifs - INPI | Bouquet API Entreprise',
+        description: <<~MARKDOWN,
+          > L'[API Bénéficiaires effectifs - INPI | Bouquet API Entreprise](https://entreprise.api.gouv.fr/catalogue/inpi/rne/beneficiaires_effectifs) permet d'obtenir les informations suivantes : **Liste des bénéficiaires effectifs d'une unité légale inscrite au répertoire national des entreprises (RNE).**
+
+          ➡️ **Cette API fait partie du bouquet [API Entreprise](https://entreprise.api.gouv.fr/catalogue)** opéré par la direction interministérielle du numérique (DINUM). Ces données et l'API source proviennent de INPI.
+
+          - 🔐 **Uniquement accessible aux administrations et collectivités**.
+          - ☎️ **Modalité d'appel** : SIREN.
+          - 📖 **[Documentation métier](https://entreprise.api.gouv.fr/catalogue/inpi/rne/beneficiaires_effectifs)**
+          - 📟 **[Documentation technique (swagger)](https://entreprise.api.gouv.fr/developpeurs/openapi#tag/Informations-generales/paths/~1v3~1inpi~1rne~1unites_legales~1%7Bsiren%7D~1beneficiaires_effectifs/get)**
+        MARKDOWN
+        tags: %w[administration administration-et-legislation api-entreprise beneficiaire droit-de-vote indivision inpi nue-propriete part patrimoine propriete rcs repartition representant-legal rne rnm titulaire usufruit],
+        rate_limiting: '15 requêtes / minute'
+      )
+    end
+  end
+
+  describe '#business_documentation_url' do
+    let(:endpoint) { APIEntreprise::Endpoint.find('dgfip/numero_tva') }
+
+    it 'is public, since DataserviceIndex matches remote dataservices on it' do
+      expect(described_class.new(endpoint).business_documentation_url).to eq('https://entreprise.api.gouv.fr/catalogue/dgfip/numero_tva')
+    end
+  end
+
+  context 'with a public API Entreprise endpoint' do
+    let(:endpoint) { APIEntreprise::Endpoint.find('dgfip/numero_tva') }
+
+    it 'maps opening: public to access_type: open' do
+      expect(payload[:access_type]).to eq('open')
+    end
+
+    it 'renders the open access line in the description' do
+      expect(payload[:description]).to include('- ✅ **Accessible à tous**.')
+    end
+
+    it 'includes a rate_limiting derived from the throttle entry' do
+      expect(payload[:rate_limiting]).to eq('250 requêtes / minute')
+    end
+
+    it 'includes the base api-entreprise tags plus provider and keyword tags' do
+      expect(payload[:tags]).to eq(%w[administration administration-et-legislation api-entreprise dgfip intracommunautaire numero-tva])
+    end
+  end
+
+  context 'with an endpoint whose swagger description ends in an ellipsis' do
+    let(:endpoint) { APIEntreprise::Endpoint.find('ministere_interieur/documents_associations') }
+
+    it 'uses the swagger description as-is' do
+      expect(payload[:description]).to include(
+        '**Divers documents administratifs en PDF tels que les statuts, le récépissé de déclaration de création, la liste des dirigeants...**'
+      )
+    end
+  end
+
+  context 'with an endpoint whose keywords attribute is entirely absent (nil)' do
+    let(:endpoint) { APIEntreprise::Endpoint.find('ministere_interieur/rna') }
+
+    it 'builds tags from the base set and provider_uids only, without raising' do
+      expect(payload[:tags]).to eq(%w[administration administration-et-legislation api-entreprise mi])
+    end
+  end
+
+  context 'with an API Particulier endpoint whose call_id is an array' do
+    let(:endpoint) { APIParticulier::Endpoint.find('education_nationale/statut_eleve_scolarise') }
+
+    it 'uses the particulier base_api_url and display name' do
+      expect(payload[:base_api_url]).to eq('https://particulier.api.gouv.fr')
+      expect(payload[:machine_documentation_url]).to eq('https://particulier.api.gouv.fr/open-api.yml')
+      expect(payload[:authorization_request_url]).to eq('https://datapass.api.gouv.fr/api-particulier')
+    end
+
+    it 'derives business and technical documentation urls from the api_particulier routes' do
+      expect(payload[:business_documentation_url]).to eq('https://particulier.api.gouv.fr/catalogue/education_nationale/statut_eleve_scolarise')
+      expect(payload[:technical_documentation_url]).to eq('https://particulier.api.gouv.fr/developpeurs/openapi#tag/Statut-eleve-scolarise/paths/~1v5~1men~1scolarites~1identite/get')
+    end
+
+    it 'joins the call_id array in the description' do
+      expect(payload[:description]).to include("Modalité d'appel** : Identité pivot / FranceConnect.")
+    end
+
+    it 'builds tags from the base set and provider_uids only, since keywords is empty' do
+      expect(payload[:tags]).to eq(%w[administration administration-et-legislation api-particulier education_nationale])
+    end
+
+    it 'uses a throttle period of 1 second worded as "seconde"' do
+      expect(payload[:rate_limiting]).to eq('20 requêtes / seconde')
+    end
+  end
+
+  context 'when the endpoint has no throttle entry' do
+    let(:endpoint) do
+      instance_double(
+        APIEntreprise::Endpoint,
+        uid: 'test/uid',
+        api: 'api_entreprise',
+        opening: 'protected',
+        redoc_anchor: 'tag/Test/paths/~1v3~1test/get',
+        title: 'Test',
+        description: 'Description de test.',
+        call_id: 'SIREN',
+        provider_uids: ['insee'],
+        keywords: ['test'],
+        providers: [instance_double(APIEntreprise::Provider, name: 'INSEE')],
+        throttle: nil
+      )
+    end
+
+    it 'sets rate_limiting to an empty string when no throttle entry resolves' do
+      expect(payload[:rate_limiting]).to eq('')
+    end
+  end
+
+  context 'when the endpoint has no provider_uids' do
+    subject(:payload) { described_class.new(endpoint).payload }
+
+    let(:endpoint) do
+      instance_double(
+        APIEntreprise::Endpoint,
+        uid: 'test/uid',
+        api: 'api_entreprise',
+        opening: 'protected',
+        redoc_anchor: 'tag/Test/paths/~1v3~1test/get',
+        title: 'Test',
+        description: 'Description de test.',
+        call_id: 'SIREN',
+        provider_uids: nil,
+        keywords: ['test'],
+        throttle: nil
+      )
+    end
+
+    it 'does not raise and omits the provider name from the title' do
+      expect(endpoint).not_to receive(:providers)
+      expect { payload }.not_to raise_error
+      expect(payload[:title]).to eq('API Test -  | Bouquet API Entreprise')
+    end
+
+    it 'still includes the base tags' do
+      expect(payload[:tags]).to eq(%w[administration administration-et-legislation api-entreprise test])
+    end
+  end
+
+  describe 'API_CONFIG' do
+    it 'uses api-particulier-scoped route helpers for API Particulier URLs' do
+      particulier_config = described_class::API_CONFIG.fetch('api_particulier')
+
+      expect(particulier_config[:business_documentation_url_helper]).to eq(:api_particulier_endpoint_url)
+      expect(particulier_config[:technical_documentation_url_helper]).to eq(:api_particulier_developers_openapi_url)
+      expect(particulier_config[:machine_documentation_url_helper]).to eq(:api_particulier_openapi_definition_url)
+    end
+
+    it 'uses api-entreprise-scoped route helpers for API Entreprise URLs' do
+      entreprise_config = described_class::API_CONFIG.fetch('api_entreprise')
+
+      expect(entreprise_config[:business_documentation_url_helper]).to eq(:endpoint_url)
+      expect(entreprise_config[:technical_documentation_url_helper]).to eq(:developers_openapi_url)
+      expect(entreprise_config[:machine_documentation_url_helper]).to eq(:openapi_without_deprecated_definition_url)
+    end
+  end
+
+  describe '#creation_payload' do
+    subject(:creation_payload) { described_class.new(endpoint).creation_payload }
+
+    let(:endpoint) { APIEntreprise::Endpoint.find('dgfip/numero_tva') }
+    let(:payload) { described_class.new(endpoint).payload }
+
+    it 'adds the DINUM organization id on top of the regular payload' do
+      expect(creation_payload).to eq(payload.merge(organization: '57fe2a35c751df21e179df72'))
+    end
+  end
+end

--- a/site/spec/services/datagouv/sync_fiche_spec.rb
+++ b/site/spec/services/datagouv/sync_fiche_spec.rb
@@ -1,0 +1,164 @@
+require 'rails_helper'
+
+RSpec.describe Datagouv::SyncFiche do
+  subject(:sync) { described_class.new(endpoint, index: index, client: client).call }
+
+  let(:client) { instance_double(DatagouvAPIClient) }
+  let(:index) { instance_double(Datagouv::DataserviceIndex) }
+
+  context 'when sync_with_datagouv is false' do
+    let(:endpoint) { APIEntreprise::Endpoint.find('insee/etablissements') }
+
+    it 'does not call the index or the client' do
+      expect(index).not_to receive(:find)
+      expect(client).not_to receive(:create_dataservice)
+      expect(client).not_to receive(:update_dataservice)
+      expect(client).not_to receive(:delete_dataservice)
+
+      sync
+    end
+
+    it 'returns a skipped result' do
+      expect(sync.status).to eq(:skipped)
+    end
+  end
+
+  context 'when the endpoint is deprecated and the index finds a match' do
+    let(:endpoint) { APIEntreprise::Endpoint.find('commission_europeenne/numero_tva') }
+
+    before do
+      allow(index).to receive(:find).with(endpoint).and_return({ 'id' => 'remote-id' })
+      allow(client).to receive(:delete_dataservice)
+    end
+
+    it 'deletes the dataservice' do
+      sync
+
+      expect(client).to have_received(:delete_dataservice).with('remote-id')
+    end
+
+    it 'returns a deleted result with the deleted remote_id' do
+      expect(sync).to have_attributes(status: :deleted, remote_id: 'remote-id')
+    end
+
+    context 'when the dataservice was already deleted' do
+      before { allow(client).to receive(:delete_dataservice).and_raise(Faraday::ResourceNotFound) }
+
+      it 'still returns a deleted result' do
+        expect(sync.status).to eq(:deleted)
+      end
+    end
+  end
+
+  context 'when the endpoint is deprecated and the index finds no match' do
+    let(:endpoint) { APIEntreprise::Endpoint.find('insee/etablissements_v3') }
+
+    before { allow(index).to receive(:find).with(endpoint).and_return(nil) }
+
+    it 'does not call the client at all' do
+      expect(client).not_to receive(:delete_dataservice)
+
+      sync
+    end
+
+    it 'returns a skipped_deprecated result' do
+      expect(sync.status).to eq(:skipped_deprecated)
+    end
+  end
+
+  context 'when the index finds no match and the endpoint is not deprecated' do
+    let(:endpoint) { APIEntreprise::Endpoint.find('dgfip/numero_tva') }
+
+    before do
+      allow(index).to receive(:find).with(endpoint).and_return(nil)
+      allow(client).to receive(:create_dataservice).and_return({ 'id' => 'brand-new-id' })
+    end
+
+    it 'creates a dataservice with the organization set' do
+      sync
+
+      expect(client).to have_received(:create_dataservice) do |payload|
+        expect(payload[:organization]).to eq('57fe2a35c751df21e179df72')
+        expect(payload[:title]).to be_present
+      end
+    end
+
+    it 'returns a created result with the new id' do
+      expect(sync).to have_attributes(status: :created, remote_id: 'brand-new-id')
+    end
+  end
+
+  context 'when the index finds a match and the remote payload differs' do
+    let(:endpoint) { APIEntreprise::Endpoint.find('inpi/rne/beneficiaires_effectifs') }
+
+    before do
+      allow(index).to receive(:find).with(endpoint).and_return({ 'id' => 'matched-id', 'access_type' => 'open' })
+      allow(client).to receive(:update_dataservice)
+    end
+
+    it 'updates the dataservice' do
+      sync
+
+      expect(client).to have_received(:update_dataservice).with('matched-id', hash_including(access_type: 'restricted'))
+    end
+
+    it 'returns an updated result' do
+      expect(sync).to have_attributes(status: :updated, remote_id: 'matched-id')
+    end
+  end
+
+  context 'when the index finds a match and the remote payload already matches' do
+    let(:endpoint) { APIEntreprise::Endpoint.find('inpi/rne/beneficiaires_effectifs') }
+    let(:matching_payload) do
+      Datagouv::FichePayloadBuilder.new(endpoint).payload.transform_keys(&:to_s).merge('id' => 'matched-id')
+    end
+
+    before do
+      allow(index).to receive(:find).with(endpoint).and_return(matching_payload)
+      allow(client).to receive(:update_dataservice)
+    end
+
+    it 'does not call update_dataservice' do
+      sync
+
+      expect(client).not_to have_received(:update_dataservice)
+    end
+
+    it 'returns an unchanged result' do
+      expect(sync.status).to eq(:unchanged)
+    end
+  end
+
+  context 'when updating a matched dataservice 404s (deleted between listing and updating)' do
+    let(:endpoint) { APIEntreprise::Endpoint.find('inpi/rne/beneficiaires_effectifs') }
+
+    before do
+      allow(index).to receive(:find).with(endpoint).and_return({ 'id' => 'matched-id', 'access_type' => 'open' })
+      allow(client).to receive(:update_dataservice).and_raise(Faraday::ResourceNotFound)
+      allow(client).to receive(:create_dataservice).and_return({ 'id' => 'healed-id' })
+    end
+
+    it 'self-heals by creating a new dataservice' do
+      sync
+
+      expect(client).to have_received(:create_dataservice)
+    end
+
+    it 'returns a created result with the new id' do
+      expect(sync).to have_attributes(status: :created, remote_id: 'healed-id')
+    end
+  end
+
+  context 'when the client raises an unexpected error' do
+    let(:endpoint) { APIEntreprise::Endpoint.find('inpi/rne/beneficiaires_effectifs') }
+
+    before do
+      allow(index).to receive(:find).with(endpoint).and_return({ 'id' => 'matched-id', 'access_type' => 'open' })
+      allow(client).to receive(:update_dataservice).and_raise(Faraday::ServerError.new('boom'))
+    end
+
+    it 'returns a failed result' do
+      expect(sync.status).to eq(:failed)
+    end
+  end
+end

--- a/site/spec/services/datagouv/sync_runner_spec.rb
+++ b/site/spec/services/datagouv/sync_runner_spec.rb
@@ -1,0 +1,122 @@
+require 'rails_helper'
+
+RSpec.describe Datagouv::SyncRunner do
+  subject(:run) { described_class.new(endpoints).call }
+
+  let(:endpoint) { APIEntreprise::Endpoint.find('inpi/rne/beneficiaires_effectifs') }
+  let(:endpoints) { [endpoint] }
+  let(:index) { instance_double(Datagouv::DataserviceIndex) }
+  let(:sync_fiche) { instance_double(Datagouv::SyncFiche) }
+
+  before do
+    allow(Datagouv::DataserviceIndex).to receive(:new).and_return(index)
+    allow(Datagouv::SyncFiche).to receive(:new).with(endpoint, index: index).and_return(sync_fiche)
+  end
+
+  context 'when the fiche is created' do
+    let(:result) { Datagouv::SyncFiche::Result.new(status: :created, uid: endpoint.uid, remote_id: 'new-id') }
+
+    before { allow(sync_fiche).to receive(:call).and_return(result) }
+
+    it 'returns true' do
+      expect(run).to be true
+    end
+
+    it 'logs the outcome including the remote_id' do
+      expect(Rails.logger).to receive(:info).with("Datagouv::SyncRunner: #{endpoint.uid} -> created (new-id)")
+
+      run
+    end
+  end
+
+  context 'when the fiche is deleted' do
+    let(:result) { Datagouv::SyncFiche::Result.new(status: :deleted, uid: endpoint.uid, remote_id: nil) }
+
+    before { allow(sync_fiche).to receive(:call).and_return(result) }
+
+    it 'returns true' do
+      expect(run).to be true
+    end
+
+    it 'logs the outcome without a remote_id suffix' do
+      expect(Rails.logger).to receive(:info).with("Datagouv::SyncRunner: #{endpoint.uid} -> deleted")
+
+      run
+    end
+  end
+
+  context 'when the fiche sync fails' do
+    let(:result) { Datagouv::SyncFiche::Result.new(status: :failed, uid: endpoint.uid, remote_id: nil) }
+
+    before { allow(sync_fiche).to receive(:call).and_return(result) }
+
+    it 'returns false' do
+      expect(run).to be false
+    end
+  end
+
+  context 'when the fiche is unchanged' do
+    let(:result) { Datagouv::SyncFiche::Result.new(status: :unchanged, uid: endpoint.uid, remote_id: 'existing-id') }
+
+    before { allow(sync_fiche).to receive(:call).and_return(result) }
+
+    it 'returns true' do
+      expect(run).to be true
+    end
+  end
+
+  context 'when the fiche is skipped as deprecated' do
+    let(:result) { Datagouv::SyncFiche::Result.new(status: :skipped_deprecated, uid: endpoint.uid, remote_id: nil) }
+
+    before { allow(sync_fiche).to receive(:call).and_return(result) }
+
+    it 'returns true' do
+      expect(run).to be true
+    end
+  end
+
+  context 'with multiple endpoints, one failing' do
+    let(:other_endpoint) { APIEntreprise::Endpoint.find('dgfip/numero_tva') }
+    let(:endpoints) { [endpoint, other_endpoint] }
+    let(:other_sync_fiche) { instance_double(Datagouv::SyncFiche) }
+    let(:result) { Datagouv::SyncFiche::Result.new(status: :created, uid: endpoint.uid, remote_id: 'new-id') }
+    let(:other_result) { Datagouv::SyncFiche::Result.new(status: :failed, uid: other_endpoint.uid, remote_id: nil) }
+
+    before do
+      allow(Datagouv::SyncFiche).to receive(:new).with(other_endpoint, index: index).and_return(other_sync_fiche)
+      allow(sync_fiche).to receive(:call).and_return(result)
+      allow(other_sync_fiche).to receive(:call).and_return(other_result)
+    end
+
+    it 'builds the index only once and shares it across endpoints' do
+      run
+
+      expect(Datagouv::DataserviceIndex).to have_received(:new).once
+    end
+
+    it 'returns false because one endpoint failed' do
+      expect(run).to be false
+    end
+  end
+
+  context 'when listing dataservices fails' do
+    before { allow(Datagouv::DataserviceIndex).to receive(:new).and_raise(Faraday::ServerError.new('boom')) }
+
+    it 'does not raise and returns false' do
+      expect { run }.not_to raise_error
+      expect(run).to be false
+    end
+
+    it 'does not attempt to sync any endpoint' do
+      expect(Datagouv::SyncFiche).not_to receive(:new)
+
+      run
+    end
+
+    it 'logs the failure' do
+      expect(Rails.logger).to receive(:error).with(a_string_including('boom'))
+
+      run
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Syncs endpoint metadata from `commons/endpoints/*.yml` to data.gouv.fr's dataservices API, triggered by a GitHub Actions workflow when fiche files change (push to `main`, i.e. the develop→main CI force-push, filtered to `commons/endpoints/**`).
- Creates or updates a dataservice per endpoint; deletes it when the endpoint is deprecated. The yml is the single source of truth — title/description/tags/URLs are always regenerated, never hand-edited on the data.gouv.fr side.
- Newly-assigned `datagouv_uid` values are written back into the yml automatically, committed to `develop` via the GitHub Contents API so the commit is GitHub-signed (required by `develop`'s branch-protection ruleset).
- `sync_with_datagouv: false` added to all endpoint entries that share a `datagouv_uid` with a sibling (deprecated/current pairs, grouped INSEE Sirene/DJEPVA entries), so the shared dataservice is never deleted out from under a still-live sibling.
- Currently points at `demo.data.gouv.fr` via the `DATAGOUV_HOST` GitHub variable — swapping it to `data.gouv.fr` later works identically, since the client has no hardcoded demo reference (also need to change DATAGOUV_API_TOKEN)

## Test plan
- [x] `bundle exec rspec spec/services/datagouv/ spec/clients/datagouv_api_client_spec.rb spec/models/abstract_endpoint_spec.rb spec/lib/tasks/datagouv_spec.rb` — 62 examples, 0 failures
- [x] `bundle exec rubocop` on all touched files — clean (one pre-existing, unrelated offense in `inflections.rb`)
- [x] Full catalog audit confirming no two unrelated endpoints share a `datagouv_uid` without `sync_with_datagouv: false`
- [ ] Live sync against `demo.data.gouv.fr` once the bot identity is added to the "Secure contain protek" ruleset's bypass list on `develop` (required for the write-back commit's `pull_request` rule, separate from the signing fix already in place)