### PR TITLE
Add API Particulier Démarche numérique DataPass webhook

### DIFF
--- a/site/app/controllers/concerns/datapass_webhooks.rb
+++ b/site/app/controllers/concerns/datapass_webhooks.rb
@@ -14,6 +14,10 @@ module DatapassWebhooks
     handle_api('api_particulier')
   end
 
+  def api_particulier_demarche_numerique
+    handle_api('api_particulier_demarche_numerique')
+  end
+
   protected
 
   def datapass_webhook_params

--- a/site/app/organizers/datapass_webhook/v2/api_particulier_demarche_numerique.rb
+++ b/site/app/organizers/datapass_webhook/v2/api_particulier_demarche_numerique.rb
@@ -1,0 +1,20 @@
+module DatapassWebhook::V2
+  class APIParticulierDemarcheNumerique < ApplicationOrganizer
+    before do
+      context.api = 'particulier'
+      context.authorization_request_data ||= {}
+      context.modalities = context.authorization_request_data['modalities'].presence || %w[params]
+    end
+
+    organize ::DatapassWebhook::AdaptV2ToV1,
+      ::DatapassWebhook::FindOrCreateUser,
+      ::DatapassWebhook::FindOrCreateAuthorizationRequest,
+      ::DatapassWebhook::FindOrCreateOrganization,
+      ::DatapassWebhook::CreateOrProlongToken,
+      ::DatapassWebhook::CreateEditorDelegation,
+      ::DatapassWebhook::ArchiveCurrentAuthorizationRequest,
+      ::DatapassWebhook::RefuseCurrentAuthorizationRequest,
+      ::DatapassWebhook::RevokeCurrentToken,
+      ::DatapassWebhook::UpdateMailjetContacts
+  end
+end

--- a/site/config/routes/api_entreprise.rb
+++ b/site/config/routes/api_entreprise.rb
@@ -5,6 +5,7 @@ constraints(APIEntrepriseDomainConstraint.new) do
 
     post '/datapass/v2/api_entreprise/webhook' => 'datapass_webhooks_v2#api_entreprise'
     post '/datapass/v2/api_particulier/webhook' => 'datapass_webhooks_v2#api_particulier'
+    post '/datapass/v2/api_particulier_demarche_numerique/webhook' => 'datapass_webhooks_v2#api_particulier_demarche_numerique'
   end
 
   post '/auth/api_gouv_entreprise', as: :login_api_gouv_entreprise

--- a/site/config/routes/api_particulier.rb
+++ b/site/config/routes/api_particulier.rb
@@ -2,6 +2,7 @@ constraints(APIParticulierDomainConstraint.new) do
   namespace :api do
     post '/datapass/api_particulier/webhook' => 'datapass_webhooks#api_particulier'
     post '/datapass/v2/api_particulier/webhook' => 'datapass_webhooks_v2#api_particulier'
+    post '/datapass/v2/api_particulier_demarche_numerique/webhook' => 'datapass_webhooks_v2#api_particulier_demarche_numerique'
   end
 
   post '/auth/api_gouv_particulier', as: :login_api_gouv_particulier

--- a/site/spec/controllers/api/datapass_webhooks_v2_controller_spec.rb
+++ b/site/spec/controllers/api/datapass_webhooks_v2_controller_spec.rb
@@ -165,4 +165,49 @@ RSpec.describe API::DatapassWebhooksV2Controller do
       end
     end
   end
+
+  describe '#api_particulier_demarche_numerique' do
+    subject do
+      post :api_particulier_demarche_numerique, params:
+    end
+
+    describe 'happy path, on validation' do
+      let(:event) { 'approve' }
+      let(:token_id) { 'token id' }
+      let(:success) { true }
+
+      before do
+        allow_any_instance_of(HubSignature).to receive(:valid?).and_return(true) # rubocop:todo RSpec/AnyInstance
+
+        allow(DatapassWebhook::V2::APIParticulierDemarcheNumerique).to receive(:call).and_return(
+          OpenStruct.new(
+            token_id:,
+            success?: true
+          )
+        )
+      end
+
+      it 'calls DatapassWebhook::V2::APIParticulierDemarcheNumerique' do
+        expect(DatapassWebhook::V2::APIParticulierDemarcheNumerique).to receive(:call)
+
+        subject
+      end
+
+      it 'renders 200' do
+        subject
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      context 'when event is approve' do
+        let(:event) { 'approve' }
+
+        it 'renders a json with a token id' do
+          subject
+
+          expect(response.parsed_body['token_id']).to eq(token_id)
+        end
+      end
+    end
+  end
 end

--- a/site/spec/organizers/datapass_webhook/v2/api_particulier_demarche_numerique_spec.rb
+++ b/site/spec/organizers/datapass_webhook/v2/api_particulier_demarche_numerique_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DatapassWebhook::V2::APIParticulierDemarcheNumerique, type: :interactor do
+  subject { described_class.call(datapass_webhook_params) }
+
+  let(:datapass_webhook_params) do
+    params = build(:datapass_webhook_v2, event: 'approve')
+
+    %w[family_name given_name email phone_number job_title].each do |attribute|
+      params['data']['data'].delete "contact_metier_#{attribute}"
+    end
+
+    params['data']['data']['scopes'] = ['cnaf_quotient_familial']
+
+    params
+  end
+
+  before do
+    allow(Mailjet::Contactslist_managemanycontacts).to receive(:create)
+  end
+
+  it_behaves_like 'datapass webhooks', 'v2'
+
+  it 'creates an authorization request with particulier api' do
+    expect(subject.authorization_request.api).to eq('particulier')
+  end
+
+  it 'creates token for API Particulier' do
+    subject
+
+    expect(Token.last.api).to eq('particulier')
+  end
+
+  describe 'Mailjet adding contacts' do
+    it 'adds contacts to Particulier mailjet list' do
+      expect(Mailjet::Contactslist_managemanycontacts).to receive(:create).with(
+        hash_including(id: Rails.application.credentials.mj_list_id_particulier!),
+        any_args
+      )
+
+      subject
+    end
+  end
+
+  it 'does not schedule any authorization request email' do
+    expect { subject }.not_to have_enqueued_job(ScheduleAuthorizationRequestEmailJob)
+  end
+
+  it 'does not schedule a formulaire qf resources job' do
+    expect { subject }.not_to have_enqueued_job(CreateFormulaireQFResourcesJob)
+  end
+
+  it 'does not notify reporters' do
+    expect(APIParticulier::ReportersMailer).not_to receive(:with)
+
+    subject
+  end
+end


### PR DESCRIPTION
Introduce a dedicated V2 DataPass webhook for the new "API Particulier via Démarche numérique" authorization definition (see etalab/data_pass#1682). It is a subset of API Particulier managed independently regarding access, emails and webhooks.

The organizer mirrors API Particulier but, being driven by Démarche numérique, it sends no email (no ScheduleAuthorizationRequestEmails, ExtractMailjetVariables nor NotifyReporters) and drops the formulaire QF modality. Mailjet contacts are still synced on the particulier list.

Only a V2 route is added since the legacy V1 webhook flow no longer exists for new definitions. The existing webhook verify token is reused, so no new credentials are required.