### PR TITLE
Add prolongation primitive for editor tokens (T14)

### DIFF
--- a/site/app/models/editor_token.rb
+++ b/site/app/models/editor_token.rb
@@ -33,6 +33,10 @@ class EditorToken < ApplicationRecord
     end
   end
 
+  def prolong!
+    update!(exp: 18.months.from_now.to_i)
+  end
+
   private
 
   def jwt_data

--- a/site/app/policies/editor_token_policy.rb
+++ b/site/app/policies/editor_token_policy.rb
@@ -17,9 +17,21 @@ class EditorTokenPolicy < ApplicationPolicy
     manageable?
   end
 
+  def prolong?
+    owner? && day_left < 90 && !editor_token.blacklisted?
+  end
+
   private
 
   def manageable?
     user.editor? && editor_token.editor == user.editor && editor_token.active?
+  end
+
+  def owner?
+    user.editor == editor_token.editor
+  end
+
+  def day_left
+    (editor_token.exp - Time.zone.now.to_i) / 1.day
   end
 end

--- a/site/spec/models/editor_token_spec.rb
+++ b/site/spec/models/editor_token_spec.rb
@@ -155,4 +155,14 @@ RSpec.describe EditorToken do
       expect(described_class.active).to contain_exactly(active_token)
     end
   end
+
+  describe '#prolong!' do
+    it 'sets exp to 18 months from now' do
+      editor_token = create(:editor_token, exp: 1.month.from_now.to_i)
+
+      editor_token.prolong!
+
+      expect(editor_token.reload.exp).to be_within(5).of(18.months.from_now.to_i)
+    end
+  end
 end

--- a/site/spec/policies/editor_token_policy_spec.rb
+++ b/site/spec/policies/editor_token_policy_spec.rb
@@ -58,4 +58,44 @@ RSpec.describe EditorTokenPolicy do
       end
     end
   end
+
+  describe '#prolong?' do
+    let(:editor_token) { create(:editor_token, editor:, exp: 1.month.from_now.to_i) }
+
+    it 'allows the owner when the token expires in less than 90 days' do
+      expect(policy.prolong?).to be true
+    end
+
+    context 'when the token expires in more than 90 days' do
+      let(:editor_token) { create(:editor_token, editor:, exp: 6.months.from_now.to_i) }
+
+      it 'denies' do
+        expect(policy.prolong?).to be false
+      end
+    end
+
+    context 'when the token is blacklisted' do
+      let(:editor_token) { create(:editor_token, :blacklisted, editor:, exp: 1.month.from_now.to_i) }
+
+      it 'denies' do
+        expect(policy.prolong?).to be false
+      end
+    end
+
+    context 'when the token belongs to another editor' do
+      let(:editor_token) { create(:editor_token, exp: 1.month.from_now.to_i) }
+
+      it 'denies' do
+        expect(policy.prolong?).to be false
+      end
+    end
+
+    context 'when the user has no editor' do
+      let(:user) { create(:user) }
+
+      it 'denies' do
+        expect(policy.prolong?).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds `EditorToken#prolong!` (+18 months) and `EditorTokenPolicy#prolong?` — the minimal primitive; UI (T6) and admin route (T7b) come separately.

Closes API-6632 → https://linear.app/pole-api/issue/API-6632/t14-generaliser-la-prolongation-aux-tokens-editeur

🤖 Generated with [Claude Code](https://claude.com/claude-code)