### PR TITLE
feat: pass Sport - identite pivot AEEH, ARS, quotient familial for nom_dusage

### DIFF
--- a/mocks/payloads/api_particulier_v3_cnav_allocation_enfant_handicape_with_civility/200_enfant_mercier_beneficiaire.yaml
+++ b/mocks/payloads/api_particulier_v3_cnav_allocation_enfant_handicape_with_civility/200_enfant_mercier_beneficiaire.yaml
@@ -1,0 +1,27 @@
+---
+description: |-
+  ## Enfant bénéficiaire AEEH (rattaché à l'allocataire QF MERCIER)
+
+  Enfant mineur de l'allocataire `MERCIER PIERRE` (nom d'usage DUBOIS) du cas
+  Quotient Familial `200-nom-usage-1_parent_3_mineurs`. Cet enfant est éligible
+  et bénéficiaire de l'AEEH.
+params:
+  nomNaissance: 'MERCIER'
+  prenoms:
+  - 'ROBERT'
+  anneeDateNaissance: 2016
+  moisDateNaissance: 3
+  jourDateNaissance: 15
+  codeCogInseeCommuneNaissance: '75102'
+  codeCogInseePaysNaissance: '99100'
+  sexeEtatCivil: 'M'
+status: 200
+payload: |-
+  {
+    "data": {
+      "status": "allocataire",
+      "date_debut_droit": "2023-06-15"
+    },
+    "links": {},
+    "meta": {}
+  }

--- a/mocks/payloads/api_particulier_v3_cnav_allocation_enfant_handicape_with_civility/README.md
+++ b/mocks/payloads/api_particulier_v3_cnav_allocation_enfant_handicape_with_civility/README.md
@@ -107,6 +107,65 @@
 
   </p>
   </details>
+* [200_enfant_mercier_beneficiaire.yaml](200_enfant_mercier_beneficiaire.yaml)
+
+  Status `200`
+
+  ## Enfant bénéficiaire AEEH (rattaché à l'allocataire QF MERCIER)
+
+Enfant mineur de l'allocataire `MERCIER PIERRE` (nom d'usage DUBOIS) du cas
+Quotient Familial `200-nom-usage-1_parent_3_mineurs`. Cet enfant est éligible
+et bénéficiaire de l'AEEH.
+
+  <details><summary>Paramètres</summary>
+  <p>
+
+  ```json
+  {
+    "nomNaissance": "MERCIER",
+    "prenoms": [
+      "ROBERT"
+    ],
+    "anneeDateNaissance": 2016,
+    "moisDateNaissance": 3,
+    "jourDateNaissance": 15,
+    "codeCogInseeCommuneNaissance": "75102",
+    "codeCogInseePaysNaissance": "99100",
+    "sexeEtatCivil": "M"
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Réponse API</summary>
+  <p>
+
+  ```json
+  {
+    "data": {
+      "status": "allocataire",
+      "date_debut_droit": "2023-06-15"
+    },
+    "links": {},
+    "meta": {}
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Commande cURL</summary>
+  <p>
+
+  ```bash
+  curl -H "Authorization: Bearer $token" \
+    -G -d 'recipient=13002526500013' -d 'nomNaissance=MERCIER' -d 'prenoms[]=ROBERT' -d 'anneeDateNaissance=2016' -d 'moisDateNaissance=3' -d 'jourDateNaissance=15' -d 'codeCogInseeCommuneNaissance=75102' -d 'codeCogInseePaysNaissance=99100' -d 'sexeEtatCivil=M' \
+    --url "https://staging.particulier.api.gouv.fr/v3/dss/allocation_enfant_handicape/identite"
+  ```
+
+  </p>
+  </details>
 * [200_non_beneficiaire.yaml](200_non_beneficiaire.yaml)
 
   Status `200`

--- a/mocks/payloads/api_particulier_v3_cnav_allocation_enfant_handicape_with_civility/summary.csv
+++ b/mocks/payloads/api_particulier_v3_cnav_allocation_enfant_handicape_with_civility/summary.csv
@@ -15,6 +15,18 @@ Titre,Description,Paramètres,Status,Réponse
   ""links"": {},
   ""meta"": {}
 }"
+,"## Enfant bénéficiaire AEEH (rattaché à l'allocataire QF MERCIER)
+
+Enfant mineur de l'allocataire `MERCIER PIERRE` (nom d'usage DUBOIS) du cas
+Quotient Familial `200-nom-usage-1_parent_3_mineurs`. Cet enfant est éligible
+et bénéficiaire de l'AEEH.","{""nomNaissance"":""MERCIER"",""prenoms"":[""ROBERT""],""anneeDateNaissance"":2016,""moisDateNaissance"":3,""jourDateNaissance"":15,""codeCogInseeCommuneNaissance"":""75102"",""codeCogInseePaysNaissance"":""99100"",""sexeEtatCivil"":""M""}",200,"{
+  ""data"": {
+    ""status"": ""allocataire"",
+    ""date_debut_droit"": ""2023-06-15""
+  },
+  ""links"": {},
+  ""meta"": {}
+}"
 ,## Non bénéficiaire,"{""nomNaissance"":""BERNARD"",""prenoms"":[""LUCAS""],""anneeDateNaissance"":2010,""moisDateNaissance"":1,""jourDateNaissance"":5,""codeCogInseeCommuneNaissance"":""13055"",""codeCogInseePaysNaissance"":""99100"",""sexeEtatCivil"":""M""}",200,"{
   ""data"": {
     ""status"": ""non_beneficiaire"",

--- a/mocks/payloads/api_particulier_v3_cnav_allocation_rentree_scolaire_with_civility/200_enfant_mercier_pierre_allocataire.yaml
+++ b/mocks/payloads/api_particulier_v3_cnav_allocation_rentree_scolaire_with_civility/200_enfant_mercier_pierre_allocataire.yaml
@@ -1,0 +1,27 @@
+---
+description: |-
+  ## Enfant bénéficiaire ARS (rattaché à l'allocataire QF MERCIER)
+
+  Enfant mineur `MERCIER PIERRE` de l'allocataire `MERCIER PIERRE` (nom d'usage
+  DUBOIS) du cas Quotient Familial `200-nom-usage-1_parent_3_mineurs`. Né en
+  2013, il respecte la condition d'âge ARS (6-18 ans) et est bénéficiaire.
+params:
+  nomNaissance: 'MERCIER'
+  prenoms:
+  - 'PIERRE'
+  anneeDateNaissance: 2013
+  moisDateNaissance: 1
+  jourDateNaissance: 10
+  codeCogInseeCommuneNaissance: '75102'
+  codeCogInseePaysNaissance: '99100'
+  sexeEtatCivil: 'M'
+status: 200
+payload: |-
+  {
+    "data": {
+      "status": "allocataire",
+      "date_debut_droit": "2024-08-09"
+    },
+    "links": {},
+    "meta": {}
+  }

--- a/mocks/payloads/api_particulier_v3_cnav_allocation_rentree_scolaire_with_civility/README.md
+++ b/mocks/payloads/api_particulier_v3_cnav_allocation_rentree_scolaire_with_civility/README.md
@@ -54,6 +54,65 @@
 
   </p>
   </details>
+* [200_enfant_mercier_pierre_allocataire.yaml](200_enfant_mercier_pierre_allocataire.yaml)
+
+  Status `200`
+
+  ## Enfant bénéficiaire ARS (rattaché à l'allocataire QF MERCIER)
+
+Enfant mineur `MERCIER PIERRE` de l'allocataire `MERCIER PIERRE` (nom d'usage
+DUBOIS) du cas Quotient Familial `200-nom-usage-1_parent_3_mineurs`. Né en
+2013, il respecte la condition d'âge ARS (6-18 ans) et est bénéficiaire.
+
+  <details><summary>Paramètres</summary>
+  <p>
+
+  ```json
+  {
+    "nomNaissance": "MERCIER",
+    "prenoms": [
+      "PIERRE"
+    ],
+    "anneeDateNaissance": 2013,
+    "moisDateNaissance": 1,
+    "jourDateNaissance": 10,
+    "codeCogInseeCommuneNaissance": "75102",
+    "codeCogInseePaysNaissance": "99100",
+    "sexeEtatCivil": "M"
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Réponse API</summary>
+  <p>
+
+  ```json
+  {
+    "data": {
+      "status": "allocataire",
+      "date_debut_droit": "2024-08-09"
+    },
+    "links": {},
+    "meta": {}
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Commande cURL</summary>
+  <p>
+
+  ```bash
+  curl -H "Authorization: Bearer $token" \
+    -G -d 'recipient=13002526500013' -d 'nomNaissance=MERCIER' -d 'prenoms[]=PIERRE' -d 'anneeDateNaissance=2013' -d 'moisDateNaissance=1' -d 'jourDateNaissance=10' -d 'codeCogInseeCommuneNaissance=75102' -d 'codeCogInseePaysNaissance=99100' -d 'sexeEtatCivil=M' \
+    --url "https://staging.particulier.api.gouv.fr/v3/dss/allocation_rentree_scolaire/identite"
+  ```
+
+  </p>
+  </details>
 * [200_non_beneficiaire.yaml](200_non_beneficiaire.yaml)
 
   Status `200`

--- a/mocks/payloads/api_particulier_v3_cnav_allocation_rentree_scolaire_with_civility/summary.csv
+++ b/mocks/payloads/api_particulier_v3_cnav_allocation_rentree_scolaire_with_civility/summary.csv
@@ -7,6 +7,18 @@ Titre,Description,Paramètres,Status,Réponse
   ""links"": {},
   ""meta"": {}
 }"
+,"## Enfant bénéficiaire ARS (rattaché à l'allocataire QF MERCIER)
+
+Enfant mineur `MERCIER PIERRE` de l'allocataire `MERCIER PIERRE` (nom d'usage
+DUBOIS) du cas Quotient Familial `200-nom-usage-1_parent_3_mineurs`. Né en
+2013, il respecte la condition d'âge ARS (6-18 ans) et est bénéficiaire.","{""nomNaissance"":""MERCIER"",""prenoms"":[""PIERRE""],""anneeDateNaissance"":2013,""moisDateNaissance"":1,""jourDateNaissance"":10,""codeCogInseeCommuneNaissance"":""75102"",""codeCogInseePaysNaissance"":""99100"",""sexeEtatCivil"":""M""}",200,"{
+  ""data"": {
+    ""status"": ""allocataire"",
+    ""date_debut_droit"": ""2024-08-09""
+  },
+  ""links"": {},
+  ""meta"": {}
+}"
 ,## Non bénéficiaire,"{""nomNaissance"":""BERNARD"",""prenoms"":[""LUCAS""],""anneeDateNaissance"":1978,""moisDateNaissance"":1,""jourDateNaissance"":5,""codeCogInseeCommuneNaissance"":""13055"",""codeCogInseePaysNaissance"":""99100"",""sexeEtatCivil"":""M""}",200,"{
   ""data"": {
     ""status"": ""non_beneficiaire"",

--- a/mocks/payloads/api_particulier_v3_cnav_quotient_familial_with_civility/200-nom-usage-1_parent_3_mineurs.yaml
+++ b/mocks/payloads/api_particulier_v3_cnav_quotient_familial_with_civility/200-nom-usage-1_parent_3_mineurs.yaml
@@ -1,0 +1,82 @@
+---
+description: |-
+  ## Parent avec nom d'usage et trois enfants mineurs - QF CNAF de 2550
+
+  Ce cas permet de tester :
+  - [Param. appel] Utilisation du paramètre nomUsage
+  - [Param. appel] Lieu de naissance en France
+  - [Réponse] Nom d'usage présent dans la réponse
+  - [Réponse] Trois enfants mineurs rattachés
+  - [Réponse] Régime CNAF
+  - [Réponse] Quotient familial de 2550
+
+  Les enfants sont calqués sur l'identité FranceConnect
+  `france_connect_200_cnaf_1_parent_3_mineurs.yml`.
+params:
+  codeCogInseeCommuneNaissance: '95277'
+  codeCogInseePaysNaissance: '99100'
+  sexeEtatCivil: 'M'
+  nomNaissance: 'MERCIER'
+  nomUsage: 'DUBOIS'
+  prenoms:
+    - 'PIERRE'
+  anneeDateNaissance: 1969
+  moisDateNaissance: 3
+  jourDateNaissance: 17
+status: 200
+payload: |-
+  {
+    "data": {
+      "allocataires": [
+        {
+          "nom_naissance": "MERCIER",
+          "nom_usage": "DUBOIS",
+          "prenoms": "PIERRE",
+          "date_naissance": "1969-03-17",
+          "sexe": "M"
+        }
+      ],
+      "enfants": [
+        {
+          "nom_naissance": "MERCIER",
+          "nom_usage": null,
+          "prenoms": "PIERRE",
+          "date_naissance": "2013-01-10",
+          "sexe": "M"
+        },
+        {
+          "nom_naissance": "MERCIER",
+          "nom_usage": null,
+          "prenoms": "ROBERT",
+          "date_naissance": "2016-03-15",
+          "sexe": "M"
+        },
+        {
+          "nom_naissance": "MERCIER",
+          "nom_usage": null,
+          "prenoms": "HENRY",
+          "date_naissance": "2022-06-20",
+          "sexe": "M"
+        }
+      ],
+      "adresse": {
+        "destinataire": "Monsieur DUBOIS PIERRE",
+        "complement_information": null,
+        "complement_information_geographique": null,
+        "numero_libelle_voie": "1 RUE MONTORGUEIL",
+        "lieu_dit": null,
+        "code_postal_ville": "75002 PARIS",
+        "pays": "FRANCE"
+      },
+      "quotient_familial": {
+        "fournisseur": "CNAF",
+        "valeur": 2550,
+        "annee": 2024,
+        "mois": 2,
+        "annee_calcul": 2024,
+        "mois_calcul": 12
+      }
+    },
+    "links": {},
+    "meta": {}
+  }

--- a/mocks/payloads/api_particulier_v3_cnav_quotient_familial_with_civility/README.md
+++ b/mocks/payloads/api_particulier_v3_cnav_quotient_familial_with_civility/README.md
@@ -3019,6 +3019,120 @@ Ce cas permet de tester :
 
   </p>
   </details>
+* [200-nom-usage-1_parent_3_mineurs.yaml](200-nom-usage-1_parent_3_mineurs.yaml)
+
+  Status `200`
+
+  ## Parent avec nom d'usage et trois enfants mineurs - QF CNAF de 2550
+
+Ce cas permet de tester :
+- [Param. appel] Utilisation du paramètre nomUsage
+- [Param. appel] Lieu de naissance en France
+- [Réponse] Nom d'usage présent dans la réponse
+- [Réponse] Trois enfants mineurs rattachés
+- [Réponse] Régime CNAF
+- [Réponse] Quotient familial de 2550
+
+Les enfants sont calqués sur l'identité FranceConnect
+`france_connect_200_cnaf_1_parent_3_mineurs.yml`.
+
+  <details><summary>Paramètres</summary>
+  <p>
+
+  ```json
+  {
+    "codeCogInseeCommuneNaissance": "95277",
+    "codeCogInseePaysNaissance": "99100",
+    "sexeEtatCivil": "M",
+    "nomNaissance": "MERCIER",
+    "nomUsage": "DUBOIS",
+    "prenoms": [
+      "PIERRE"
+    ],
+    "anneeDateNaissance": 1969,
+    "moisDateNaissance": 3,
+    "jourDateNaissance": 17
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Réponse API</summary>
+  <p>
+
+  ```json
+  {
+    "data": {
+      "allocataires": [
+        {
+          "nom_naissance": "MERCIER",
+          "nom_usage": "DUBOIS",
+          "prenoms": "PIERRE",
+          "date_naissance": "1969-03-17",
+          "sexe": "M"
+        }
+      ],
+      "enfants": [
+        {
+          "nom_naissance": "MERCIER",
+          "nom_usage": null,
+          "prenoms": "PIERRE",
+          "date_naissance": "2013-01-10",
+          "sexe": "M"
+        },
+        {
+          "nom_naissance": "MERCIER",
+          "nom_usage": null,
+          "prenoms": "ROBERT",
+          "date_naissance": "2016-03-15",
+          "sexe": "M"
+        },
+        {
+          "nom_naissance": "MERCIER",
+          "nom_usage": null,
+          "prenoms": "HENRY",
+          "date_naissance": "2022-06-20",
+          "sexe": "M"
+        }
+      ],
+      "adresse": {
+        "destinataire": "Monsieur DUBOIS PIERRE",
+        "complement_information": null,
+        "complement_information_geographique": null,
+        "numero_libelle_voie": "1 RUE MONTORGUEIL",
+        "lieu_dit": null,
+        "code_postal_ville": "75002 PARIS",
+        "pays": "FRANCE"
+      },
+      "quotient_familial": {
+        "fournisseur": "CNAF",
+        "valeur": 2550,
+        "annee": 2024,
+        "mois": 2,
+        "annee_calcul": 2024,
+        "mois_calcul": 12
+      }
+    },
+    "links": {},
+    "meta": {}
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Commande cURL</summary>
+  <p>
+
+  ```bash
+  curl -H "Authorization: Bearer $token" \
+    -G -d 'recipient=13002526500013' -d 'codeCogInseeCommuneNaissance=95277' -d 'codeCogInseePaysNaissance=99100' -d 'sexeEtatCivil=M' -d 'nomNaissance=MERCIER' -d 'nomUsage=DUBOIS' -d 'prenoms[]=PIERRE' -d 'anneeDateNaissance=1969' -d 'moisDateNaissance=3' -d 'jourDateNaissance=17' \
+    --url "https://staging.particulier.api.gouv.fr/v3/dss/quotient_familial/identite"
+  ```
+
+  </p>
+  </details>
 * [200-nom-usage-femme-seule-qf_caf_800.yaml](200-nom-usage-femme-seule-qf_caf_800.yaml)
 
   Status `200`

--- a/mocks/payloads/api_particulier_v3_cnav_quotient_familial_with_civility/summary.csv
+++ b/mocks/payloads/api_particulier_v3_cnav_quotient_familial_with_civility/summary.csv
@@ -1653,6 +1653,72 @@ Ce cas permet de tester :
   ""links"": {},
   ""meta"": {}
 }"
+,"## Parent avec nom d'usage et trois enfants mineurs - QF CNAF de 2550
+
+Ce cas permet de tester :
+- [Param. appel] Utilisation du paramètre nomUsage
+- [Param. appel] Lieu de naissance en France
+- [Réponse] Nom d'usage présent dans la réponse
+- [Réponse] Trois enfants mineurs rattachés
+- [Réponse] Régime CNAF
+- [Réponse] Quotient familial de 2550
+
+Les enfants sont calqués sur l'identité FranceConnect
+`france_connect_200_cnaf_1_parent_3_mineurs.yml`.","{""codeCogInseeCommuneNaissance"":""95277"",""codeCogInseePaysNaissance"":""99100"",""sexeEtatCivil"":""M"",""nomNaissance"":""MERCIER"",""nomUsage"":""DUBOIS"",""prenoms"":[""PIERRE""],""anneeDateNaissance"":1969,""moisDateNaissance"":3,""jourDateNaissance"":17}",200,"{
+  ""data"": {
+    ""allocataires"": [
+      {
+        ""nom_naissance"": ""MERCIER"",
+        ""nom_usage"": ""DUBOIS"",
+        ""prenoms"": ""PIERRE"",
+        ""date_naissance"": ""1969-03-17"",
+        ""sexe"": ""M""
+      }
+    ],
+    ""enfants"": [
+      {
+        ""nom_naissance"": ""MERCIER"",
+        ""nom_usage"": null,
+        ""prenoms"": ""PIERRE"",
+        ""date_naissance"": ""2013-01-10"",
+        ""sexe"": ""M""
+      },
+      {
+        ""nom_naissance"": ""MERCIER"",
+        ""nom_usage"": null,
+        ""prenoms"": ""ROBERT"",
+        ""date_naissance"": ""2016-03-15"",
+        ""sexe"": ""M""
+      },
+      {
+        ""nom_naissance"": ""MERCIER"",
+        ""nom_usage"": null,
+        ""prenoms"": ""HENRY"",
+        ""date_naissance"": ""2022-06-20"",
+        ""sexe"": ""M""
+      }
+    ],
+    ""adresse"": {
+      ""destinataire"": ""Monsieur DUBOIS PIERRE"",
+      ""complement_information"": null,
+      ""complement_information_geographique"": null,
+      ""numero_libelle_voie"": ""1 RUE MONTORGUEIL"",
+      ""lieu_dit"": null,
+      ""code_postal_ville"": ""75002 PARIS"",
+      ""pays"": ""FRANCE""
+    },
+    ""quotient_familial"": {
+      ""fournisseur"": ""CNAF"",
+      ""valeur"": 2550,
+      ""annee"": 2024,
+      ""mois"": 2,
+      ""annee_calcul"": 2024,
+      ""mois_calcul"": 12
+    }
+  },
+  ""links"": {},
+  ""meta"": {}
+}"
 ,"## Femme seule avec nom d'usage - QF CAF de 800
 
 Ce cas permet de tester :


### PR DESCRIPTION
# Feature
Pass Sport - identité pivot mocks (AEEH, ARS, quotient familial) pour l'identité FC avec_nom_dusage (https://github.com/france-connect/sources/blob/main/docker/volumes/fcp-low/mocks/idp/databases/citizen/base.csv)

# Contexte
Dans le cadre du Pass Sport, on a besoin de tester le parcours d'identité pivot d'une famille (allocataire + enfants mineurs) à travers plusieurs endpoints API Particulier, en couvrant en particulier le cas d'un allocataire disposant d'un nom d'usage distinct de son nom de naissance.

## Ce que fait cette PR
Ajoute une famille de mocks cohérente reliant trois endpoints autour d'un même foyer fictif : l'allocataire MERCIER PIERRE (nom d'usage DUBOIS) et ses trois enfants mineurs (PIERRE, ROBERT, HENRY).

## Quotient familial (CNAF) - api_particulier_v3_cnav_quotient_familial_with_civility
- Nouveau cas 200-nom-usage-1_parent_3_mineurs.yaml
- Parent avec nomUsage, régime CNAF, QF de 2550, trois enfants mineurs rattachés
- Enfants calqués sur l'identité FranceConnect france_connect_200_cnaf_1_parent_3_mineurs.yml
- Couvre : paramètre nomUsage, lieu de naissance en France, nom d'usage présent dans la réponse

## AEEH (CNAV) - api_particulier_v3_cnav_allocation_enfant_handicape_with_civility
- Nouveau cas 200_enfant_mercier_beneficiaire.yaml
- Enfant mineur (ROBERT, né 2016) rattaché à l'allocataire QF ci-dessus, bénéficiaire AEEH

## ARS (CNAV) - api_particulier_v3_cnav_allocation_rentree_scolaire_with_civility
- Nouveau cas 200_enfant_mercier_pierre_allocataire.yaml
- Enfant mineur (PIERRE, né 2013) respectant la condition d'âge ARS (6–18 ans), bénéficiaire ARS

## Test
Les 3 cas partagent une identité pivot cohérente → permet de dérouler le parcours Pass Sport de bout en bout (QF → AEEH / ARS) sur une même famille.