### PR TITLE
feat: pass Sport - corrections aeeh,ars et ajouts cnous et aah

### DIFF
--- a/mocks/payloads/api_particulier_v3_cnav_allocation_adulte_handicape_with_civility/200-usager-nom-50-caracteres-france_connect.yml
+++ b/mocks/payloads/api_particulier_v3_cnav_allocation_adulte_handicape_with_civility/200-usager-nom-50-caracteres-france_connect.yml
@@ -1,0 +1,28 @@
+---
+description: |-
+  ## Identité `nom_50+_caractères` de la base de test de France Connect
+
+  Ce cas permet de tester un appel à partir des données de l'identité pivot
+  France Connect `nom_50+_caractères` (nom de naissance de plus de 50
+  caractères). Cet usager est bénéficiaire de l'AAH.
+params:
+  nomNaissance: 'AZERTYUIOPMLKJHGFDSQWXCVBNAZERTYUIOPMLKJHGFDSQWXCVBN'
+  prenoms:
+  - 'BERTRAND'
+  - 'CYRIL'
+  anneeDateNaissance: 2000
+  moisDateNaissance: 3
+  jourDateNaissance: 1
+  codeCogInseeCommuneNaissance: '75119'
+  codeCogInseePaysNaissance: '99100'
+  sexeEtatCivil: 'M'
+status: 200
+payload: |-
+  {
+    "data": {
+      "est_beneficiaire": true,
+      "date_debut_droit": "2023-04-01"
+    },
+    "links": {},
+    "meta": {}
+  }

--- a/mocks/payloads/api_particulier_v3_cnav_allocation_adulte_handicape_with_civility/README.md
+++ b/mocks/payloads/api_particulier_v3_cnav_allocation_adulte_handicape_with_civility/README.md
@@ -52,6 +52,64 @@
 
   </p>
   </details>
+* [200-usager-nom-50-caracteres-france_connect.yml](200-usager-nom-50-caracteres-france_connect.yml)
+
+  Status `200`
+
+  ## Identité `nom_50+_caractères` de la base de test de France Connect
+
+Ce cas permet de tester un appel à partir des données de l'identité pivot
+France Connect `nom_50+_caractères` (nom de naissance de plus de 50
+caractères). Cet usager est bénéficiaire de l'AAH.
+
+  <details><summary>Paramètres</summary>
+  <p>
+
+  ```json
+  {
+    "nomNaissance": "AZERTYUIOPMLKJHGFDSQWXCVBNAZERTYUIOPMLKJHGFDSQWXCVBN",
+    "prenoms": [
+      "BERTRAND",
+      "CYRIL"
+    ],
+    "anneeDateNaissance": 2000,
+    "moisDateNaissance": 3,
+    "jourDateNaissance": 1,
+    "codeCogInseeCommuneNaissance": "75119",
+    "codeCogInseePaysNaissance": "99100",
+    "sexeEtatCivil": "M"
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Réponse API</summary>
+  <p>
+
+  ```json
+  {
+    "data": {
+      "est_beneficiaire": true,
+      "date_debut_droit": "2023-04-01"
+    },
+    "links": {},
+    "meta": {}
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Commande cURL</summary>
+  <p>
+
+  ```bash
+  curl -H "Authorization: Bearer $token_france_connect" --url "https://staging.particulier.api.gouv.fr/v3/dss/allocation_adulte_handicape/identite?recipient=13002526500013"
+  ```
+
+  </p>
+  </details>
 * [200_beneficiaire.yaml](200_beneficiaire.yaml)
 
   Status `200`

--- a/mocks/payloads/api_particulier_v3_cnav_allocation_adulte_handicape_with_civility/summary.csv
+++ b/mocks/payloads/api_particulier_v3_cnav_allocation_adulte_handicape_with_civility/summary.csv
@@ -7,6 +7,18 @@ Titre,Description,Paramètres,Status,Réponse
   ""links"": {},
   ""meta"": {}
 }"
+,"## Identité `nom_50+_caractères` de la base de test de France Connect
+
+Ce cas permet de tester un appel à partir des données de l'identité pivot
+France Connect `nom_50+_caractères` (nom de naissance de plus de 50
+caractères). Cet usager est bénéficiaire de l'AAH.","{""nomNaissance"":""AZERTYUIOPMLKJHGFDSQWXCVBNAZERTYUIOPMLKJHGFDSQWXCVBN"",""prenoms"":[""BERTRAND"",""CYRIL""],""anneeDateNaissance"":2000,""moisDateNaissance"":3,""jourDateNaissance"":1,""codeCogInseeCommuneNaissance"":""75119"",""codeCogInseePaysNaissance"":""99100"",""sexeEtatCivil"":""M""}",200,"{
+  ""data"": {
+    ""est_beneficiaire"": true,
+    ""date_debut_droit"": ""2023-04-01""
+  },
+  ""links"": {},
+  ""meta"": {}
+}"
 ,## Bénéficiaire,"{""nomUsage"":""DUPONT"",""nomNaissance"":""MARTIN"",""prenoms"":[""PIERRE"",""RICHARD""],""anneeDateNaissance"":1987,""moisDateNaissance"":12,""jourDateNaissance"":1,""codeCogInseeCommuneNaissance"":""08480"",""codeCogInseePaysNaissance"":""99100"",""sexeEtatCivil"":""M""}",200,"{
   ""data"": {
     ""est_beneficiaire"": true,

--- a/mocks/payloads/api_particulier_v3_cnav_allocation_enfant_handicape_with_civility/200_enfant_mercier_beneficiaire.yaml
+++ b/mocks/payloads/api_particulier_v3_cnav_allocation_enfant_handicape_with_civility/200_enfant_mercier_beneficiaire.yaml
@@ -12,7 +12,7 @@ params:
   anneeDateNaissance: 2016
   moisDateNaissance: 3
   jourDateNaissance: 15
-  codeCogInseeCommuneNaissance: '75102'
+  codeCogInseeCommuneNaissance: '95277'
   codeCogInseePaysNaissance: '99100'
   sexeEtatCivil: 'M'
 status: 200

--- a/mocks/payloads/api_particulier_v3_cnav_allocation_enfant_handicape_with_civility/README.md
+++ b/mocks/payloads/api_particulier_v3_cnav_allocation_enfant_handicape_with_civility/README.md
@@ -129,7 +129,7 @@ et bénéficiaire de l'AEEH.
     "anneeDateNaissance": 2016,
     "moisDateNaissance": 3,
     "jourDateNaissance": 15,
-    "codeCogInseeCommuneNaissance": "75102",
+    "codeCogInseeCommuneNaissance": "95277",
     "codeCogInseePaysNaissance": "99100",
     "sexeEtatCivil": "M"
   }
@@ -160,7 +160,7 @@ et bénéficiaire de l'AEEH.
 
   ```bash
   curl -H "Authorization: Bearer $token" \
-    -G -d 'recipient=13002526500013' -d 'nomNaissance=MERCIER' -d 'prenoms[]=ROBERT' -d 'anneeDateNaissance=2016' -d 'moisDateNaissance=3' -d 'jourDateNaissance=15' -d 'codeCogInseeCommuneNaissance=75102' -d 'codeCogInseePaysNaissance=99100' -d 'sexeEtatCivil=M' \
+    -G -d 'recipient=13002526500013' -d 'nomNaissance=MERCIER' -d 'prenoms[]=ROBERT' -d 'anneeDateNaissance=2016' -d 'moisDateNaissance=3' -d 'jourDateNaissance=15' -d 'codeCogInseeCommuneNaissance=95277' -d 'codeCogInseePaysNaissance=99100' -d 'sexeEtatCivil=M' \
     --url "https://staging.particulier.api.gouv.fr/v3/dss/allocation_enfant_handicape/identite"
   ```
 

--- a/mocks/payloads/api_particulier_v3_cnav_allocation_enfant_handicape_with_civility/summary.csv
+++ b/mocks/payloads/api_particulier_v3_cnav_allocation_enfant_handicape_with_civility/summary.csv
@@ -19,7 +19,7 @@ Titre,Description,Paramètres,Status,Réponse
 
 Enfant mineur de l'allocataire `MERCIER PIERRE` (nom d'usage DUBOIS) du cas
 Quotient Familial `200-nom-usage-1_parent_3_mineurs`. Cet enfant est éligible
-et bénéficiaire de l'AEEH.","{""nomNaissance"":""MERCIER"",""prenoms"":[""ROBERT""],""anneeDateNaissance"":2016,""moisDateNaissance"":3,""jourDateNaissance"":15,""codeCogInseeCommuneNaissance"":""75102"",""codeCogInseePaysNaissance"":""99100"",""sexeEtatCivil"":""M""}",200,"{
+et bénéficiaire de l'AEEH.","{""nomNaissance"":""MERCIER"",""prenoms"":[""ROBERT""],""anneeDateNaissance"":2016,""moisDateNaissance"":3,""jourDateNaissance"":15,""codeCogInseeCommuneNaissance"":""95277"",""codeCogInseePaysNaissance"":""99100"",""sexeEtatCivil"":""M""}",200,"{
   ""data"": {
     ""status"": ""allocataire"",
     ""date_debut_droit"": ""2023-06-15""

--- a/mocks/payloads/api_particulier_v3_cnav_allocation_rentree_scolaire_with_civility/200_enfant_mercier_pierre_allocataire.yaml
+++ b/mocks/payloads/api_particulier_v3_cnav_allocation_rentree_scolaire_with_civility/200_enfant_mercier_pierre_allocataire.yaml
@@ -12,7 +12,7 @@ params:
   anneeDateNaissance: 2013
   moisDateNaissance: 1
   jourDateNaissance: 10
-  codeCogInseeCommuneNaissance: '75102'
+  codeCogInseeCommuneNaissance: '95277'
   codeCogInseePaysNaissance: '99100'
   sexeEtatCivil: 'M'
 status: 200

--- a/mocks/payloads/api_particulier_v3_cnav_allocation_rentree_scolaire_with_civility/README.md
+++ b/mocks/payloads/api_particulier_v3_cnav_allocation_rentree_scolaire_with_civility/README.md
@@ -76,7 +76,7 @@ DUBOIS) du cas Quotient Familial `200-nom-usage-1_parent_3_mineurs`. Né en
     "anneeDateNaissance": 2013,
     "moisDateNaissance": 1,
     "jourDateNaissance": 10,
-    "codeCogInseeCommuneNaissance": "75102",
+    "codeCogInseeCommuneNaissance": "95277",
     "codeCogInseePaysNaissance": "99100",
     "sexeEtatCivil": "M"
   }
@@ -107,7 +107,7 @@ DUBOIS) du cas Quotient Familial `200-nom-usage-1_parent_3_mineurs`. Né en
 
   ```bash
   curl -H "Authorization: Bearer $token" \
-    -G -d 'recipient=13002526500013' -d 'nomNaissance=MERCIER' -d 'prenoms[]=PIERRE' -d 'anneeDateNaissance=2013' -d 'moisDateNaissance=1' -d 'jourDateNaissance=10' -d 'codeCogInseeCommuneNaissance=75102' -d 'codeCogInseePaysNaissance=99100' -d 'sexeEtatCivil=M' \
+    -G -d 'recipient=13002526500013' -d 'nomNaissance=MERCIER' -d 'prenoms[]=PIERRE' -d 'anneeDateNaissance=2013' -d 'moisDateNaissance=1' -d 'jourDateNaissance=10' -d 'codeCogInseeCommuneNaissance=95277' -d 'codeCogInseePaysNaissance=99100' -d 'sexeEtatCivil=M' \
     --url "https://staging.particulier.api.gouv.fr/v3/dss/allocation_rentree_scolaire/identite"
   ```
 

--- a/mocks/payloads/api_particulier_v3_cnav_allocation_rentree_scolaire_with_civility/summary.csv
+++ b/mocks/payloads/api_particulier_v3_cnav_allocation_rentree_scolaire_with_civility/summary.csv
@@ -11,7 +11,7 @@ Titre,Description,Paramètres,Status,Réponse
 
 Enfant mineur `MERCIER PIERRE` de l'allocataire `MERCIER PIERRE` (nom d'usage
 DUBOIS) du cas Quotient Familial `200-nom-usage-1_parent_3_mineurs`. Né en
-2013, il respecte la condition d'âge ARS (6-18 ans) et est bénéficiaire.","{""nomNaissance"":""MERCIER"",""prenoms"":[""PIERRE""],""anneeDateNaissance"":2013,""moisDateNaissance"":1,""jourDateNaissance"":10,""codeCogInseeCommuneNaissance"":""75102"",""codeCogInseePaysNaissance"":""99100"",""sexeEtatCivil"":""M""}",200,"{
+2013, il respecte la condition d'âge ARS (6-18 ans) et est bénéficiaire.","{""nomNaissance"":""MERCIER"",""prenoms"":[""PIERRE""],""anneeDateNaissance"":2013,""moisDateNaissance"":1,""jourDateNaissance"":10,""codeCogInseeCommuneNaissance"":""95277"",""codeCogInseePaysNaissance"":""99100"",""sexeEtatCivil"":""M""}",200,"{
   ""data"": {
     ""status"": ""allocataire"",
     ""date_debut_droit"": ""2024-08-09""

--- a/mocks/payloads/api_particulier_v3_cnous_etudiant_boursier_with_civility/200-usager-moins-25-ans-france_connect.yml
+++ b/mocks/payloads/api_particulier_v3_cnous_etudiant_boursier_with_civility/200-usager-moins-25-ans-france_connect.yml
@@ -1,0 +1,47 @@
+---
+description: |-
+  ## Identité `moins_25_ans` de la base de test de France Connect
+
+  Ce cas permet de tester un appel à partir des données de l'identité pivot
+  France Connect `moins_25_ans` (usager de moins de 25 ans). Cet usager est
+  bénéficiaire d'une bourse.
+params:
+  nomNaissance: 'CUILLERE'
+  prenoms:
+  - 'PAUL'
+  anneeDateNaissance: 2007
+  moisDateNaissance: 1
+  jourDateNaissance: 23
+  codeCogInseeCommuneNaissance: '42218'
+  sexeEtatCivil: 'M'
+status: 200
+payload: |-
+  {
+    "data": {
+      "est_boursier": true,
+      "periode_versement_bourse": {
+        "date_rentree": "2025-09-01",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Saint-Etienne",
+        "nom_etablissement": "Université Jean Monnet"
+      },
+      "echelon_bourse": {
+        "echelon": "2",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "minnannuxammi-4532@yopmail.com",
+      "identite": {
+        "nom": "CUILLERE",
+        "prenoms": [
+          "PAUL"
+        ],
+        "date_naissance": "2007-01-23",
+        "nom_commune_naissance": "Saint-Etienne",
+        "sexe": "M"
+      }
+    },
+    "links": {},
+    "meta": {}
+  }

--- a/mocks/payloads/api_particulier_v3_cnous_etudiant_boursier_with_civility/README.md
+++ b/mocks/payloads/api_particulier_v3_cnous_etudiant_boursier_with_civility/README.md
@@ -1,4 +1,81 @@
 # [Identité] Statut étudiant boursier
+* [200-usager-moins-25-ans-france_connect.yml](200-usager-moins-25-ans-france_connect.yml)
+
+  Status `200`
+
+  ## Identité `moins_25_ans` de la base de test de France Connect
+
+Ce cas permet de tester un appel à partir des données de l'identité pivot
+France Connect `moins_25_ans` (usager de moins de 25 ans). Cet usager est
+bénéficiaire d'une bourse.
+
+  <details><summary>Paramètres</summary>
+  <p>
+
+  ```json
+  {
+    "nomNaissance": "CUILLERE",
+    "prenoms": [
+      "PAUL"
+    ],
+    "anneeDateNaissance": 2007,
+    "moisDateNaissance": 1,
+    "jourDateNaissance": 23,
+    "codeCogInseeCommuneNaissance": "42218",
+    "sexeEtatCivil": "M"
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Réponse API</summary>
+  <p>
+
+  ```json
+  {
+    "data": {
+      "est_boursier": true,
+      "periode_versement_bourse": {
+        "date_rentree": "2025-09-01",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Saint-Etienne",
+        "nom_etablissement": "Université Jean Monnet"
+      },
+      "echelon_bourse": {
+        "echelon": "2",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "minnannuxammi-4532@yopmail.com",
+      "identite": {
+        "nom": "CUILLERE",
+        "prenoms": [
+          "PAUL"
+        ],
+        "date_naissance": "2007-01-23",
+        "nom_commune_naissance": "Saint-Etienne",
+        "sexe": "M"
+      }
+    },
+    "links": {},
+    "meta": {}
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Commande cURL</summary>
+  <p>
+
+  ```bash
+  curl -H "Authorization: Bearer $token_france_connect" --url "https://staging.particulier.api.gouv.fr/v3/cnous/etudiant_boursier/identite?recipient=13002526500013"
+  ```
+
+  </p>
+  </details>
 * [404.yaml](404.yaml)
 
   Status `404`

--- a/mocks/payloads/api_particulier_v3_cnous_etudiant_boursier_with_civility/summary.csv
+++ b/mocks/payloads/api_particulier_v3_cnous_etudiant_boursier_with_civility/summary.csv
@@ -1,4 +1,37 @@
 Titre,Description,Paramètres,Status,Réponse
+,"## Identité `moins_25_ans` de la base de test de France Connect
+
+Ce cas permet de tester un appel à partir des données de l'identité pivot
+France Connect `moins_25_ans` (usager de moins de 25 ans). Cet usager est
+bénéficiaire d'une bourse.","{""nomNaissance"":""CUILLERE"",""prenoms"":[""PAUL""],""anneeDateNaissance"":2007,""moisDateNaissance"":1,""jourDateNaissance"":23,""codeCogInseeCommuneNaissance"":""42218"",""sexeEtatCivil"":""M""}",200,"{
+  ""data"": {
+    ""est_boursier"": true,
+    ""periode_versement_bourse"": {
+      ""date_rentree"": ""2025-09-01"",
+      ""duree"": 12
+    },
+    ""etablissement_etudes"": {
+      ""nom_commune"": ""Saint-Etienne"",
+      ""nom_etablissement"": ""Université Jean Monnet""
+    },
+    ""echelon_bourse"": {
+      ""echelon"": ""2"",
+      ""echelon_bourse_regionale_provisoire"": false
+    },
+    ""email"": ""minnannuxammi-4532@yopmail.com"",
+    ""identite"": {
+      ""nom"": ""CUILLERE"",
+      ""prenoms"": [
+        ""PAUL""
+      ],
+      ""date_naissance"": ""2007-01-23"",
+      ""nom_commune_naissance"": ""Saint-Etienne"",
+      ""sexe"": ""M""
+    }
+  },
+  ""links"": {},
+  ""meta"": {}
+}"
 ,Dossier non trouvé,"{""nomNaissance"":""NOEL""}",404,"{
   ""errors"": [
     {


### PR DESCRIPTION
## Payloads mocks : alignement lieu de naissance enfants MERCIER + nouveaux cas AAH & CNOUS basés FranceConnect

  ### Modifié

  **Enfants MERCIER — lieu de naissance aligné sur le cas QF du parent (`75102` → `95277`)**

  Les deux enfants rattachés au cas Quotient Familial `200-nom-usage-1_parent_3_mineurs`
  (allocataire MERCIER PIERRE, nom d'usage DUBOIS) utilisent désormais le même
  `codeCogInseeCommuneNaissance` que le cas du parent :

  - `api_particulier_v3_cnav_allocation_rentree_scolaire_with_civility/200_enfant_mercier_pierre_allocataire.yaml` (ARS)
  - `api_particulier_v3_cnav_allocation_enfant_handicape_with_civility/200_enfant_mercier_beneficiaire.yaml` (AEEH)

  ### Ajouté

  **Bénéficiaire AAH — identité FranceConnect `nom_50+_caractères`**

  - `api_particulier_v3_cnav_allocation_adulte_handicape_with_civility/200-usager-nom-50-caracteres-france_connect.yml`
  - Identité pivot issue de la [base de test
  FranceConnect](https://github.com/france-connect/sources/blob/main/docker/volumes/fcp-low/mocks/idp/databases/citizen/base.csv) :
    nom de naissance de 52 caractères, BERTRAND CYRIL, né le 01/03/2000 à 75119 — `est_beneficiaire: true`

  **Étudiant boursier CNOUS — identité FranceConnect `moins_25_ans`**

  - `api_particulier_v3_cnous_etudiant_boursier_with_civility/200-usager-moins-25-ans-france_connect.yml`
  - CUILLERE PAUL, né le 23/01/2007 à 42218 (Saint-Étienne) — `est_boursier: true`, échelon 2
  - Note : `codeCogInseePaysNaissance` omis, non défini pour cet endpoint dans la spec OpenAPI