### PR TITLE
fix: pass Sport - corrections readme for cnous and aah curls

### DIFF
--- a/mocks/payloads/api_particulier_v3_cnav_allocation_adulte_handicape_with_civility/README.md
+++ b/mocks/payloads/api_particulier_v3_cnav_allocation_adulte_handicape_with_civility/README.md
@@ -47,7 +47,9 @@
   <p>
 
   ```bash
-  curl -H "Authorization: Bearer $token_france_connect" --url "https://staging.particulier.api.gouv.fr/v3/dss/allocation_adulte_handicape/identite?recipient=13002526500013"
+  curl -H "Authorization: Bearer $token" \
+    -G -d 'recipient=13002526500013' -d 'nomNaissance=MERCIER' -d 'prenoms[]=PIERRE' -d 'anneeDateNaissance=1969' -d 'moisDateNaissance=3' -d 'jourDateNaissance=17' -d 'codeCogInseeCommuneNaissance=95277' -d 'codeCogInseePaysNaissance=99100' -d 'sexeEtatCivil=M' \
+    --url "https://staging.particulier.api.gouv.fr/v3/dss/allocation_adulte_handicape/identite"
   ```
 
   </p>
@@ -105,7 +107,9 @@ caractères). Cet usager est bénéficiaire de l'AAH.
   <p>
 
   ```bash
-  curl -H "Authorization: Bearer $token_france_connect" --url "https://staging.particulier.api.gouv.fr/v3/dss/allocation_adulte_handicape/identite?recipient=13002526500013"
+  curl -H "Authorization: Bearer $token" \
+    -G -d 'recipient=13002526500013' -d 'nomNaissance=AZERTYUIOPMLKJHGFDSQWXCVBNAZERTYUIOPMLKJHGFDSQWXCVBN' -d 'prenoms[]=BERTRAND' -d 'prenoms[]=CYRIL' -d 'anneeDateNaissance=2000' -d 'moisDateNaissance=3' -d 'jourDateNaissance=1' -d 'codeCogInseeCommuneNaissance=75119' -d 'codeCogInseePaysNaissance=99100' -d 'sexeEtatCivil=M' \
+    --url "https://staging.particulier.api.gouv.fr/v3/dss/allocation_adulte_handicape/identite"
   ```
 
   </p>

--- a/mocks/payloads/api_particulier_v3_cnous_etudiant_boursier_with_civility/README.md
+++ b/mocks/payloads/api_particulier_v3_cnous_etudiant_boursier_with_civility/README.md
@@ -71,7 +71,9 @@ bénéficiaire d'une bourse.
   <p>
 
   ```bash
-  curl -H "Authorization: Bearer $token_france_connect" --url "https://staging.particulier.api.gouv.fr/v3/cnous/etudiant_boursier/identite?recipient=13002526500013"
+  curl -H "Authorization: Bearer $token" \
+    -G -d 'recipient=13002526500013' -d 'nomNaissance=CUILLERE' -d 'prenoms[]=PAUL' -d 'anneeDateNaissance=2007' -d 'moisDateNaissance=1' -d 'jourDateNaissance=23' -d 'codeCogInseeCommuneNaissance=42218' -d 'sexeEtatCivil=M' \
+    --url "https://staging.particulier.api.gouv.fr/v3/cnous/etudiant_boursier/identite"
   ```
 
   </p>


### PR DESCRIPTION
# Description
Fixed curls for AAH and CNOUS created for pass Sport (used to take france connect token instead of api part token, and added parameters to curls)