### PR TITLE
Fill scopes on non-reopening authorization request webhooks

### DIFF
--- a/site/app/interactors/datapass_webhook/create_or_prolong_token.rb
+++ b/site/app/interactors/datapass_webhook/create_or_prolong_token.rb
@@ -1,4 +1,6 @@
 class DatapassWebhook::CreateOrProlongToken < ApplicationInteractor
+  include DatapassWebhook::PassScopes
+
   before do
     context.modalities ||= %w[params]
   end
@@ -45,26 +47,13 @@ class DatapassWebhook::CreateOrProlongToken < ApplicationInteractor
   end
 
   def affect_scopes(token)
-    computed_scopes = scopes
+    computed_scopes = pass_scopes
     token.update!(scopes: computed_scopes)
     authorization_request.update!(scopes: computed_scopes)
   end
 
   def token_already_exists?
     context.authorization_request.token.present?
-  end
-
-  def scopes
-    valid_scopes = extract_checked_scopes
-    valid_scopes << 'open_data' if valid_scopes.any? { |scope| scope.start_with?('open_data_') }
-    valid_scopes.reject! { |scope| scope.start_with?('open_data_') }
-    valid_scopes.compact.uniq
-  end
-
-  def extract_checked_scopes
-    context.data['pass']['scopes'].map do |code, bool|
-      code if bool
-    end
   end
 
   def authorization_request

--- a/site/app/interactors/datapass_webhook/find_or_create_authorization_request.rb
+++ b/site/app/interactors/datapass_webhook/find_or_create_authorization_request.rb
@@ -1,5 +1,7 @@
 # TODO: can be factorized better with previous interactor
 class DatapassWebhook::FindOrCreateAuthorizationRequest < ApplicationInteractor
+  include DatapassWebhook::PassScopes
+
   def call # rubocop:disable Metrics/AbcSize
     context.authorization_request = AuthorizationRequest.find_or_initialize_by(external_id: context.data['pass']['id'])
 
@@ -80,12 +82,18 @@ class DatapassWebhook::FindOrCreateAuthorizationRequest < ApplicationInteractor
       'demarche',
       'status',
       'siret'
-    ).merge(authorization_request_attributes_for_current_event).merge(
+    ).merge(authorization_request_attributes_for_current_event).merge(requested_scopes_attributes).merge(
       'last_update' => fired_at_as_datetime,
       'previous_external_id' => context.data['pass']['copied_from_enrollment_id'],
       'api' => context.api,
       'extra_infos' => extra_infos_with_service_provider
     )
+  end
+
+  def requested_scopes_attributes
+    return {} if context.reopening
+
+    { 'scopes' => pass_scopes }
   end
 
   def extra_infos_with_service_provider

--- a/site/app/interactors/datapass_webhook/pass_scopes.rb
+++ b/site/app/interactors/datapass_webhook/pass_scopes.rb
@@ -1,0 +1,10 @@
+module DatapassWebhook::PassScopes
+  private
+
+  def pass_scopes
+    scopes = Hash(context.data.dig('pass', 'scopes')).filter_map { |code, checked| code if checked }
+    scopes << 'open_data' if scopes.any? { |scope| scope.start_with?('open_data_') }
+    scopes.reject! { |scope| scope.start_with?('open_data_') }
+    scopes.uniq
+  end
+end

--- a/site/spec/interactors/datapass_webhook/find_or_create_authorization_request_spec.rb
+++ b/site/spec/interactors/datapass_webhook/find_or_create_authorization_request_spec.rb
@@ -228,4 +228,42 @@ RSpec.describe DatapassWebhook::FindOrCreateAuthorizationRequest, type: :interac
       }.to change { authorization_request.reload.validated_at.to_i }.to(fired_at)
     end
   end
+
+  describe 'requested scopes' do
+    let(:datapass_webhook_params) do
+      build(:datapass_webhook, event:, fired_at:, authorization_request_attributes: { id: authorization_id })
+    end
+
+    before do
+      datapass_webhook_params['data']['pass']['scopes'] = {
+        'cnous_statut_boursier' => true,
+        'cnous_identite' => true,
+        'cnous_email' => false
+      }
+    end
+
+    context 'when the event is not a reopening' do
+      let(:event) { 'submit' }
+      let!(:authorization_request) { create(:authorization_request, external_id: authorization_id, scopes: []) }
+
+      it 'fills the checked scopes so pending requests are attributable to a provider' do
+        expect {
+          subject
+        }.to change { authorization_request.reload.scopes.sort }.to(%w[cnous_identite cnous_statut_boursier])
+      end
+    end
+
+    context 'when the event is a reopening of a validated request' do
+      let(:event) { 'transfer' }
+      let!(:authorization_request) do
+        create(:authorization_request, external_id: authorization_id, status: 'validated', scopes: %w[cnous_statut_bourse])
+      end
+
+      it 'does not overwrite the scopes of the running habilitation' do
+        expect {
+          subject
+        }.not_to change { authorization_request.reload.scopes }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Pending authorization requests (submitted, changes_requested, refused, draft) had an empty `scopes` array: scopes were only written at validation, by CreateOrProlongToken when the token is created.

The provider dashboard habilitations section narrows requests by `scopes ?| ARRAY[route scopes]` (feature "narrow dashboard habilitations to scopes of selected routes"). With empty scopes, a pending request can never match, so submitted demandes were invisible to a provider — they could not be attributed to any provider without their scopes.

Populate `scopes` from the pass payload in FindOrCreateAuthorizationRequest on every non-reopening event, so pending requests carry their requested scopes. Reopenings (a validated request receiving a new event) are left untouched to avoid altering the scopes of a running habilitation; those are still (re)computed at validation by CreateOrProlongToken.

Extract the shared scope computation into DatapassWebhook::PassScopes, used by both interactors. The extraction also stops crashing on unchecked (false) scopes by compacting before the open_data collapse.

Both interactors are shared by the API Entreprise and API Particulier organizers, so the fix covers both APIs.

Existing pending requests keep their empty scopes until a new webhook event replays their payload; a resync/replay is needed to backfill them.