### PR TITLE
Add boursier N-1 and N-2 test cases for api_particulier_v5_cnous_etud…

### DIFF
--- a/mocks/payloads/api_particulier_v5_cnous_etudiant_boursier_with_ine/200_boursier_annee_n1_fille_dupont.yaml
+++ b/mocks/payloads/api_particulier_v5_cnous_etudiant_boursier_with_ine/200_boursier_annee_n1_fille_dupont.yaml
@@ -1,0 +1,40 @@
+---
+description: 'Boursier sur année N-1 - Fille Dupont - Dijon Carnot'
+params:
+  ine: '0987654321M'
+status: 200
+payload: |-
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": true,
+        "est_radie": false,
+        "date_radiation": null
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "2025-09-01",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Dijon",
+        "nom_etablissement": "Carnot"
+      },
+      "echelon_bourse": {
+        "echelon": "6",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "fille@dupont.com",
+      "identite": {
+        "nom": "DUPONT",
+        "prenoms": [
+          "FILLE"
+        ],
+        "date_naissance": "2003-10-01",
+        "nom_commune_naissance": "Marseille",
+        "sexe": "F"
+      },
+      "ine": "0987654321M"
+    },
+    "links": {},
+    "meta": {}
+  }

--- a/mocks/payloads/api_particulier_v5_cnous_etudiant_boursier_with_ine/200_boursier_annee_n2_fille_b_dupont.yaml
+++ b/mocks/payloads/api_particulier_v5_cnous_etudiant_boursier_with_ine/200_boursier_annee_n2_fille_b_dupont.yaml
@@ -1,0 +1,40 @@
+---
+description: 'Boursier sur année N-2 - Fille B Dupont - Dijon Carnot'
+params:
+  ine: '0987654321N'
+status: 200
+payload: |-
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": true,
+        "est_radie": false,
+        "date_radiation": null
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "2024-09-01",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Dijon",
+        "nom_etablissement": "Carnot"
+      },
+      "echelon_bourse": {
+        "echelon": "6",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "filleb@dupont.com",
+      "identite": {
+        "nom": "DUPONT",
+        "prenoms": [
+          "FILLE B"
+        ],
+        "date_naissance": "2003-10-01",
+        "nom_commune_naissance": "Marseille",
+        "sexe": "F"
+      },
+      "ine": "0987654321N"
+    },
+    "links": {},
+    "meta": {}
+  }

--- a/mocks/payloads/api_particulier_v5_cnous_etudiant_boursier_with_ine/README.md
+++ b/mocks/payloads/api_particulier_v5_cnous_etudiant_boursier_with_ine/README.md
@@ -52,8 +52,10 @@
       },
       "ine": "1234567890A"
     },
-    "links": {},
-    "meta": {}
+    "links": {
+    },
+    "meta": {
+    }
   }
   ```
 
@@ -66,6 +68,154 @@
   ```bash
   curl -H "Authorization: Bearer $token" \
     -G -d 'recipient=13002526500013' -d 'ine=1234567890A' \
+    --url "https://staging.particulier.api.gouv.fr/v5/cnous/etudiant_boursier/ine"
+  ```
+
+  </p>
+  </details>
+* [200_boursier_annee_n1_fille_dupont.yaml](200_boursier_annee_n1_fille_dupont.yaml)
+
+  Status `200`
+
+  Boursier sur année N-1 - Fille Dupont - Dijon Carnot
+
+  <details><summary>Paramètres</summary>
+  <p>
+
+  ```json
+  {
+    "ine": "0987654321M"
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Réponse API</summary>
+  <p>
+
+  ```json
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": true,
+        "est_radie": false,
+        "date_radiation": null
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "2025-09-01",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Dijon",
+        "nom_etablissement": "Carnot"
+      },
+      "echelon_bourse": {
+        "echelon": "6",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "fille@dupont.com",
+      "identite": {
+        "nom": "DUPONT",
+        "prenoms": [
+          "FILLE"
+        ],
+        "date_naissance": "2003-10-01",
+        "nom_commune_naissance": "Marseille",
+        "sexe": "F"
+      },
+      "ine": "0987654321M"
+    },
+    "links": {
+    },
+    "meta": {
+    }
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Commande cURL</summary>
+  <p>
+
+  ```bash
+  curl -H "Authorization: Bearer $token" \
+    -G -d 'recipient=13002526500013' -d 'ine=0987654321M' \
+    --url "https://staging.particulier.api.gouv.fr/v5/cnous/etudiant_boursier/ine"
+  ```
+
+  </p>
+  </details>
+* [200_boursier_annee_n2_fille_b_dupont.yaml](200_boursier_annee_n2_fille_b_dupont.yaml)
+
+  Status `200`
+
+  Boursier sur année N-2 - Fille B Dupont - Dijon Carnot
+
+  <details><summary>Paramètres</summary>
+  <p>
+
+  ```json
+  {
+    "ine": "0987654321N"
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Réponse API</summary>
+  <p>
+
+  ```json
+  {
+    "data": {
+      "statut_boursier": {
+        "est_boursier": true,
+        "est_radie": false,
+        "date_radiation": null
+      },
+      "periode_versement_bourse": {
+        "date_rentree": "2024-09-01",
+        "duree": 12
+      },
+      "etablissement_etudes": {
+        "nom_commune": "Dijon",
+        "nom_etablissement": "Carnot"
+      },
+      "echelon_bourse": {
+        "echelon": "6",
+        "echelon_bourse_regionale_provisoire": false
+      },
+      "email": "filleb@dupont.com",
+      "identite": {
+        "nom": "DUPONT",
+        "prenoms": [
+          "FILLE B"
+        ],
+        "date_naissance": "2003-10-01",
+        "nom_commune_naissance": "Marseille",
+        "sexe": "F"
+      },
+      "ine": "0987654321N"
+    },
+    "links": {
+    },
+    "meta": {
+    }
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Commande cURL</summary>
+  <p>
+
+  ```bash
+  curl -H "Authorization: Bearer $token" \
+    -G -d 'recipient=13002526500013' -d 'ine=0987654321N' \
     --url "https://staging.particulier.api.gouv.fr/v5/cnous/etudiant_boursier/ine"
   ```
 
@@ -125,8 +275,10 @@
       },
       "ine": "1234567890A"
     },
-    "links": {},
-    "meta": {}
+    "links": {
+    },
+    "meta": {
+    }
   }
   ```
 
@@ -197,8 +349,10 @@
       },
       "ine": "0987654321F"
     },
-    "links": {},
-    "meta": {}
+    "links": {
+    },
+    "meta": {
+    }
   }
   ```
 
@@ -269,8 +423,10 @@
       },
       "ine": "0987654321E"
     },
-    "links": {},
-    "meta": {}
+    "links": {
+    },
+    "meta": {
+    }
   }
   ```
 
@@ -341,8 +497,10 @@
       },
       "ine": "0987654321D"
     },
-    "links": {},
-    "meta": {}
+    "links": {
+    },
+    "meta": {
+    }
   }
   ```
 
@@ -413,8 +571,10 @@
       },
       "ine": "0987654321H"
     },
-    "links": {},
-    "meta": {}
+    "links": {
+    },
+    "meta": {
+    }
   }
   ```
 
@@ -485,8 +645,10 @@
       },
       "ine": "0987654321G"
     },
-    "links": {},
-    "meta": {}
+    "links": {
+    },
+    "meta": {
+    }
   }
   ```
 
@@ -557,8 +719,10 @@
       },
       "ine": "123456789AB"
     },
-    "links": {},
-    "meta": {}
+    "links": {
+    },
+    "meta": {
+    }
   }
   ```
 
@@ -629,8 +793,10 @@
       },
       "ine": "0987654321K"
     },
-    "links": {},
-    "meta": {}
+    "links": {
+    },
+    "meta": {
+    }
   }
   ```
 
@@ -701,8 +867,10 @@
       },
       "ine": "0987654321J"
     },
-    "links": {},
-    "meta": {}
+    "links": {
+    },
+    "meta": {
+    }
   }
   ```
 
@@ -773,8 +941,10 @@
       },
       "ine": "0987654321C"
     },
-    "links": {},
-    "meta": {}
+    "links": {
+    },
+    "meta": {
+    }
   }
   ```
 
@@ -845,8 +1015,10 @@
       },
       "ine": "0987654321A"
     },
-    "links": {},
-    "meta": {}
+    "links": {
+    },
+    "meta": {
+    }
   }
   ```
 
@@ -917,8 +1089,10 @@
       },
       "ine": "0987654321L"
     },
-    "links": {},
-    "meta": {}
+    "links": {
+    },
+    "meta": {
+    }
   }
   ```
 
@@ -989,8 +1163,10 @@
       },
       "ine": "0987654321B"
     },
-    "links": {},
-    "meta": {}
+    "links": {
+    },
+    "meta": {
+    }
   }
   ```
 

--- a/mocks/payloads/api_particulier_v5_cnous_etudiant_boursier_with_ine/summary.csv
+++ b/mocks/payloads/api_particulier_v5_cnous_etudiant_boursier_with_ine/summary.csv
@@ -33,6 +33,74 @@ Titre,Description,Paramètres,Status,Réponse
   ""links"": {},
   ""meta"": {}
 }"
+,Boursier sur année N-1 - Fille Dupont - Dijon Carnot,"{""ine"":""0987654321M""}",200,"{
+  ""data"": {
+    ""statut_boursier"": {
+      ""est_boursier"": true,
+      ""est_radie"": false,
+      ""date_radiation"": null
+    },
+    ""periode_versement_bourse"": {
+      ""date_rentree"": ""2025-09-01"",
+      ""duree"": 12
+    },
+    ""etablissement_etudes"": {
+      ""nom_commune"": ""Dijon"",
+      ""nom_etablissement"": ""Carnot""
+    },
+    ""echelon_bourse"": {
+      ""echelon"": ""6"",
+      ""echelon_bourse_regionale_provisoire"": false
+    },
+    ""email"": ""fille@dupont.com"",
+    ""identite"": {
+      ""nom"": ""DUPONT"",
+      ""prenoms"": [
+        ""FILLE""
+      ],
+      ""date_naissance"": ""2003-10-01"",
+      ""nom_commune_naissance"": ""Marseille"",
+      ""sexe"": ""F""
+    },
+    ""ine"": ""0987654321M""
+  },
+  ""links"": {},
+  ""meta"": {}
+}"
+,Boursier sur année N-2 - Fille B Dupont - Dijon Carnot,"{""ine"":""0987654321N""}",200,"{
+  ""data"": {
+    ""statut_boursier"": {
+      ""est_boursier"": true,
+      ""est_radie"": false,
+      ""date_radiation"": null
+    },
+    ""periode_versement_bourse"": {
+      ""date_rentree"": ""2024-09-01"",
+      ""duree"": 12
+    },
+    ""etablissement_etudes"": {
+      ""nom_commune"": ""Dijon"",
+      ""nom_etablissement"": ""Carnot""
+    },
+    ""echelon_bourse"": {
+      ""echelon"": ""6"",
+      ""echelon_bourse_regionale_provisoire"": false
+    },
+    ""email"": ""filleb@dupont.com"",
+    ""identite"": {
+      ""nom"": ""DUPONT"",
+      ""prenoms"": [
+        ""FILLE B""
+      ],
+      ""date_naissance"": ""2003-10-01"",
+      ""nom_commune_naissance"": ""Marseille"",
+      ""sexe"": ""F""
+    },
+    ""ine"": ""0987654321N""
+  },
+  ""links"": {},
+  ""meta"": {}
+}"
 ,Boursier sur une campagne antérieure ciblée via campaignYear,"{""ine"":""1234567890A"",""campaignYear"":2022}",200,"{
   ""data"": {
     ""statut_boursier"": {


### PR DESCRIPTION
This PR adds new test datasets for the API Particulier CNous v5 endpoint: `api_particulier_v5_cnous_etudiant_boursier_with_ine`.

## Purpose

Improve test coverage for multi-year student scholarship (boursier) scenarios using INE-based identification, as requested for Dinum API testing.

## Added test cases

This PR introduces 2 new YAML payloads covering scholarship history across different years:

- Boursier sur année N-1 (`date_rentree: 2025-09-01`) — établissement Carnot (Dijon), INE `0987654321M`
- Boursier sur année N-2 (`date_rentree: 2024-09-01`) — établissement Carnot (Dijon), INE `0987654321N`

## Test structure

Each YAML file defines:

- request parameters (INE-based input scenario)
- expected HTTP status (`200`)
- mocked API response payload

## Validation

- [x] All payloads follow existing CNous v4 mock format
- [x] Compatible with staging mock server
- [x] README and summary files regenerated via `bin/generate_payload_readme.rb`

## Related endpoint

`/api_particulier/v5/cnous/etudiants-boursiers-with-ine`