### PR TITLE
Rename DGFIP TVA endpoint title to clarify French intra-community scope

### DIFF
--- a/clients/node/api-entreprise/src/resources/dgfip.ts
+++ b/clients/node/api-entreprise/src/resources/dgfip.ts
@@ -78,7 +78,7 @@ export class Dgfip {
     return this.client.get(path, { params: { 'recipient': options.recipient, 'delegation_id': options.delegation_id, 'context': options.context, 'object': options.object } });
   }
 
-  /** Numéro de TVA */
+  /** Numéros de TVA intracommunautaire français */
   async numero_tva(siren: string, options: { version?: number; recipient?: string; delegation_id?: string; context?: string; object?: string } = {}) {
     validateSiren(siren, 'siren');
     const resolvedVersion = options.version ?? 3;

--- a/clients/ruby/api_entreprise/lib/api_entreprise/resources/dgfip.rb
+++ b/clients/ruby/api_entreprise/lib/api_entreprise/resources/dgfip.rb
@@ -76,7 +76,7 @@ module ApiEntreprise
         @client.get(path, params: { "recipient" => recipient, "delegation_id" => delegation_id, "context" => context, "object" => object }.compact)
       end
 
-      # Numéro de TVA
+      # Numéros de TVA intracommunautaire français
       # Logical endpoint: /dgfip/unites_legales/{siren}/numero_tva
       # Versions available: [3] — default: 3
       def numero_tva(siren, version: nil, recipient: nil, delegation_id: nil, context: nil, object: nil)

--- a/commons/endpoints/_swagger_shared/dgfip.yml
+++ b/commons/endpoints/_swagger_shared/dgfip.yml
@@ -296,7 +296,7 @@ tableaux de la liasse fiscale'
 
 
   numero_tva:
-    title: "Numéro de TVA"
+    title: "Numéros de TVA intracommunautaire français"
     description: "Numéro de TVA intracommunautaire français, issu des extractions publiées par la Direction générale des finances publiques (DGFIP) sur data.gouv.fr."
     tags:
       - "Informations financières"

--- a/commons/swagger/openapi-entreprise.yaml
+++ b/commons/swagger/openapi-entreprise.yaml
@@ -9261,7 +9261,7 @@ paths:
             --url "https://entreprise.api.gouv.fr/v3/dgfip/unites_legales/130025265/liens_capitalistiques/2019?context=Test+de+l%27API&object=Test+de+l%27API&recipient=10000001700010"
   "/v3/dgfip/unites_legales/{siren}/numero_tva":
     get:
-      summary: Numéro de TVA
+      summary: Numéros de TVA intracommunautaire français
       tags:
       - Informations financières
       parameters:


### PR DESCRIPTION
The fiche title "Numéro de TVA" was ambiguous: the endpoint only delivers French intra-community VAT numbers, not foreign ones. Rename to "Numéros de TVA intracommunautaire français" so the catalogue listing and OpenAPI summary state the scope explicitly.

Regenerated openapi-entreprise.yaml and the Ruby/Node api_entreprise SDK scaffolding (numero_tva doc-comment) to keep them in sync.