### PR TITLE
Add ARS staging mock for FranceConnect default identity (Angela Dubois)

### DIFF
--- a/mocks/payloads/api_particulier_v3_cnav_allocation_rentree_scolaire_with_france_connect/200_allocataire_angela_dubois.yaml
+++ b/mocks/payloads/api_particulier_v3_cnav_allocation_rentree_scolaire_with_france_connect/200_allocataire_angela_dubois.yaml
@@ -1,0 +1,26 @@
+---
+description: |-
+  Cas de test avec l'identité pivot FranceConnect par défaut du bac à sable
+  d'intégration (Angela DUBOIS).
+params:
+  nomNaissance: 'DUBOIS'
+  prenoms:
+  - 'Angela'
+  - 'Claire'
+  - 'Louise'
+  anneeDateNaissance: 1962
+  moisDateNaissance: 8
+  jourDateNaissance: 24
+  codeCogInseeCommuneNaissance: '75107'
+  codeCogInseePaysNaissance: '99100'
+  sexeEtatCivil: 'F'
+status: 200
+payload: |-
+  {
+    "data": {
+      "status": "allocataire",
+      "date_debut_droit": "2024-08-09"
+    },
+    "links": {},
+    "meta": {}
+  }

--- a/mocks/payloads/api_particulier_v3_cnav_allocation_rentree_scolaire_with_france_connect/README.md
+++ b/mocks/payloads/api_particulier_v3_cnav_allocation_rentree_scolaire_with_france_connect/README.md
@@ -52,6 +52,62 @@
 
   </p>
   </details>
+* [200_allocataire_angela_dubois.yaml](200_allocataire_angela_dubois.yaml)
+
+  Status `200`
+
+  Cas de test avec l'identité pivot FranceConnect par défaut du bac à sable
+d'intégration (Angela DUBOIS).
+
+  <details><summary>Paramètres</summary>
+  <p>
+
+  ```json
+  {
+    "nomNaissance": "DUBOIS",
+    "prenoms": [
+      "Angela",
+      "Claire",
+      "Louise"
+    ],
+    "anneeDateNaissance": 1962,
+    "moisDateNaissance": 8,
+    "jourDateNaissance": 24,
+    "codeCogInseeCommuneNaissance": "75107",
+    "codeCogInseePaysNaissance": "99100",
+    "sexeEtatCivil": "F"
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Réponse API</summary>
+  <p>
+
+  ```json
+  {
+    "data": {
+      "status": "allocataire",
+      "date_debut_droit": "2024-08-09"
+    },
+    "links": {},
+    "meta": {}
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Commande cURL</summary>
+  <p>
+
+  ```bash
+  curl -H "Authorization: Bearer $token_france_connect" --url "https://staging.particulier.api.gouv.fr/v3/dss/allocation_rentree_scolaire/france_connect?recipient=13002526500013"
+  ```
+
+  </p>
+  </details>
 * [404.yaml](404.yaml)
 
   Status `404`

--- a/mocks/payloads/api_particulier_v3_cnav_allocation_rentree_scolaire_with_france_connect/summary.csv
+++ b/mocks/payloads/api_particulier_v3_cnav_allocation_rentree_scolaire_with_france_connect/summary.csv
@@ -7,6 +7,15 @@ Titre,Description,Paramètres,Status,Réponse
   ""links"": {},
   ""meta"": {}
 }"
+,"Cas de test avec l'identité pivot FranceConnect par défaut du bac à sable
+d'intégration (Angela DUBOIS).","{""nomNaissance"":""DUBOIS"",""prenoms"":[""Angela"",""Claire"",""Louise""],""anneeDateNaissance"":1962,""moisDateNaissance"":8,""jourDateNaissance"":24,""codeCogInseeCommuneNaissance"":""75107"",""codeCogInseePaysNaissance"":""99100"",""sexeEtatCivil"":""F""}",200,"{
+  ""data"": {
+    ""status"": ""allocataire"",
+    ""date_debut_droit"": ""2024-08-09""
+  },
+  ""links"": {},
+  ""meta"": {}
+}"
 ,## Allocataire non trouvé,"{""nomNaissance"":""LEROY"",""prenoms"":[""CLAUDE""],""anneeDateNaissance"":1965,""moisDateNaissance"":9,""jourDateNaissance"":2,""codeCogInseeCommuneNaissance"":""33063"",""codeCogInseePaysNaissance"":""99100"",""sexeEtatCivil"":""F""}",404,"{
   ""errors"": [
     {


### PR DESCRIPTION
## Summary
- Add a `200 allocataire` mock in `api_particulier_v3_cnav_allocation_rentree_scolaire_with_france_connect` keyed to Angela Dubois's identity pivot (the identity real FranceConnect sandbox logins default to)
- Previously no fixture matched her, so a real FC token for this endpoint fell back to the generic swagger response in staging instead of a real payload
- Regenerated `README.md`/`summary.csv` via `bin/generate_payload_readme.rb`

## Test plan
- [x] `bundle exec rspec spec/acceptances/payloads_spec.rb -e "allocation_rentree_scolaire"` (60 examples, 0 failures)