### PR TITLE
Validate editor allowed IPs at the source instead of failing at token generation

### DIFF
--- a/site/app/controllers/editor/tokens_controller.rb
+++ b/site/app/controllers/editor/tokens_controller.rb
@@ -14,9 +14,13 @@ class Editor::TokensController < EditorController
   def create
     authorize EditorToken
 
-    @editor_token = current_editor.tokens.create!(allowed_ips: current_editor.allowed_ips)
+    @editor_token = current_editor.tokens.new(allowed_ips: current_editor.allowed_ips)
 
-    render :created
+    if @editor_token.save
+      render :created
+    else
+      redirect_with_errors(@editor_token)
+    end
   end
 
   def update
@@ -30,9 +34,13 @@ class Editor::TokensController < EditorController
   end
 
   def rotate
-    @editor_token = authorize(token, :rotate?).rotate!
+    @editor_token = authorize(token, :rotate?).rotate
 
-    render :created
+    if @editor_token.persisted?
+      render :created
+    else
+      redirect_with_errors(@editor_token)
+    end
   end
 
   def revoke
@@ -42,6 +50,15 @@ class Editor::TokensController < EditorController
   end
 
   private
+
+  def redirect_with_errors(editor_token)
+    error_message(
+      title: t('editor.tokens.errors.invalid_allowed_ips'),
+      description: editor_token.errors.full_messages.to_sentence
+    )
+
+    redirect_to editor_tokens_path
+  end
 
   def ensure_editor_tokens_enabled
     redirect_to editor_tokens_path unless current_editor.editor_tokens_enabled?

--- a/site/app/models/editor.rb
+++ b/site/app/models/editor.rb
@@ -18,6 +18,7 @@ class Editor < ApplicationRecord
   validates :role, inclusion: { in: ROLES }, allow_nil: true
   validates :deployment_type, inclusion: { in: DEPLOYMENT_TYPES }, allow_nil: true
   validates :contact_email, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_blank: true
+  validates :allowed_ips, allowed_ips: true, if: :allowed_ips_changed?
   validate :apis_included_in_list
 
   scope :delegable, -> { where(editor_tokens_enabled: true) }

--- a/site/app/models/editor_token.rb
+++ b/site/app/models/editor_token.rb
@@ -26,12 +26,17 @@ class EditorToken < ApplicationRecord
     update!(blacklisted_at: Time.zone.now)
   end
 
-  def rotate!
+  def rotate
+    replacement = editor.tokens.new(allowed_ips: allowed_ips)
+    return replacement unless replacement.valid?
+
     transaction do
       revoke!
 
-      editor.tokens.create!(allowed_ips: allowed_ips)
+      replacement.save!
     end
+
+    replacement
   end
 
   def prolong!

--- a/site/app/views/admin/editors/_form.html.erb
+++ b/site/app/views/admin/editors/_form.html.erb
@@ -103,10 +103,13 @@
       </div>
     </div>
     <div class="fr-col-6">
-      <div class="fr-input-group">
+      <div class="fr-input-group <%= 'fr-input-group--error' if editor.errors[:allowed_ips].any? %>">
         <%= f.label :allowed_ips, 'IPs autorisées', class: 'fr-label' %>
-        <span class="fr-hint-text">Séparées par des virgules ou retours à la ligne</span>
+        <span class="fr-hint-text">Séparées par des virgules ou retours à la ligne. Adresses publiques uniquement, 10 maximum, préfixe IPv4 minimum : /24</span>
         <%= f.text_area :allowed_ips, value: editor.allowed_ips.join(', '), class: 'fr-input', rows: 3 %>
+        <% editor.errors[:allowed_ips].each do |message| %>
+          <p class="fr-error-text"><%= message %></p>
+        <% end %>
       </div>
     </div>
   </div>

--- a/site/config/locales/fr.yml
+++ b/site/config/locales/fr.yml
@@ -554,6 +554,8 @@ fr:
         label: IPs autorisées
         hint: "Une IP ou plage CIDR par ligne (10 maximum, préfixe IPv4 minimum : /24). Liste vide : aucune restriction."
         submit: Enregistrer
+      errors:
+        invalid_allowed_ips: "Impossible de générer le jeton : les IPs autorisées de votre organisation sont invalides. Contactez le support."
       created:
         warning_title: Copiez ce jeton maintenant
         warning: Ce jeton ne pourra plus être affiché. Si vous le perdez, révoquez-le et générez-en un nouveau.

--- a/site/spec/features/admin/editors_spec.rb
+++ b/site/spec/features/admin/editors_spec.rb
@@ -130,6 +130,25 @@ RSpec.describe 'Admin: editors', app: :api_entreprise do
       expect(page).to have_css('.fr-alert.fr-alert--success')
     end
 
+    it 'refuses allowed IPs the editor tokens could never accept' do
+      visit edit_admin_editor_path(editor)
+
+      fill_in 'editor_allowed_ips', with: '192.168.1.1'
+      click_on 'Sauvegarder'
+
+      expect(editor.reload.allowed_ips).to be_empty
+      expect(page).to have_text('plage privée ou réservée')
+    end
+
+    it 'accepts public allowed IPs' do
+      visit edit_admin_editor_path(editor)
+
+      fill_in 'editor_allowed_ips', with: '203.0.113.0/24, 198.51.100.5'
+      click_on 'Sauvegarder'
+
+      expect(editor.reload.allowed_ips).to eq(['203.0.113.0/24', '198.51.100.5'])
+    end
+
     it 'updates new fields' do
       visit edit_admin_editor_path(editor)
 

--- a/site/spec/features/editor/tokens_spec.rb
+++ b/site/spec/features/editor/tokens_spec.rb
@@ -106,6 +106,22 @@ RSpec.describe 'Editor: tokens', app: :api_entreprise do
     end
   end
 
+  describe 'generate a token when the editor carries unusable allowed IPs' do
+    before do
+      editor.update_column(:allowed_ips, ['192.168.1.1'])
+
+      visit editor_tokens_path
+      click_button 'Générer un nouveau jeton éditeur'
+    end
+
+    it 'explains the failure instead of blowing up, and creates nothing' do
+      expect(page).to have_current_path(editor_tokens_path)
+      expect(page).to have_text('Impossible de générer le jeton')
+      expect(page).to have_text('plage privée ou réservée')
+      expect(editor.tokens).to be_empty
+    end
+  end
+
   describe 'edit allowed IPs' do
     let!(:editor_token) { create(:editor_token, editor:) }
 

--- a/site/spec/models/editor_spec.rb
+++ b/site/spec/models/editor_spec.rb
@@ -14,6 +14,33 @@ RSpec.describe Editor do
     it { expect(build(:editor, apis: %w[entreprise wrong])).not_to be_valid }
   end
 
+  describe 'allowed_ips validation' do
+    it { expect(build(:editor, allowed_ips: [])).to be_valid }
+    it { expect(build(:editor, allowed_ips: ['203.0.113.10', '198.51.100.0/24'])).to be_valid }
+
+    it 'rejects private ranges, which would make editor token generation fail' do
+      editor = build(:editor, allowed_ips: ['192.168.1.1'])
+
+      expect(editor).not_to be_valid
+      expect(editor.errors[:allowed_ips]).to be_present
+    end
+
+    it 'rejects ranges wider than /24' do
+      expect(build(:editor, allowed_ips: ['203.0.113.0/16'])).not_to be_valid
+    end
+
+    it 'rejects garbage entries' do
+      expect(build(:editor, allowed_ips: ['not-an-ip'])).not_to be_valid
+    end
+
+    it 'leaves legacy records untouched as long as allowed_ips is not edited' do
+      editor = build(:editor, allowed_ips: ['192.168.1.1'])
+      editor.save!(validate: false)
+
+      expect(editor.reload.update(name: 'Renamed')).to be(true)
+    end
+  end
+
   describe '.for_api' do
     let!(:entreprise_editor) { create(:editor, apis: %w[entreprise]) }
     let!(:particulier_editor) { create(:editor, apis: %w[particulier]) }

--- a/site/spec/models/editor_token_spec.rb
+++ b/site/spec/models/editor_token_spec.rb
@@ -185,11 +185,11 @@ RSpec.describe EditorToken do
     end
   end
 
-  describe '#rotate!' do
+  describe '#rotate' do
     let(:editor_token) { create(:editor_token, exp: 3.months.from_now.to_i, allowed_ips: ['203.0.113.0/24']) }
 
     it 'revokes the token and returns a fresh one for the same editor' do
-      new_token = editor_token.rotate!
+      new_token = editor_token.rotate
 
       expect(editor_token).to be_blacklisted
       expect(new_token).to be_active
@@ -198,7 +198,22 @@ RSpec.describe EditorToken do
     end
 
     it 'copies allowed_ips to the new token' do
-      expect(editor_token.rotate!.allowed_ips).to eq(editor_token.allowed_ips)
+      expect(editor_token.rotate.allowed_ips).to eq(editor_token.allowed_ips)
+    end
+
+    context 'when the replacement token would be invalid' do
+      before do
+        editor_token.editor.update_column(:allowed_ips, ['192.168.1.1'])
+        editor_token.editor.reload
+      end
+
+      it 'keeps the current token alive and returns the unsaved replacement with its errors' do
+        replacement = editor_token.rotate
+
+        expect(replacement).not_to be_persisted
+        expect(replacement.errors[:allowed_ips]).to be_present
+        expect(editor_token.reload).not_to be_blacklisted
+      end
     end
   end
 


### PR DESCRIPTION
`EditorToken` validates its `allowed_ips` (no private/loopback/link-local range, /24 minimum IPv4 prefix, 10 entries max), but `Editor` did not validate the very same attribute the tokens are seeded from. An admin could therefore save an editor with, say, `192.168.1.1`, and the editor would then hit a bare Rails 422 error page when clicking "Générer un nouveau jeton éditeur": `current_editor.tokens.create!` copies the editor IPs, the token validation rejects them, `RecordInvalid` bubbles up. The data was accepted where it could be corrected and refused where it could not.