### PR TITLE
Stop auto-activating HubEE subscriptions, use the datapass scope

### DIFF
--- a/site/app/clients/hubee_api_authentication.rb
+++ b/site/app/clients/hubee_api_authentication.rb
@@ -3,7 +3,7 @@ class HubEEAPIAuthentication < AbstractHubEEAPIClient
   def access_token
     http_connection.post(
       auth_url,
-      'grant_type=client_credentials&scope=ADMIN',
+      'grant_type=client_credentials&scope=DATAPASS',
       {
         'Authorization' => "Basic #{encoded_client_id_and_secret}"
       }

--- a/site/app/clients/hubee_api_client.rb
+++ b/site/app/clients/hubee_api_client.rb
@@ -38,7 +38,9 @@ class HubEEAPIClient < AbstractHubEEAPIClient
   end
 
   def create_subscription(authorization_request, organization_payload, process_code)
-    find_or_create_inactive_subscription(authorization_request, organization_payload, process_code)
+    create_inactive_subscription(authorization_request, organization_payload, process_code)
+  rescue AlreadyExists
+    find_subscription(authorization_request, organization_payload, process_code)
   end
 
   def find_subscription(_authorization_request, organization_payload, process_code)
@@ -99,11 +101,5 @@ class HubEEAPIClient < AbstractHubEEAPIClient
     raise AlreadyExists if already_exists_error?(e)
 
     raise
-  end
-
-  def find_or_create_inactive_subscription(authorization_request, organization_payload, process_code)
-    create_inactive_subscription(authorization_request, organization_payload, process_code)
-  rescue HubEEAPIClient::AlreadyExists
-    find_subscription(authorization_request, organization_payload, process_code)
   end
 end

--- a/site/app/clients/hubee_api_client.rb
+++ b/site/app/clients/hubee_api_client.rb
@@ -37,10 +37,8 @@ class HubEEAPIClient < AbstractHubEEAPIClient
     raise
   end
 
-  def create_subscription(authorization_request, organization_payload, process_code, editor_payload = {})
-    subscription_payload = find_or_create_inactive_subscription(authorization_request, organization_payload, process_code)
-    activate_subscription(subscription_payload, editor_payload)
-    subscription_payload
+  def create_subscription(authorization_request, organization_payload, process_code, _editor_payload = {})
+    find_or_create_inactive_subscription(authorization_request, organization_payload, process_code)
   end
 
   def find_subscription(_authorization_request, organization_payload, process_code)
@@ -72,28 +70,6 @@ class HubEEAPIClient < AbstractHubEEAPIClient
   end
 
   private
-
-  def activate_subscription(subscription_payload, editor_payload = {}) # rubocop:disable Metrics/AbcSize
-    subscription_id = Hash(subscription_payload)['id']
-    return if subscription_id.blank?
-
-    payload = subscription_payload.with_indifferent_access.merge({
-      status: 'Actif',
-      activateDateTime: DateTime.now.iso8601,
-      accessMode: 'API',
-      notificationFrequency: 'Aucune'
-    }.with_indifferent_access)
-
-    payload.delete('id')
-    payload.delete('creationDateTime')
-    payload.merge!(editor_payload.with_indifferent_access)
-
-    http_connection.put(
-      "#{host}/referential/v1/subscriptions/#{subscription_id}",
-      payload.to_json,
-      'Content-Type' => 'application/json'
-    ).body
-  end
 
   def create_inactive_subscription(authorization_request, organization_payload, process_code) # rubocop:disable Metrics/AbcSize
     http_connection.post(

--- a/site/app/clients/hubee_api_client.rb
+++ b/site/app/clients/hubee_api_client.rb
@@ -37,7 +37,7 @@ class HubEEAPIClient < AbstractHubEEAPIClient
     raise
   end
 
-  def create_subscription(authorization_request, organization_payload, process_code, _editor_payload = {})
+  def create_subscription(authorization_request, organization_payload, process_code)
     find_or_create_inactive_subscription(authorization_request, organization_payload, process_code)
   end
 

--- a/site/app/interactors/datapass_webhook/api_particulier/create_hubee_subscription.rb
+++ b/site/app/interactors/datapass_webhook/api_particulier/create_hubee_subscription.rb
@@ -9,35 +9,7 @@ class DatapassWebhook::APIParticulier::CreateHubEESubscription < ApplicationInte
   private
 
   def create_subscription_on_hubee
-    hubee_api_client.create_subscription(authorization_request, hubee_organization_payload, process_code, editor_payload)
-  end
-
-  def editor_organization
-    @editor_organization ||= begin
-      organization = Organization.find_or_create_by(siret: service_provider['siret'])
-
-      UpdateOrganizationINSEEPayloadJob.new.perform(organization.id)
-      organization.reload
-
-      organization
-    end
-  end
-
-  def editor_payload
-    return {} unless editor_subscription?
-
-    {
-      delegationActor: {
-        branchCode: editor_organization.code_commune_etablissement,
-        companyRegister: editor_organization.siret,
-        type: 'EDT'
-      },
-      accessMode: 'API'
-    }
-  end
-
-  def editor_subscription?
-    service_provider['type'] == 'editor'
+    hubee_api_client.create_subscription(authorization_request, hubee_organization_payload, process_code)
   end
 
   def hubee_api_client
@@ -51,9 +23,5 @@ class DatapassWebhook::APIParticulier::CreateHubEESubscription < ApplicationInte
   def save_hubee_subscription_id_to_authorization_request
     authorization_request.extra_infos['hubee_subscription_id'] = hubee_subscription_payload['id']
     authorization_request.save!
-  end
-
-  def service_provider
-    @service_provider ||= Hash(authorization_request.extra_infos['service_provider'])
   end
 end

--- a/site/spec/clients/hubee_api_authentication_spec.rb
+++ b/site/spec/clients/hubee_api_authentication_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe HubEEAPIAuthentication do
 
     before do
       stub_request(:post, auth_url)
-        .with(body: 'grant_type=client_credentials&scope=datapass')
+        .with(body: 'grant_type=client_credentials&scope=DATAPASS')
         .to_return(
           status: 200,
           headers: { 'Content-Type' => 'application/json' },

--- a/site/spec/clients/hubee_api_authentication_spec.rb
+++ b/site/spec/clients/hubee_api_authentication_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe HubEEAPIAuthentication do
+  describe '#access_token' do
+    subject(:access_token) { described_class.new.access_token }
+
+    let(:auth_url) { Rails.application.credentials.hubee_auth_url }
+
+    before do
+      stub_request(:post, auth_url)
+        .with(body: 'grant_type=client_credentials&scope=datapass')
+        .to_return(
+          status: 200,
+          headers: { 'Content-Type' => 'application/json' },
+          body: { access_token: 'hubee_access_token' }.to_json
+        )
+    end
+
+    it 'requests a token with the datapass scope' do
+      expect(access_token).to eq('hubee_access_token')
+    end
+  end
+end

--- a/site/spec/clients/hubee_api_client_spec.rb
+++ b/site/spec/clients/hubee_api_client_spec.rb
@@ -64,4 +64,61 @@ RSpec.describe HubEEAPIClient do
       end
     end
   end
+
+  describe '#create_subscription' do
+    subject(:create_subscription) { described_class.new.create_subscription(authorization_request, organization_payload, process_code) }
+
+    let(:authorization_request) { create(:authorization_request, :with_demandeur, api: 'particulier') }
+    let(:organization_payload) { hubee_organization_payload }
+    let(:process_code) { 'FormulaireQF' }
+    let(:host) { Rails.application.credentials.hubee_api_url }
+    let(:subscription_payload) { hubee_subscription_payload(authorization_request:, process_code:) }
+
+    context 'when the subscription does not exist yet' do
+      before do
+        stub_request(:post, "#{host}/referential/v1/subscriptions").to_return(
+          status: 201,
+          headers: { 'Content-Type' => 'application/json' },
+          body: subscription_payload.to_json
+        )
+      end
+
+      it 'returns the created subscription payload' do
+        expect(create_subscription).to eq(subscription_payload)
+      end
+
+      it 'does not activate the subscription' do
+        create_subscription
+
+        expect(a_request(:put, %r{#{host}/referential/v1/subscriptions/})).not_to have_been_made
+      end
+    end
+
+    context 'when the subscription already exists' do
+      before do
+        stub_request(:post, "#{host}/referential/v1/subscriptions").to_return(
+          status: 400,
+          headers: { 'Content-Type' => 'application/json' },
+          body: { 'errors' => [{ 'message' => 'Subscription already exists' }] }.to_json
+        )
+        stub_request(:get, "#{host}/referential/v1/subscriptions")
+          .with(query: { companyRegister: organization_payload['companyRegister'], processCode: process_code })
+          .to_return(
+            status: 200,
+            headers: { 'Content-Type' => 'application/json' },
+            body: [subscription_payload].to_json
+          )
+      end
+
+      it 'returns the existing subscription payload' do
+        expect(create_subscription).to eq(subscription_payload)
+      end
+
+      it 'does not activate the subscription' do
+        create_subscription
+
+        expect(a_request(:put, %r{#{host}/referential/v1/subscriptions/})).not_to have_been_made
+      end
+    end
+  end
 end

--- a/site/spec/interactors/datapass_webhook/api_particulier/create_hubee_subscription_spec.rb
+++ b/site/spec/interactors/datapass_webhook/api_particulier/create_hubee_subscription_spec.rb
@@ -15,43 +15,16 @@ RSpec.describe DatapassWebhook::APIParticulier::CreateHubEESubscription, type: :
       allow(hubee_api_client).to receive(:create_subscription).and_return(stripped_hubee_subscription_payload)
     end
 
-    context 'when the authorization request has a service provider' do
-      let(:authorization_request) { create(:authorization_request, extra_infos: { 'service_provider' => service_provider }) }
-      let(:editor_siret) { '13002526500013' }
-      let(:service_provider) { { 'type' => 'editor', 'siret' => editor_siret } }
-
-      context 'when the service provider is an editor' do
-        let(:insee_api_authentication) { instance_double(INSEEAPIAuthentication, access_token: 'access_token') }
-        let(:insee_payload) { insee_sirene_api_etablissement_valid_payload(siret: editor_siret, full: true) }
-
-        before do
-          allow(INSEEAPIAuthentication).to receive(:new).and_return(insee_api_authentication)
-          stub_request(:get, "https://api.insee.fr/api-sirene/prive/3.11/siret/#{editor_siret}").to_return(
-            status: 200,
-            headers: { 'Content-Type' => 'application/json' },
-            body: insee_payload.to_json
-          )
-        end
-
-        it 'creates a subscription on HubEE with the editor payload' do
-          expect(hubee_api_client).to receive(:create_subscription).with(authorization_request, stripped_hubee_organization_payload, 'FormulaireQF', { delegationActor: { branchCode: '75107', companyRegister: '13002526500013', type: 'EDT' }, accessMode: 'API' })
-          interactor
-        end
-      end
-
-      context 'when the service provider is not an editor' do
-        let(:service_provider) { { 'type' => 'service', 'siret' => '123456' } }
-
-        it 'creates a subscription on HubEE without the editor payload' do
-          expect(hubee_api_client).to receive(:create_subscription).with(authorization_request, stripped_hubee_organization_payload, 'FormulaireQF', {})
-          interactor
-        end
-      end
+    it 'creates a subscription on HubEE' do
+      expect(hubee_api_client).to receive(:create_subscription).with(authorization_request, stripped_hubee_organization_payload, 'FormulaireQF')
+      interactor
     end
 
-    context 'when the authorization request does not have a service provider' do
-      it 'creates a subscription on HubEE' do
-        expect(hubee_api_client).to receive(:create_subscription).with(authorization_request, stripped_hubee_organization_payload, 'FormulaireQF', {})
+    context 'when the service provider is an editor' do
+      let(:authorization_request) { create(:authorization_request, extra_infos: { 'service_provider' => { 'type' => 'editor', 'siret' => '13002526500013' } }) }
+
+      it 'creates the subscription without any editor delegation' do
+        expect(hubee_api_client).to receive(:create_subscription).with(authorization_request, stripped_hubee_organization_payload, 'FormulaireQF')
         interactor
       end
     end

--- a/site/spec/organizers/datapass_webhook/create_formulaire_qf_resources_spec.rb
+++ b/site/spec/organizers/datapass_webhook/create_formulaire_qf_resources_spec.rb
@@ -4,12 +4,8 @@ RSpec.describe DatapassWebhook::CreateFormulaireQFResources do
   subject(:interactor) { described_class.call(authorization_request:) }
 
   let(:hubee_api_client) { instance_double(HubEEAPIClient) }
-  let(:insee_api_authentication) { instance_double(INSEEAPIAuthentication, access_token: 'access_token') }
-  let(:insee_payload) { insee_sirene_api_etablissement_valid_payload(siret: editor_siret, full: true) }
   let(:authorization_request) { create(:authorization_request, :with_demandeur, api: 'particulier') }
   let(:subscription_payload) { hubee_subscription_payload(authorization_request:) }
-  let(:editor_siret) { '13002526500013' }
-  let(:service_provider) { { 'type' => 'editor', 'siret' => editor_siret } }
   let(:formulaire_qf_api_client) { instance_double(FormulaireQFAPIClient) }
   let(:siret) { '12345678901234' }
   let(:code_commune) { '12345' }
@@ -19,12 +15,6 @@ RSpec.describe DatapassWebhook::CreateFormulaireQFResources do
   before do
     allow(HubEEAPIClient).to receive(:new).and_return(hubee_api_client)
     allow(hubee_api_client).to receive_messages(find_or_create_organization: organization_payload, create_subscription: subscription_payload)
-    allow(INSEEAPIAuthentication).to receive(:new).and_return(insee_api_authentication)
-    stub_request(:get, "https://api.insee.fr/entreprises/sirene/V3.11/siret/#{editor_siret}").to_return(
-      status: 200,
-      headers: { 'Content-Type' => 'application/json' },
-      body: insee_payload.to_json
-    )
     allow(FormulaireQFAPIClient).to receive(:new).and_return(formulaire_qf_api_client)
     allow(formulaire_qf_api_client).to receive(:create_collectivity)
   end

--- a/site/spec/support/hubee_api_mocks.rb
+++ b/site/spec/support/hubee_api_mocks.rb
@@ -21,7 +21,7 @@ module HubEEAPIMocks
     {
       'id' => SecureRandom.uuid,
       'datapassId' => authorization_request.external_id.to_i,
-      'notificationFrequency' => 'unitaire',
+      'notificationFrequency' => 'Aucune',
       'processCode' => process_code,
       'email' => authorization_request.demandeur.email,
       'localAdministrator' => {
@@ -29,7 +29,7 @@ module HubEEAPIMocks
         'firstName' => authorization_request.demandeur.first_name,
         'lastName' => authorization_request.demandeur.last_name
       },
-      'status' => 'Actif',
+      'status' => 'Inactif',
       'subscriber' => {
         'branchCode' => organization_payload['branchCode'],
         'companyRegister' => organization_payload['companyRegister'],

--- a/site/spec/support/insee_sirene_api_mocks.rb
+++ b/site/spec/support/insee_sirene_api_mocks.rb
@@ -1,20 +1,16 @@
 # frozen_string_literal: true
 
 module INSEESireneAPIMocks
-  def insee_sirene_api_etablissement_valid_payload(siret:, full: false)
-    if full
-      read_json_fixture("insee/#{siret}.json")
-    else
-      {
-        'header' => {
-          'statut' => 200,
-          'message' => 'OK'
-        },
-        'etablissement' => {
-          'siren' => siret.first(9)
-        }
+  def insee_sirene_api_etablissement_valid_payload(siret:)
+    {
+      'header' => {
+        'statut' => 200,
+        'message' => 'OK'
+      },
+      'etablissement' => {
+        'siren' => siret.first(9)
       }
-    end
+    }
   end
 
   def insee_sirene_api_not_found_payload
@@ -24,9 +20,5 @@ module INSEESireneAPIMocks
         'message' => 'Not Found'
       }
     }
-  end
-
-  def read_json_fixture(file)
-    JSON.parse(Rails.root.join('spec', 'fixtures', file).read)
   end
 end


### PR DESCRIPTION
The DataPass webhook now only creates HubEE subscriptions (status Inactif) with a datapass-scoped token; activation and editor delegation become manual steps for the services instructeurs.

Companion PR: https://github.com/etalab/formulaire-qf/pull/367

Closes API-7125 → https://linear.app/pole-api/issue/API-7125/fqf-retirer-lactivation-auto-des-abonnements-hubee-et-le-scope-admin