### PR TITLE
Sentry: track missing france_connect credentials

### DIFF
--- a/siade/app/interactors/france_connect/data_fetcher_through_access_token/make_request.rb
+++ b/siade/app/interactors/france_connect/data_fetcher_through_access_token/make_request.rb
@@ -37,6 +37,12 @@ class FranceConnect::DataFetcherThroughAccessToken::MakeRequest < MakeRequest::P
 
   private
 
+  def api_call
+    track_missing_credentials! if credentials_missing?
+
+    super
+  end
+
   def token
     context.params[:token]
   end
@@ -59,5 +65,18 @@ class FranceConnect::DataFetcherThroughAccessToken::MakeRequest < MakeRequest::P
 
   def api_name
     context.params[:api_name]
+  end
+
+  def credentials_missing?
+    client_id == "france_connect_v2_#{api_name}_client_id" ||
+      client_secret == "france_connect_v2_#{api_name}_client_secret"
+  end
+
+  def track_missing_credentials!
+    MonitoringService.instance.track(
+      'error',
+      "FranceConnect client credentials missing for api_name=#{api_name}",
+      fingerprint: ['france-connect-missing-credentials', api_name]
+    )
   end
 end

--- a/siade/spec/interactors/france_connect/data_fetcher_through_access_token/make_request_spec.rb
+++ b/siade/spec/interactors/france_connect/data_fetcher_through_access_token/make_request_spec.rb
@@ -78,4 +78,44 @@ RSpec.describe FranceConnect::DataFetcherThroughAccessToken::MakeRequest, type: 
       end
     end
   end
+
+  context 'when FranceConnect client credentials are missing for this api_name' do
+    before do
+      allow(Rails).to receive(:env).and_return('production'.inquiry)
+      allow(Siade.credentials).to receive(:[]).and_call_original
+      allow(Siade.credentials).to receive(:[]).with(:france_connect_v2_quotient_familial_client_id)
+        .and_return('france_connect_v2_quotient_familial_client_id')
+      allow(Siade.credentials).to receive(:[]).with(:france_connect_v2_quotient_familial_client_secret)
+        .and_return('france_connect_v2_quotient_familial_client_secret')
+      allow(MonitoringService.instance).to receive(:track)
+    end
+
+    it 'tracks a distinct, alertable error to Sentry' do
+      make_call
+
+      expect(MonitoringService.instance).to have_received(:track).with(
+        'error',
+        a_string_including('quotient_familial'),
+        fingerprint: %w[france-connect-missing-credentials quotient_familial]
+      )
+    end
+  end
+
+  context 'when FranceConnect client credentials are configured for this api_name' do
+    before do
+      allow(Rails).to receive(:env).and_return('production'.inquiry)
+      allow(Siade.credentials).to receive(:[]).and_call_original
+      allow(Siade.credentials).to receive(:[]).with(:france_connect_v2_quotient_familial_client_id)
+        .and_return('a_real_looking_client_id')
+      allow(Siade.credentials).to receive(:[]).with(:france_connect_v2_quotient_familial_client_secret)
+        .and_return('a_real_looking_client_secret')
+      allow(MonitoringService.instance).to receive(:track)
+    end
+
+    it 'does not track anything' do
+      make_call
+
+      expect(MonitoringService.instance).not_to have_received(:track)
+    end
+  end
 end


### PR DESCRIPTION
Because I lost a bunch of time debugging missing credentials