### PR TITLE
Enhance: differentiate CNAV's unattributed provider error from the generic baseline

### DIFF
--- a/commons/swagger/openapi-particulier.yaml
+++ b/commons/swagger/openapi-particulier.yaml
@@ -1269,14 +1269,14 @@ paths:
                 unexpected_error:
                   value:
                     errors:
-                    - code: '37999'
-                      title: Erreur inconnue du fournisseur de données
+                    - code: '37998'
+                      title: Réponse inconnue du fournisseur de données
                       detail: Une erreur inattendue est survenue lors de la collecte
                         des données
                       source:
                       meta:
                         provider: CNAV
-                  summary: Erreur inconnue du fournisseur de données
+                  summary: Réponse inconnue du fournisseur de données
                   description: Une erreur inattendue est survenue lors de la collecte
                     des données
                 erreur_inconnue_du_fournisseur_de_donnees_37999:
@@ -1700,14 +1700,14 @@ paths:
                 unexpected_error:
                   value:
                     errors:
-                    - code: '37999'
-                      title: Erreur inconnue du fournisseur de données
+                    - code: '37998'
+                      title: Réponse inconnue du fournisseur de données
                       detail: Une erreur inattendue est survenue lors de la collecte
                         des données
                       source:
                       meta:
                         provider: CNAV
-                  summary: Erreur inconnue du fournisseur de données
+                  summary: Réponse inconnue du fournisseur de données
                   description: Une erreur inattendue est survenue lors de la collecte
                     des données
               schema:
@@ -2172,14 +2172,14 @@ paths:
                 unexpected_error:
                   value:
                     errors:
-                    - code: '37999'
-                      title: Erreur inconnue du fournisseur de données
+                    - code: '37998'
+                      title: Réponse inconnue du fournisseur de données
                       detail: Une erreur inattendue est survenue lors de la collecte
                         des données
                       source:
                       meta:
                         provider: CNAV
-                  summary: Erreur inconnue du fournisseur de données
+                  summary: Réponse inconnue du fournisseur de données
                   description: Une erreur inattendue est survenue lors de la collecte
                     des données
                 erreur_inconnue_du_fournisseur_de_donnees_37999:
@@ -2619,14 +2619,14 @@ paths:
                 unexpected_error:
                   value:
                     errors:
-                    - code: '37999'
-                      title: Erreur inconnue du fournisseur de données
+                    - code: '37998'
+                      title: Réponse inconnue du fournisseur de données
                       detail: Une erreur inattendue est survenue lors de la collecte
                         des données
                       source:
                       meta:
                         provider: CNAV
-                  summary: Erreur inconnue du fournisseur de données
+                  summary: Réponse inconnue du fournisseur de données
                   description: Une erreur inattendue est survenue lors de la collecte
                     des données
               schema:
@@ -3085,14 +3085,14 @@ paths:
                 unexpected_error:
                   value:
                     errors:
-                    - code: '37999'
-                      title: Erreur inconnue du fournisseur de données
+                    - code: '37998'
+                      title: Réponse inconnue du fournisseur de données
                       detail: Une erreur inattendue est survenue lors de la collecte
                         des données
                       source:
                       meta:
                         provider: CNAV
-                  summary: Erreur inconnue du fournisseur de données
+                  summary: Réponse inconnue du fournisseur de données
                   description: Une erreur inattendue est survenue lors de la collecte
                     des données
                 erreur_inconnue_du_fournisseur_de_donnees_37999:
@@ -3525,14 +3525,14 @@ paths:
                 unexpected_error:
                   value:
                     errors:
-                    - code: '37999'
-                      title: Erreur inconnue du fournisseur de données
+                    - code: '37998'
+                      title: Réponse inconnue du fournisseur de données
                       detail: Une erreur inattendue est survenue lors de la collecte
                         des données
                       source:
                       meta:
                         provider: CNAV
-                  summary: Erreur inconnue du fournisseur de données
+                  summary: Réponse inconnue du fournisseur de données
                   description: Une erreur inattendue est survenue lors de la collecte
                     des données
               schema:
@@ -3984,14 +3984,14 @@ paths:
                 unexpected_error:
                   value:
                     errors:
-                    - code: '37999'
-                      title: Erreur inconnue du fournisseur de données
+                    - code: '37998'
+                      title: Réponse inconnue du fournisseur de données
                       detail: Une erreur inattendue est survenue lors de la collecte
                         des données
                       source:
                       meta:
                         provider: CNAV
-                  summary: Erreur inconnue du fournisseur de données
+                  summary: Réponse inconnue du fournisseur de données
                   description: Une erreur inattendue est survenue lors de la collecte
                     des données
                 erreur_inconnue_du_fournisseur_de_donnees_37999:
@@ -4417,14 +4417,14 @@ paths:
                 unexpected_error:
                   value:
                     errors:
-                    - code: '37999'
-                      title: Erreur inconnue du fournisseur de données
+                    - code: '37998'
+                      title: Réponse inconnue du fournisseur de données
                       detail: Une erreur inattendue est survenue lors de la collecte
                         des données
                       source:
                       meta:
                         provider: CNAV
-                  summary: Erreur inconnue du fournisseur de données
+                  summary: Réponse inconnue du fournisseur de données
                   description: Une erreur inattendue est survenue lors de la collecte
                     des données
               schema:
@@ -4898,14 +4898,14 @@ paths:
                 unexpected_error:
                   value:
                     errors:
-                    - code: '37999'
-                      title: Erreur inconnue du fournisseur de données
+                    - code: '37998'
+                      title: Réponse inconnue du fournisseur de données
                       detail: Une erreur inattendue est survenue lors de la collecte
                         des données
                       source:
                       meta:
                         provider: CNAV
-                  summary: Erreur inconnue du fournisseur de données
+                  summary: Réponse inconnue du fournisseur de données
                   description: Une erreur inattendue est survenue lors de la collecte
                     des données
                 erreur_inconnue_du_fournisseur_de_donnees_37999:
@@ -5353,14 +5353,14 @@ paths:
                 unexpected_error:
                   value:
                     errors:
-                    - code: '37999'
-                      title: Erreur inconnue du fournisseur de données
+                    - code: '37998'
+                      title: Réponse inconnue du fournisseur de données
                       detail: Une erreur inattendue est survenue lors de la collecte
                         des données
                       source:
                       meta:
                         provider: CNAV
-                  summary: Erreur inconnue du fournisseur de données
+                  summary: Réponse inconnue du fournisseur de données
                   description: Une erreur inattendue est survenue lors de la collecte
                     des données
               schema:
@@ -7020,14 +7020,14 @@ paths:
                 unexpected_error:
                   value:
                     errors:
-                    - code: '37999'
-                      title: Erreur inconnue du fournisseur de données
+                    - code: '37998'
+                      title: Réponse inconnue du fournisseur de données
                       detail: Une erreur inattendue est survenue lors de la collecte
                         des données
                       source:
                       meta:
                         provider: CNAV
-                  summary: Erreur inconnue du fournisseur de données
+                  summary: Réponse inconnue du fournisseur de données
                   description: Une erreur inattendue est survenue lors de la collecte
                     des données
                 erreur_inconnue_du_fournisseur_de_donnees_37999:
@@ -7463,14 +7463,14 @@ paths:
                 unexpected_error:
                   value:
                     errors:
-                    - code: '37999'
-                      title: Erreur inconnue du fournisseur de données
+                    - code: '37998'
+                      title: Réponse inconnue du fournisseur de données
                       detail: Une erreur inattendue est survenue lors de la collecte
                         des données
                       source:
                       meta:
                         provider: CNAV
-                  summary: Erreur inconnue du fournisseur de données
+                  summary: Réponse inconnue du fournisseur de données
                   description: Une erreur inattendue est survenue lors de la collecte
                     des données
                 erreur_inconnue_du_fournisseur_de_donnees_37999:
@@ -8313,14 +8313,14 @@ paths:
                 unexpected_error:
                   value:
                     errors:
-                    - code: '37999'
-                      title: Erreur inconnue du fournisseur de données
+                    - code: '37998'
+                      title: Réponse inconnue du fournisseur de données
                       detail: Une erreur inattendue est survenue lors de la collecte
                         des données
                       source:
                       meta:
                         provider: CNAV
-                  summary: Erreur inconnue du fournisseur de données
+                  summary: Réponse inconnue du fournisseur de données
                   description: Une erreur inattendue est survenue lors de la collecte
                     des données
                 erreur_inconnue_du_fournisseur_de_donnees_37999:
@@ -8996,14 +8996,14 @@ paths:
                 unexpected_error:
                   value:
                     errors:
-                    - code: '37999'
-                      title: Erreur inconnue du fournisseur de données
+                    - code: '37998'
+                      title: Réponse inconnue du fournisseur de données
                       detail: Une erreur inattendue est survenue lors de la collecte
                         des données
                       source:
                       meta:
                         provider: CNAV
-                  summary: Erreur inconnue du fournisseur de données
+                  summary: Réponse inconnue du fournisseur de données
                   description: Une erreur inattendue est survenue lors de la collecte
                     des données
               schema:
@@ -9465,14 +9465,14 @@ paths:
                 unexpected_error:
                   value:
                     errors:
-                    - code: '37999'
-                      title: Erreur inconnue du fournisseur de données
+                    - code: '37998'
+                      title: Réponse inconnue du fournisseur de données
                       detail: Une erreur inattendue est survenue lors de la collecte
                         des données
                       source:
                       meta:
                         provider: CNAV
-                  summary: Erreur inconnue du fournisseur de données
+                  summary: Réponse inconnue du fournisseur de données
                   description: Une erreur inattendue est survenue lors de la collecte
                     des données
                 erreur_inconnue_du_fournisseur_de_donnees_37999:
@@ -9908,14 +9908,14 @@ paths:
                 unexpected_error:
                   value:
                     errors:
-                    - code: '37999'
-                      title: Erreur inconnue du fournisseur de données
+                    - code: '37998'
+                      title: Réponse inconnue du fournisseur de données
                       detail: Une erreur inattendue est survenue lors de la collecte
                         des données
                       source:
                       meta:
                         provider: CNAV
-                  summary: Erreur inconnue du fournisseur de données
+                  summary: Réponse inconnue du fournisseur de données
                   description: Une erreur inattendue est survenue lors de la collecte
                     des données
               schema:

--- a/commons/swagger/openapi-particulierv2.yaml
+++ b/commons/swagger/openapi-particulierv2.yaml
@@ -328,7 +328,7 @@ paths:
                       des données
                     message: Une erreur inattendue est survenue lors de la collecte
                       des données
-                  summary: Erreur inconnue du fournisseur de données
+                  summary: Réponse inconnue du fournisseur de données
                   description: Une erreur inattendue est survenue lors de la collecte
                     des données
               schema:
@@ -630,7 +630,7 @@ paths:
                       des données
                     message: Une erreur inattendue est survenue lors de la collecte
                       des données
-                  summary: Erreur inconnue du fournisseur de données
+                  summary: Réponse inconnue du fournisseur de données
                   description: Une erreur inattendue est survenue lors de la collecte
                     des données
               schema:
@@ -943,7 +943,7 @@ paths:
                       des données
                     message: Une erreur inattendue est survenue lors de la collecte
                       des données
-                  summary: Erreur inconnue du fournisseur de données
+                  summary: Réponse inconnue du fournisseur de données
                   description: Une erreur inattendue est survenue lors de la collecte
                     des données
               schema:
@@ -1253,7 +1253,7 @@ paths:
                       des données
                     message: Une erreur inattendue est survenue lors de la collecte
                       des données
-                  summary: Erreur inconnue du fournisseur de données
+                  summary: Réponse inconnue du fournisseur de données
                   description: Une erreur inattendue est survenue lors de la collecte
                     des données
               schema:
@@ -2117,7 +2117,7 @@ paths:
                       des données
                     message: Une erreur inattendue est survenue lors de la collecte
                       des données
-                  summary: Erreur inconnue du fournisseur de données
+                  summary: Réponse inconnue du fournisseur de données
                   description: Une erreur inattendue est survenue lors de la collecte
                     des données
               schema:

--- a/siade/app/errors/provider_unknown_error.rb
+++ b/siade/app/errors/provider_unknown_error.rb
@@ -1,7 +1,10 @@
 class ProviderUnknownError < AbstractGenericProviderError
-  def subcode
-    '999'
+  def initialize(provider_name, message = nil, subcode: '999')
+    super(provider_name, message)
+    @subcode = subcode
   end
+
+  attr_reader :subcode
 
   def tracking_level
     'error'

--- a/siade/app/interactors/cnav/validate_response.rb
+++ b/siade/app/interactors/cnav/validate_response.rb
@@ -18,7 +18,7 @@ class CNAV::ValidateResponse < ValidateResponse
 
     return regime_not_found_error(regime) if regime.present?
 
-    unknown_provider_response!('Une erreur inattendue est survenue lors de la collecte des données')
+    unknown_provider_response!('Une erreur inattendue est survenue lors de la collecte des données', subcode: '998')
   end
 
   def sub_provider_error?

--- a/siade/app/interactors/validate_response.rb
+++ b/siade/app/interactors/validate_response.rb
@@ -24,8 +24,8 @@ class ValidateResponse < ApplicationInteractor
 
   protected
 
-  def build_error(error_klass, message = nil)
-    error_klass.new(context.provider_name, message)
+  def build_error(error_klass, message = nil, **)
+    error_klass.new(context.provider_name, message, **)
   end
 
   def fail_with_error!(error)
@@ -41,8 +41,8 @@ class ValidateResponse < ApplicationInteractor
     fail_with_error!(build_error(::ProviderTemporaryError, message))
   end
 
-  def unknown_provider_response!(message = nil)
-    error = build_error(::ProviderUnknownError, message)
+  def unknown_provider_response!(message = nil, **)
+    error = build_error(::ProviderUnknownError, message, **)
 
     add_monitoring_private_context(error)
 

--- a/siade/config/errors.yml
+++ b/siade/config/errors.yml
@@ -4,6 +4,10 @@
   title: 'Erreur inconnue du fournisseur de données'
   detail: "La réponse retournée par le fournisseur de données est invalide et inconnue de notre service. L'équipe technique a été notifiée de cette erreur pour investigation."
 
+- subcode: '998'
+  title: 'Réponse inconnue du fournisseur de données'
+  detail: "La réponse retournée par le fournisseur de données correspond à un cas d'erreur imprévu. L'équipe technique a été notifiée de cette erreur pour investigation."
+
 - subcode: '000'
   title: 'Erreur interne du fournisseur de données'
   detail: 'La réponse retournée par le fournisseur de données est invalide et a été identifié comme étant une erreur interne. Si le problème persiste, consultez la page de status ou contactez nous sur le support.'

--- a/siade/spec/errors/provider_unknown_error_spec.rb
+++ b/siade/spec/errors/provider_unknown_error_spec.rb
@@ -2,4 +2,20 @@ RSpec.describe ProviderUnknownError, type: :error do
   it_behaves_like 'a valid error' do
     let(:instance) { described_class.new('INSEE') }
   end
+
+  it 'defaults to subcode 999' do
+    expect(described_class.new('INSEE').subcode).to eq('999')
+  end
+
+  context 'with a custom subcode' do
+    let(:instance) { described_class.new('CNAV', subcode: '998') }
+
+    it 'uses the given subcode' do
+      expect(instance.subcode).to eq('998')
+    end
+
+    it 'resolves the title for that subcode' do
+      expect(instance.title).to eq('Réponse inconnue du fournisseur de données')
+    end
+  end
 end

--- a/siade/spec/interactors/cnav/validate_response_spec.rb
+++ b/siade/spec/interactors/cnav/validate_response_spec.rb
@@ -122,6 +122,10 @@ RSpec.describe CNAV::ValidateResponse, type: :validate_response do
       it 'returns a provider unknown error' do
         expect(subject.errors.first.detail).to include('Une erreur inattendue est survenue lors de la collecte des données')
       end
+
+      it 'uses the dedicated unattributed-error subcode' do
+        expect(subject.errors.first.subcode).to eq('998')
+      end
     end
   end
 

--- a/siade/spec/requests/api_particulier/v2/cnav/allocation_adulte_handicape_spec.rb
+++ b/siade/spec/requests/api_particulier/v2/cnav/allocation_adulte_handicape_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe 'CNAV: Allocation Adulte Handicapé', api: :particulierv2, type: 
                 stub_cnav_404('allocation_adulte_handicape')
               end
 
-              build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données'), :unexpected_error)
+              build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données', subcode: '998'), :unexpected_error)
 
               schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v2/cnav/allocation_soutien_familial_spec.rb
+++ b/siade/spec/requests/api_particulier/v2/cnav/allocation_soutien_familial_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe 'CNAV: Allocation Soutien Familial', api: :particulierv2, type: %
                 stub_cnav_404('allocation_soutien_familial')
               end
 
-              build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données'), :unexpected_error)
+              build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données', subcode: '998'), :unexpected_error)
 
               schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v2/cnav/complementaire_sante_solidaire_spec.rb
+++ b/siade/spec/requests/api_particulier/v2/cnav/complementaire_sante_solidaire_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe 'CNAV: Complementaire Santé Solidaire', api: :particulierv2, typ
                   stub_cnav_404('complementaire_sante_solidaire')
                 end
 
-                build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données'), :unexpected_error)
+                build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données', subcode: '998'), :unexpected_error)
 
                 schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v2/cnav/prime_activite_spec.rb
+++ b/siade/spec/requests/api_particulier/v2/cnav/prime_activite_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe "CNAV: Prime d'activité", api: :particulierv2, type: %i[request 
                 stub_cnav_404('prime_activite')
               end
 
-              build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données'), :unexpected_error)
+              build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données', subcode: '998'), :unexpected_error)
 
               schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v2/cnav/quotient_familial_v2_spec.rb
+++ b/siade/spec/requests/api_particulier/v2/cnav/quotient_familial_v2_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe 'CNAV: Quotient Familial V2', api: :particulierv2, type: %i[reque
                   stub_cnav_404('quotient_familial_v2')
                 end
 
-                build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données'), :unexpected_error)
+                build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données', subcode: '998'), :unexpected_error)
 
                 schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v2/cnav/revenu_solidarite_active_spec.rb
+++ b/siade/spec/requests/api_particulier/v2/cnav/revenu_solidarite_active_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe 'CNAV: Revenu de solidarité active', api: :particulierv2, type: 
                 stub_cnav_404('revenu_solidarite_active')
               end
 
-              build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données'), :unexpected_error)
+              build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données', subcode: '998'), :unexpected_error)
 
               schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_adulte_handicape_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_adulte_handicape_with_civility_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe 'API Particulier CNAV: allocation adulte handicape with civility'
               stub_cnav_404('allocation_adulte_handicape')
             end
 
-            build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données'), :unexpected_error)
+            build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données', subcode: '998'), :unexpected_error)
 
             schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_adulte_handicape_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_adulte_handicape_with_france_connect_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe 'API Particulier: CNAV: Allocation Adulte Handicape with FranceCo
               stub_cnav_404('allocation_adulte_handicape')
             end
 
-            build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données'), :unexpected_error)
+            build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données', subcode: '998'), :unexpected_error)
 
             schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_enfant_handicape/allocation_enfant_handicape_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_enfant_handicape/allocation_enfant_handicape_with_civility_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe 'API Particulier CNAV: Allocation enfant handicapé (AEEH) with c
               stub_cnav_404('allocation_enfant_handicape')
             end
 
-            build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données'), :unexpected_error)
+            build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données', subcode: '998'), :unexpected_error)
 
             schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_enfant_handicape/allocation_enfant_handicape_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_enfant_handicape/allocation_enfant_handicape_with_france_connect_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe 'API Particulier: CNAV: Allocation enfant handicapé (AEEH) with 
               stub_cnav_404('allocation_enfant_handicape')
             end
 
-            build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données'), :unexpected_error)
+            build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données', subcode: '998'), :unexpected_error)
 
             schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_rentree_scolaire/allocation_rentree_scolaire_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_rentree_scolaire/allocation_rentree_scolaire_with_civility_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe 'API Particulier CNAV: Allocation de rentrée scolaire (ARS) with
               stub_cnav_404('allocation_rentree_scolaire')
             end
 
-            build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données'), :unexpected_error)
+            build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données', subcode: '998'), :unexpected_error)
 
             schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_rentree_scolaire/allocation_rentree_scolaire_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_rentree_scolaire/allocation_rentree_scolaire_with_france_connect_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe 'API Particulier: CNAV: Allocation de rentrée scolaire (ARS) wit
               stub_cnav_404('allocation_rentree_scolaire')
             end
 
-            build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données'), :unexpected_error)
+            build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données', subcode: '998'), :unexpected_error)
 
             schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_soutien_familial_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_soutien_familial_with_civility_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe 'API Particulier CNAV: allocation soutien familial with civility'
               stub_cnav_404('allocation_soutien_familial')
             end
 
-            build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données'), :unexpected_error)
+            build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données', subcode: '998'), :unexpected_error)
 
             schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_soutien_familial_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_soutien_familial_with_france_connect_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe 'API Particulier: CNAV: Allocation Soutien Familial with FranceCo
               stub_cnav_404('allocation_soutien_familial')
             end
 
-            build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données'), :unexpected_error)
+            build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données', subcode: '998'), :unexpected_error)
 
             schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/complementaire_sante_solidaire_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/complementaire_sante_solidaire_with_civility_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe 'API Particulier CNAV: complementaire sante solidaire with civili
               stub_cnav_404('complementaire_sante_solidaire')
             end
 
-            build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données'), :unexpected_error)
+            build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données', subcode: '998'), :unexpected_error)
 
             schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/complementaire_sante_solidaire_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/complementaire_sante_solidaire_with_france_connect_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe 'API Particulier: CNAV: Complementaire Sante Solidaire with Franc
               stub_cnav_404('complementaire_sante_solidaire')
             end
 
-            build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données'), :unexpected_error)
+            build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données', subcode: '998'), :unexpected_error)
 
             schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/prime_activite_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/prime_activite_with_civility_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe 'API Particulier CNAV: prime activite with civility', api: :parti
               stub_cnav_404('prime_activite')
             end
 
-            build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données'), :unexpected_error)
+            build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données', subcode: '998'), :unexpected_error)
 
             schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/prime_activite_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/prime_activite_with_france_connect_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe 'API Particulier: CNAV: Prime Activite with FranceConnect', api: 
               stub_cnav_404('prime_activite')
             end
 
-            build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données'), :unexpected_error)
+            build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données', subcode: '998'), :unexpected_error)
 
             schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/quotient_familial_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/quotient_familial_with_civility_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe 'API Particulier CNAV: Quotient Familial with civility', api: :pa
               stub_cnav_404('quotient_familial_v2')
             end
 
-            build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données'), :unexpected_error)
+            build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données', subcode: '998'), :unexpected_error)
 
             schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/quotient_familial_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/quotient_familial_with_france_connect_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe 'API Particulier: CNAV: Quotient Familial with FranceConnect', ap
               stub_cnav_404('quotient_familial_v2')
             end
 
-            build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données'), :unexpected_error)
+            build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données', subcode: '998'), :unexpected_error)
 
             schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/revenu_solidarite_active_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/revenu_solidarite_active_with_civility_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe 'API Particulier CNAV: Revenu de solidarité active with civility
               stub_cnav_404('revenu_solidarite_active')
             end
 
-            build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données'), :unexpected_error)
+            build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données', subcode: '998'), :unexpected_error)
 
             schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/revenu_solidarite_active_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/revenu_solidarite_active_with_france_connect_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe 'API Particulier: CNAV: Revenu Solidarite Active with FranceConne
               stub_cnav_404('revenu_solidarite_active')
             end
 
-            build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données'), :unexpected_error)
+            build_rswag_example(ProviderUnknownError.new('CNAV', 'Une erreur inattendue est survenue lors de la collecte des données', subcode: '998'), :unexpected_error)
 
             schema '$ref' => '#/components/schemas/Error'
 


### PR DESCRIPTION
Follow-up to #321 (return `ProviderUnknownError` instead of 404 for unattributed CNAV errors), addressing feedback that the new error was indistinguishable from the existing generic `ProviderUnknownError` example in the swagger docs.
