### PR TITLE
Fix develop CI: HubEE specs read the retired credentials source

### DIFF
--- a/site/spec/clients/hubee_api_authentication_spec.rb
+++ b/site/spec/clients/hubee_api_authentication_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe HubEEAPIAuthentication do
   describe '#access_token' do
     subject(:access_token) { described_class.new.access_token }
 
-    let(:auth_url) { Rails.application.credentials.hubee_auth_url }
+    let(:auth_url) { AdminApientreprise.credentials[:hubee_auth_url] }
 
     before do
       stub_request(:post, auth_url)

--- a/site/spec/clients/hubee_api_client_spec.rb
+++ b/site/spec/clients/hubee_api_client_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe HubEEAPIClient do
     let(:authorization_request) { create(:authorization_request, :with_demandeur, api: 'particulier') }
     let(:organization_payload) { hubee_organization_payload }
     let(:process_code) { 'FormulaireQF' }
-    let(:host) { Rails.application.credentials.hubee_api_url }
+    let(:host) { AdminApientreprise.credentials[:hubee_api_url] }
     let(:subscription_payload) { hubee_subscription_payload(authorization_request:, process_code:) }
 
     context 'when the subscription does not exist yet' do


### PR DESCRIPTION
Switch the two HubEE spec `let` lines from `Rails.application.credentials` (retired by cfa040a91) to `AdminApientreprise.credentials` — semantic conflict from the #309 merge, 5 red specs on develop.

Closes API-7125 → https://linear.app/pole-api/issue/API-7125/fqf-retirer-lactivation-auto-des-abonnements-hubee-et-le-scope-admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)