### PR TITLE
Revert HubEE OAuth scope to ADMIN

### DIFF
--- a/site/app/clients/hubee_api_authentication.rb
+++ b/site/app/clients/hubee_api_authentication.rb
@@ -3,7 +3,7 @@ class HubEEAPIAuthentication < AbstractHubEEAPIClient
   def access_token
     http_connection.post(
       auth_url,
-      'grant_type=client_credentials&scope=DATAPASS',
+      'grant_type=client_credentials&scope=ADMIN',
       {
         'Authorization' => "Basic #{encoded_client_id_and_secret}"
       }

--- a/site/spec/clients/hubee_api_authentication_spec.rb
+++ b/site/spec/clients/hubee_api_authentication_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe HubEEAPIAuthentication do
 
     before do
       stub_request(:post, auth_url)
-        .with(body: 'grant_type=client_credentials&scope=DATAPASS')
+        .with(body: 'grant_type=client_credentials&scope=ADMIN')
         .to_return(
           status: 200,
           headers: { 'Content-Type' => 'application/json' },


### PR DESCRIPTION
The DATAPASS scope HubEE asked for is misconfigured on their side and their team is on holiday. Back to ADMIN, the known-working scope, until they fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)