### PR TITLE
Restore HubEE OAuth scope to DATAPASS

### DIFF
--- a/site/app/clients/hubee_api_authentication.rb
+++ b/site/app/clients/hubee_api_authentication.rb
@@ -3,7 +3,7 @@ class HubEEAPIAuthentication < AbstractHubEEAPIClient
   def access_token
     http_connection.post(
       auth_url,
-      'grant_type=client_credentials&scope=ADMIN',
+      'grant_type=client_credentials&scope=DATAPASS',
       {
         'Authorization' => "Basic #{encoded_client_id_and_secret}"
       }

--- a/site/spec/clients/hubee_api_authentication_spec.rb
+++ b/site/spec/clients/hubee_api_authentication_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe HubEEAPIAuthentication do
 
     before do
       stub_request(:post, auth_url)
-        .with(body: 'grant_type=client_credentials&scope=ADMIN')
+        .with(body: 'grant_type=client_credentials&scope=DATAPASS')
         .to_return(
           status: 200,
           headers: { 'Content-Type' => 'application/json' },


### PR DESCRIPTION
⏳ **Waiting for hubee team update to merge this PR**

Restores the DATAPASS scope (API-7125) once HubEE fixes their Keycloak configuration — planned for Monday 2026-08-10. Reverts the temporary fallback to ADMIN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)