### PR TITLE
Clean: dont document 502 CNAV twice

### DIFF
--- a/commons/swagger/openapi-particulier.yaml
+++ b/commons/swagger/openapi-particulier.yaml
@@ -1266,19 +1266,6 @@ paths:
           content:
             application/json:
               examples:
-                unexpected_error:
-                  value:
-                    errors:
-                    - code: '37999'
-                      title: Erreur inconnue du fournisseur de données
-                      detail: Une erreur inattendue est survenue lors de la collecte
-                        des données
-                      source:
-                      meta:
-                        provider: CNAV
-                  summary: Erreur inconnue du fournisseur de données
-                  description: Une erreur inattendue est survenue lors de la collecte
-                    des données
                 erreur_inconnue_du_fournisseur_de_donnees_37999:
                   value:
                     errors:
@@ -2169,19 +2156,6 @@ paths:
           content:
             application/json:
               examples:
-                unexpected_error:
-                  value:
-                    errors:
-                    - code: '37999'
-                      title: Erreur inconnue du fournisseur de données
-                      detail: Une erreur inattendue est survenue lors de la collecte
-                        des données
-                      source:
-                      meta:
-                        provider: CNAV
-                  summary: Erreur inconnue du fournisseur de données
-                  description: Une erreur inattendue est survenue lors de la collecte
-                    des données
                 erreur_inconnue_du_fournisseur_de_donnees_37999:
                   value:
                     errors:
@@ -3082,19 +3056,6 @@ paths:
           content:
             application/json:
               examples:
-                unexpected_error:
-                  value:
-                    errors:
-                    - code: '37999'
-                      title: Erreur inconnue du fournisseur de données
-                      detail: Une erreur inattendue est survenue lors de la collecte
-                        des données
-                      source:
-                      meta:
-                        provider: CNAV
-                  summary: Erreur inconnue du fournisseur de données
-                  description: Une erreur inattendue est survenue lors de la collecte
-                    des données
                 erreur_inconnue_du_fournisseur_de_donnees_37999:
                   value:
                     errors:
@@ -3981,19 +3942,6 @@ paths:
           content:
             application/json:
               examples:
-                unexpected_error:
-                  value:
-                    errors:
-                    - code: '37999'
-                      title: Erreur inconnue du fournisseur de données
-                      detail: Une erreur inattendue est survenue lors de la collecte
-                        des données
-                      source:
-                      meta:
-                        provider: CNAV
-                  summary: Erreur inconnue du fournisseur de données
-                  description: Une erreur inattendue est survenue lors de la collecte
-                    des données
                 erreur_inconnue_du_fournisseur_de_donnees_37999:
                   value:
                     errors:
@@ -4895,19 +4843,6 @@ paths:
           content:
             application/json:
               examples:
-                unexpected_error:
-                  value:
-                    errors:
-                    - code: '37999'
-                      title: Erreur inconnue du fournisseur de données
-                      detail: Une erreur inattendue est survenue lors de la collecte
-                        des données
-                      source:
-                      meta:
-                        provider: CNAV
-                  summary: Erreur inconnue du fournisseur de données
-                  description: Une erreur inattendue est survenue lors de la collecte
-                    des données
                 erreur_inconnue_du_fournisseur_de_donnees_37999:
                   value:
                     errors:
@@ -7017,19 +6952,6 @@ paths:
           content:
             application/json:
               examples:
-                unexpected_error:
-                  value:
-                    errors:
-                    - code: '37999'
-                      title: Erreur inconnue du fournisseur de données
-                      detail: Une erreur inattendue est survenue lors de la collecte
-                        des données
-                      source:
-                      meta:
-                        provider: CNAV
-                  summary: Erreur inconnue du fournisseur de données
-                  description: Une erreur inattendue est survenue lors de la collecte
-                    des données
                 erreur_inconnue_du_fournisseur_de_donnees_37999:
                   value:
                     errors:
@@ -7460,19 +7382,6 @@ paths:
           content:
             application/json:
               examples:
-                unexpected_error:
-                  value:
-                    errors:
-                    - code: '37999'
-                      title: Erreur inconnue du fournisseur de données
-                      detail: Une erreur inattendue est survenue lors de la collecte
-                        des données
-                      source:
-                      meta:
-                        provider: CNAV
-                  summary: Erreur inconnue du fournisseur de données
-                  description: Une erreur inattendue est survenue lors de la collecte
-                    des données
                 erreur_inconnue_du_fournisseur_de_donnees_37999:
                   value:
                     errors:
@@ -8310,19 +8219,6 @@ paths:
           content:
             application/json:
               examples:
-                unexpected_error:
-                  value:
-                    errors:
-                    - code: '37999'
-                      title: Erreur inconnue du fournisseur de données
-                      detail: Une erreur inattendue est survenue lors de la collecte
-                        des données
-                      source:
-                      meta:
-                        provider: CNAV
-                  summary: Erreur inconnue du fournisseur de données
-                  description: Une erreur inattendue est survenue lors de la collecte
-                    des données
                 erreur_inconnue_du_fournisseur_de_donnees_37999:
                   value:
                     errors:
@@ -9462,19 +9358,6 @@ paths:
           content:
             application/json:
               examples:
-                unexpected_error:
-                  value:
-                    errors:
-                    - code: '37999'
-                      title: Erreur inconnue du fournisseur de données
-                      detail: Une erreur inattendue est survenue lors de la collecte
-                        des données
-                      source:
-                      meta:
-                        provider: CNAV
-                  summary: Erreur inconnue du fournisseur de données
-                  description: Une erreur inattendue est survenue lors de la collecte
-                    des données
                 erreur_inconnue_du_fournisseur_de_donnees_37999:
                   value:
                     errors:

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_adulte_handicape_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_adulte_handicape_with_civility_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe 'API Particulier CNAV: allocation adulte handicape with civility'
           # rubocop:enable RSpec/ContextWording
         end
 
-        response '502', 'Erreur du fournisseur' do
+        response '502', 'Erreur du fournisseur', document: false do
           # rubocop:disable RSpec/ContextWording
           context 'Erreur inattendue' do
             before do

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_enfant_handicape/allocation_enfant_handicape_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_enfant_handicape/allocation_enfant_handicape_with_civility_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe 'API Particulier CNAV: Allocation enfant handicapé (AEEH) with c
           # rubocop:enable RSpec/ContextWording
         end
 
-        response '502', 'Erreur du fournisseur' do
+        response '502', 'Erreur du fournisseur', document: false do
           # rubocop:disable RSpec/ContextWording
           context 'Erreur inattendue' do
             before do

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_rentree_scolaire/allocation_rentree_scolaire_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_rentree_scolaire/allocation_rentree_scolaire_with_civility_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe 'API Particulier CNAV: Allocation de rentrée scolaire (ARS) with
           end
         end
 
-        response '502', 'Erreur du fournisseur' do
+        response '502', 'Erreur du fournisseur', document: false do
           context 'when an unexpected error occurs' do
             before do
               stub_cnav_404('allocation_rentree_scolaire')

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_soutien_familial_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_soutien_familial_with_civility_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe 'API Particulier CNAV: allocation soutien familial with civility'
           # rubocop:enable RSpec/ContextWording
         end
 
-        response '502', 'Erreur du fournisseur' do
+        response '502', 'Erreur du fournisseur', document: false do
           # rubocop:disable RSpec/ContextWording
           context 'Erreur inattendue' do
             before do

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/complementaire_sante_solidaire_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/complementaire_sante_solidaire_with_civility_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe 'API Particulier CNAV: complementaire sante solidaire with civili
           # rubocop:enable RSpec/ContextWording
         end
 
-        response '502', 'Erreur du fournisseur' do
+        response '502', 'Erreur du fournisseur', document: false do
           # rubocop:disable RSpec/ContextWording
           context 'Erreur inattendue' do
             before do

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/prime_activite_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/prime_activite_with_civility_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe 'API Particulier CNAV: prime activite with civility', api: :parti
           # rubocop:enable RSpec/ContextWording
         end
 
-        response '502', 'Erreur du fournisseur' do
+        response '502', 'Erreur du fournisseur', document: false do
           # rubocop:disable RSpec/ContextWording
           context 'Erreur inattendue' do
             before do

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/prime_activite_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/prime_activite_with_france_connect_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe 'API Particulier: CNAV: Prime Activite with FranceConnect', api: 
           # rubocop:enable RSpec/ContextWording
         end
 
-        response '502', 'Erreur du fournisseur' do
+        response '502', 'Erreur du fournisseur', document: false do
           # rubocop:disable RSpec/ContextWording
           context 'Erreur inattendue' do
             before do

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/quotient_familial_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/quotient_familial_with_civility_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe 'API Particulier CNAV: Quotient Familial with civility', api: :pa
           # rubocop:enable RSpec/ContextWording
         end
 
-        response '502', 'Erreur du fournisseur' do
+        response '502', 'Erreur du fournisseur', document: false do
           # rubocop:disable RSpec/ContextWording
           context 'Erreur inattendue' do
             before do

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/revenu_solidarite_active_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/revenu_solidarite_active_with_civility_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe 'API Particulier CNAV: Revenu de solidarité active with civility
           # rubocop:enable RSpec/ContextWording
         end
 
-        response '502', 'Erreur du fournisseur' do
+        response '502', 'Erreur du fournisseur', document: false do
           # rubocop:disable RSpec/ContextWording
           context 'Erreur inattendue' do
             before do


### PR DESCRIPTION
We have classic 502 error tested for CNAV
but we also have the FD 404 with unexpected unknown message where we 502 as well

We want to keep those tests but not document twice the same 502 error