### PR TITLE
Run mocks CI on pull requests, including from forks

### DIFF
--- a/.github/workflows/mocks-tests.yml
+++ b/.github/workflows/mocks-tests.yml
@@ -4,11 +4,17 @@ defaults:
   run:
     working-directory: mocks
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:
       - 'mocks/**'
       - 'commons/**'
+  pull_request:
+    paths:
+      - 'mocks/**'
 
 jobs:
   tests:


### PR DESCRIPTION
Closes https://linear.app/pole-api/issue/API-7219/add-github-rule-to-trigger-workflow-on-forked-pr-but-only-for-mock

External contributors currently can't get CI feedback on mocks/ PRs: mocks-tests.yml only triggers on push, and a push to a fork never reaches this repo, so the workflow silently never runs for outside contributions.

Add a pull_request trigger scoped to mocks/** only (commons/** stays push-only, since outside contributors have no reason to touch it).

This is safe to run automatically on fork PRs: for pull_request (not pull_request_target) events from a fork of a public repo, GitHub forces GITHUB_TOKEN to read-only and withholds all other secrets, and this cannot be overridden for public repos. The workflow definition that actually runs is also pinned to the version on develop, not the fork's copy, so a PR can't rewrite its own CI steps. This job doesn't use any secrets to begin with. The added `permissions: contents: read` block makes that read-only intent explicit in the file itself, on top of GitHub's automatic enforcement.

As extra protection, the repo's "Fork pull request workflows" setting has been tightened from "first-time contributors" to requiring maintainer approval every time a fork PR run is queued.

TLDR: Quand je merges les contributions à mocks/ je voudrais pouvoir lancer la CI