### PR TITLE
Fix INSEE password rotation invalidating cache on failed renewal

### DIFF
--- a/siade/app/interactors/insee/renew_password.rb
+++ b/siade/app/interactors/insee/renew_password.rb
@@ -38,7 +38,20 @@ class INSEE::RenewPassword < MakeRequest::Post
   end
 
   def fail_with_authentication_error!
+    track_renewal_rejected!
+
     context.errors << ProviderAuthenticationError.new(context.provider_name)
     context.fail!
+  end
+
+  def track_renewal_rejected!
+    MonitoringService.instance.track_with_added_context(
+      'error',
+      'Fail to rotate INSEE password',
+      {
+        http_response_code: context.response&.code,
+        http_response_body: context.response&.body
+      }
+    )
   end
 end

--- a/siade/app/interactors/insee/renew_password.rb
+++ b/siade/app/interactors/insee/renew_password.rb
@@ -1,4 +1,10 @@
 class INSEE::RenewPassword < MakeRequest::Post
+  def call
+    super
+
+    fail_with_authentication_error! unless renewal_accepted?
+  end
+
   protected
 
   def request_uri
@@ -23,5 +29,16 @@ class INSEE::RenewPassword < MakeRequest::Post
 
   def sirene_base_path
     'api-sirene/prive/3.11'
+  end
+
+  private
+
+  def renewal_accepted?
+    context.response&.code&.to_i == 200
+  end
+
+  def fail_with_authentication_error!
+    context.errors << ProviderAuthenticationError.new(context.provider_name)
+    context.fail!
   end
 end

--- a/siade/spec/interactors/insee/make_request_spec.rb
+++ b/siade/spec/interactors/insee/make_request_spec.rb
@@ -277,6 +277,27 @@ RSpec.describe INSEE::MakeRequest, type: :interactor do
       end
     end
 
+    context 'when the renewal API rejects the old password (400)' do
+      let(:token) { jwt_token_with_pwd_changed_time('2026-08-15T10:00:00Z') }
+
+      before do
+        Timecop.freeze(Date.new(2026, 9, 15))
+        EncryptedCache.write('insee/authenticate', token)
+
+        stub_request(:get, /#{insee_sirene_url}/)
+          .to_return(status: 200, body: '{"uniteLegale":{}}')
+
+        stub_request(:post, renew_url)
+          .to_return(status: 400, body: '{"message":"Ancien mot de passe incorrect"}')
+      end
+
+      it 'does not invalidate the token cache' do
+        make_request
+
+        expect(EncryptedCache.read('insee/authenticate')).to eq(token)
+      end
+    end
+
     context 'when pwdChangedTime is in the current bimester' do
       let(:token) { jwt_token_with_pwd_changed_time('2026-09-10T10:00:00Z') }
 

--- a/siade/spec/interactors/insee/renew_password_spec.rb
+++ b/siade/spec/interactors/insee/renew_password_spec.rb
@@ -47,10 +47,14 @@ RSpec.describe INSEE::RenewPassword, type: :interactor do
         .to_return(status: 400, body: '{"message":"Ancien mot de passe incorrect"}')
     end
 
-    it { is_expected.to be_a_success }
+    it { is_expected.to be_a_failure }
 
     it 'returns the 400 response' do
       expect(renew.response.code).to eq('400')
+    end
+
+    it 'fails with a ProviderAuthenticationError' do
+      expect(renew.errors.first).to be_a(ProviderAuthenticationError)
     end
   end
 
@@ -60,7 +64,7 @@ RSpec.describe INSEE::RenewPassword, type: :interactor do
         .to_return(status: 400, body: '{"message":"Le mot de passe ne respecte pas les règles"}')
     end
 
-    it { is_expected.to be_a_success }
+    it { is_expected.to be_a_failure }
 
     it 'returns the 400 response' do
       expect(renew.response.code).to eq('400')

--- a/siade/spec/interactors/insee/renew_password_spec.rb
+++ b/siade/spec/interactors/insee/renew_password_spec.rb
@@ -56,6 +56,19 @@ RSpec.describe INSEE::RenewPassword, type: :interactor do
     it 'fails with a ProviderAuthenticationError' do
       expect(renew.errors.first).to be_a(ProviderAuthenticationError)
     end
+
+    it 'raises a Sentry alert' do
+      expect(MonitoringService.instance).to receive(:track_with_added_context).with(
+        'error',
+        'Fail to rotate INSEE password',
+        {
+          http_response_code: '400',
+          http_response_body: '{"message":"Ancien mot de passe incorrect"}'
+        }
+      )
+
+      renew
+    end
   end
 
   context 'when the new password is invalid (400)' do


### PR DESCRIPTION
rotate_password_if_needed! invalidated the cached auth token based on the RenewPassword interactor's success?, which stays true even on a non-2xx response (this codebase's convention: HTTP errors don't fail the interactor context, see renew_password_spec.rb). A renewal INSEE actually rejected (e.g. old password mismatch) still cleared the cache, so the next request would authenticate with a password INSEE never accepted -- feeding the existing blind 5x auth retry loop and risking the 5-failed-attempts/12h account lockout INSEE enforces (API-7157).

Check the actual HTTP response code instead.