### PR TITLE
Add France Travail mock: unemployed claimant registered in Paris

### DIFF
--- a/mocks/payloads/api_particulier_v3_france_travail_statut_with_identifiant/README.md
+++ b/mocks/payloads/api_particulier_v3_france_travail_statut_with_identifiant/README.md
@@ -666,3 +666,80 @@
 
   </p>
   </details>
+* [id_123463A_inscrit_paris.yaml](id_123463A_inscrit_paris.yaml)
+
+  Status `200`
+
+  Identifiant 123463A, inscrite, Paris
+
+  <details><summary>Paramètres</summary>
+  <p>
+
+  ```json
+  {
+    "identifiant": "123463A"
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Réponse API</summary>
+  <p>
+
+  ```json
+  {
+    "data": {
+      "identifiant": "123463A",
+      "identite": {
+        "civilite": "MME",
+        "nom_naissance": "Bercy",
+        "nom_usage": null,
+        "prenom": "Camille",
+        "sexe": "Féminin",
+        "date_naissance": "1988-03-12"
+      },
+      "contact": {
+        "email": "camille.bercy@fake.fr",
+        "telephone": "0601020304",
+        "telephone2": null
+      },
+      "adresse": {
+        "code_cog_insee_commune": "75112",
+        "code_postal": "75012",
+        "ligne_complement_adresse": null,
+        "ligne_complement_destinataire": "appt 337",
+        "ligne_complement_distribution": null,
+        "ligne_nom": "Bercy",
+        "ligne_voie": "227 rue de bercy ",
+        "localite": "75012 Paris"
+      },
+      "inscription": {
+        "date_debut": "2024-01-01",
+        "date_fin": null,
+        "code_certification_cnav": "VC",
+        "categorie": {
+          "code": 1,
+          "libelle": "PERSONNE SANS EMPLOI DISPONIBLE DUREE INDETERMINEE PLEIN TPS"
+        }
+      }
+    },
+    "links": {},
+    "meta": {}
+  }
+  ```
+
+  </p>
+  </details>
+
+  <details><summary>Commande cURL</summary>
+  <p>
+
+  ```bash
+  curl -H "Authorization: Bearer $token" \
+    -G -d 'recipient=13002526500013' -d 'identifiant=123463A' \
+    --url "https://staging.particulier.api.gouv.fr/v3/france_travail/statut/identifiant"
+  ```
+
+  </p>
+  </details>

--- a/mocks/payloads/api_particulier_v3_france_travail_statut_with_identifiant/id_123463A_inscrit_paris.yaml
+++ b/mocks/payloads/api_particulier_v3_france_travail_statut_with_identifiant/id_123463A_inscrit_paris.yaml
@@ -1,0 +1,45 @@
+---
+description: 'Identifiant 123463A, inscrite, Paris'
+params:
+  identifiant: '123463A'
+status: 200
+payload: |-
+  {
+    "data": {
+      "identifiant": "123463A",
+      "identite": {
+        "civilite": "MME",
+        "nom_naissance": "Bercy",
+        "nom_usage": null,
+        "prenom": "Camille",
+        "sexe": "Féminin",
+        "date_naissance": "1988-03-12"
+      },
+      "contact": {
+        "email": "camille.bercy@fake.fr",
+        "telephone": "0601020304",
+        "telephone2": null
+      },
+      "adresse": {
+        "code_cog_insee_commune": "75112",
+        "code_postal": "75012",
+        "ligne_complement_adresse": null,
+        "ligne_complement_destinataire": "appt 337",
+        "ligne_complement_distribution": null,
+        "ligne_nom": "Bercy",
+        "ligne_voie": "227 rue de bercy ",
+        "localite": "75012 Paris"
+      },
+      "inscription": {
+        "date_debut": "2024-01-01",
+        "date_fin": null,
+        "code_certification_cnav": "VC",
+        "categorie": {
+          "code": 1,
+          "libelle": "PERSONNE SANS EMPLOI DISPONIBLE DUREE INDETERMINEE PLEIN TPS"
+        }
+      }
+    },
+    "links": {},
+    "meta": {}
+  }

--- a/mocks/payloads/api_particulier_v3_france_travail_statut_with_identifiant/summary.csv
+++ b/mocks/payloads/api_particulier_v3_france_travail_statut_with_identifiant/summary.csv
@@ -324,3 +324,42 @@ Titre,Description,Paramètres,Status,Réponse
   ""links"": {},
   ""meta"": {}
 }"
+,"Identifiant 123463A, inscrite, Paris","{""identifiant"":""123463A""}",200,"{
+  ""data"": {
+    ""identifiant"": ""123463A"",
+    ""identite"": {
+      ""civilite"": ""MME"",
+      ""nom_naissance"": ""Bercy"",
+      ""nom_usage"": null,
+      ""prenom"": ""Camille"",
+      ""sexe"": ""Féminin"",
+      ""date_naissance"": ""1988-03-12""
+    },
+    ""contact"": {
+      ""email"": ""camille.bercy@fake.fr"",
+      ""telephone"": ""0601020304"",
+      ""telephone2"": null
+    },
+    ""adresse"": {
+      ""code_cog_insee_commune"": ""75112"",
+      ""code_postal"": ""75012"",
+      ""ligne_complement_adresse"": null,
+      ""ligne_complement_destinataire"": ""appt 337"",
+      ""ligne_complement_distribution"": null,
+      ""ligne_nom"": ""Bercy"",
+      ""ligne_voie"": ""227 rue de bercy "",
+      ""localite"": ""75012 Paris""
+    },
+    ""inscription"": {
+      ""date_debut"": ""2024-01-01"",
+      ""date_fin"": null,
+      ""code_certification_cnav"": ""VC"",
+      ""categorie"": {
+        ""code"": 1,
+        ""libelle"": ""PERSONNE SANS EMPLOI DISPONIBLE DUREE INDETERMINEE PLEIN TPS""
+      }
+    }
+  },
+  ""links"": {},
+  ""meta"": {}
+}"


### PR DESCRIPTION
## Summary
- Add a new `api_particulier_v3_france_travail_statut_with_identifiant` mock (`identifiant=123463A`) for a claimant registered as unemployed (catégorie 1) and domiciled in Paris 12e — the sandbox dataset only had Toulouse addresses for this category.
- Address fields (`75112`/`75012`, `227 rue de bercy`, `appt 337`, `75012 Paris`) match the client-supplied data verbatim.
- Regenerated `README.md`/`summary.csv` for the endpoint folder via `bin/generate_payload_readme.rb`.

## Test plan
- [x] `bundle exec rspec spec/acceptances/payloads_spec.rb -e api_particulier_v3_france_travail_statut_with_identifiant` — 60 examples, 0 failures