### PR TITLE
Harden Civility::ValidatePrenoms character validation

### DIFF
--- a/siade/app/interactors/concerns/validate_prenoms_format.rb
+++ b/siade/app/interactors/concerns/validate_prenoms_format.rb
@@ -4,6 +4,7 @@ module ValidatePrenomsFormat
   def valid_prenoms_format?
     param(:prenoms) == [*param(:prenoms)] &&
       !param(:prenoms).empty? &&
-      param(:prenoms).none? { |p| String.try_convert(p).nil? }
+      param(:prenoms).none? { |p| String.try_convert(p).nil? } &&
+      param(:prenoms).none? { |p| p.include?(',') }
   end
 end

--- a/siade/spec/interactors/civility/validate_prenoms_spec.rb
+++ b/siade/spec/interactors/civility/validate_prenoms_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe Civility::ValidatePrenoms, type: :validate_params do
     its(:errors) { is_expected.to be_empty }
   end
 
+  context 'when a prenom is a comma-separated composite name' do
+    let(:prenoms) { ['LILY-ROSE, CLARA'] }
+
+    it { is_expected.to be_a_failure }
+
+    its(:errors) { is_expected.to include(instance_of(UnprocessableEntityError)) }
+  end
+
   context 'with invalid user_id' do
     context 'when prenoms is empty' do
       let(:prenoms) { [] }


### PR DESCRIPTION
 A production MEN Scolarites request forwarded `prenoms: ["LILY-ROSE, CLARA"]` (two given names joined by a comma in one array element instead of split across two) straight to the provider, which rejected it with an opaque 400.

Adding change for all FDs to standardize / we never want comma in the prenoms 

fix https://errors.data.gouv.fr/organizations/sentry/issues/296639/events/oldest/?project=8&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=oldest-event&statsPeriod=1h&stream_index=0

