### PR TITLE
fix: route all datagouv sync logging through the dedicated log file

### DIFF
--- a/site/app/jobs/datagouv/sync_fiches_job.rb
+++ b/site/app/jobs/datagouv/sync_fiches_job.rb
@@ -5,14 +5,17 @@ module Datagouv
     retry_on StandardError, wait: :polynomially_longer, attempts: 5
 
     def perform
-      return unless acquire_lock!
+      unless acquire_lock!
+        logger.info('lock already held, skipping this run')
+        return
+      end
 
       begin
-        logger.info('Start syncing fiches with data.gouv.fr')
+        logger.info('start')
 
-        result = SyncRunner.new(endpoints).call
+        result = SyncRunner.new(endpoints, logger: logger).call
 
-        logger.info("End syncing fiches with data.gouv.fr (#{result ? 'success' : 'with failures'})")
+        logger.info("end (#{result ? 'success' : 'with failures'})")
       ensure
         release_lock!
       end

--- a/site/app/services/datagouv/dataservice_index.rb
+++ b/site/app/services/datagouv/dataservice_index.rb
@@ -8,6 +8,8 @@ module Datagouv
       by_business_url[FichePayloadBuilder.new(endpoint).business_documentation_url]
     end
 
+    delegate :size, to: :dataservices
+
     private
 
     attr_reader :dataservices

--- a/site/app/services/datagouv/sync_fiche.rb
+++ b/site/app/services/datagouv/sync_fiche.rb
@@ -2,10 +2,11 @@ module Datagouv
   class SyncFiche
     Result = Struct.new(:status, :uid, :remote_id, keyword_init: true)
 
-    def initialize(endpoint, index:, client: DatagouvAPIClient.new)
+    def initialize(endpoint, index:, client: DatagouvAPIClient.new, logger: Rails.logger)
       @endpoint = endpoint
       @index = index
       @client = client
+      @logger = logger
     end
 
     def call
@@ -19,7 +20,7 @@ module Datagouv
 
     private
 
-    attr_reader :endpoint, :index, :client
+    attr_reader :endpoint, :index, :client, :logger
 
     def skipped_result
       result(:skipped)
@@ -70,7 +71,7 @@ module Datagouv
     end
 
     def failed_result(error)
-      Rails.logger.error("Datagouv::SyncFiche: #{endpoint.uid} failed - #{error.message}")
+      logger.error("SyncFiche: #{endpoint.uid} failed - #{error.class}: #{error.message}")
       result(:failed)
     end
 

--- a/site/app/services/datagouv/sync_runner.rb
+++ b/site/app/services/datagouv/sync_runner.rb
@@ -1,7 +1,8 @@
 module Datagouv
   class SyncRunner
-    def initialize(endpoints)
+    def initialize(endpoints, logger: Rails.logger)
       @endpoints = endpoints
+      @logger = logger
     end
 
     def call
@@ -9,29 +10,37 @@ module Datagouv
       return false if index.nil?
 
       results = endpoints.map { |endpoint| sync_one(endpoint, index) }
+      logger.info("SyncRunner: #{summary(results)}")
       results.none? { |result| result.status == :failed }
     end
 
     private
 
-    attr_reader :endpoints
+    attr_reader :endpoints, :logger
 
     def build_index
-      DataserviceIndex.new
+      index = DataserviceIndex.new
+      logger.info("SyncRunner: matched against #{index.size} existing remote dataservices")
+      index
     rescue Faraday::Error => e
-      Rails.logger.error("Datagouv::SyncRunner: failed to list dataservices - #{e.message}")
+      logger.error("SyncRunner: failed to list dataservices - #{e.message}")
       nil
     end
 
+    def summary(results)
+      counts = results.group_by(&:status).transform_values(&:size)
+      "#{results.size} endpoints processed - #{counts.map { |status, count| "#{status}: #{count}" }.join(', ')}"
+    end
+
     def sync_one(endpoint, index)
-      result = SyncFiche.new(endpoint, index: index).call
-      Rails.logger.info(log_message(result))
+      result = SyncFiche.new(endpoint, index: index, logger: logger).call
+      logger.info(log_message(result))
       result
     end
 
     def log_message(result)
       suffix = result.remote_id ? " (#{result.remote_id})" : ''
-      "Datagouv::SyncRunner: #{result.uid} -> #{result.status}#{suffix}"
+      "SyncRunner: #{result.uid} -> #{result.status}#{suffix}"
     end
   end
 end

--- a/site/spec/jobs/datagouv/sync_fiches_job_spec.rb
+++ b/site/spec/jobs/datagouv/sync_fiches_job_spec.rb
@@ -33,12 +33,21 @@ RSpec.describe Datagouv::SyncFichesJob do
     end
 
     context 'when the lock is already held' do
-      before { Rails.cache.write('datagouv_sync_in_progress', true, namespace: described_class::LOCK_NAMESPACE) }
+      before do
+        Rails.cache.write('datagouv_sync_in_progress', true, namespace: described_class::LOCK_NAMESPACE)
+        FileUtils.touch(Rails.root.join('log/datagouv.log').to_s)
+      end
 
       it 'does not run the sync' do
         perform
 
         expect(Datagouv::SyncRunner).not_to have_received(:new)
+      end
+
+      it 'logs that the run was skipped, so a stuck lock is visible instead of silent' do
+        expect {
+          perform
+        }.to(change { File.read(Rails.root.join('log/datagouv.log').to_s) })
       end
     end
 

--- a/site/spec/services/datagouv/sync_runner_spec.rb
+++ b/site/spec/services/datagouv/sync_runner_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe Datagouv::SyncRunner do
 
   let(:endpoint) { APIEntreprise::Endpoint.find('inpi/rne/beneficiaires_effectifs') }
   let(:endpoints) { [endpoint] }
-  let(:index) { instance_double(Datagouv::DataserviceIndex) }
+  let(:index) { instance_double(Datagouv::DataserviceIndex, size: 1) }
   let(:sync_fiche) { instance_double(Datagouv::SyncFiche) }
 
   before do
     allow(Datagouv::DataserviceIndex).to receive(:new).and_return(index)
-    allow(Datagouv::SyncFiche).to receive(:new).with(endpoint, index: index).and_return(sync_fiche)
+    allow(Datagouv::SyncFiche).to receive(:new).with(endpoint, index: index, logger: Rails.logger).and_return(sync_fiche)
   end
 
   context 'when the fiche is created' do
@@ -23,7 +23,22 @@ RSpec.describe Datagouv::SyncRunner do
     end
 
     it 'logs the outcome including the remote_id' do
-      expect(Rails.logger).to receive(:info).with("Datagouv::SyncRunner: #{endpoint.uid} -> created (new-id)")
+      allow(Rails.logger).to receive(:info)
+      expect(Rails.logger).to receive(:info).with("SyncRunner: #{endpoint.uid} -> created (new-id)")
+
+      run
+    end
+
+    it 'logs how many existing remote dataservices the index matched against' do
+      allow(Rails.logger).to receive(:info)
+      expect(Rails.logger).to receive(:info).with('SyncRunner: matched against 1 existing remote dataservices')
+
+      run
+    end
+
+    it 'logs a summary of results by status' do
+      allow(Rails.logger).to receive(:info)
+      expect(Rails.logger).to receive(:info).with('SyncRunner: 1 endpoints processed - created: 1')
 
       run
     end
@@ -39,7 +54,8 @@ RSpec.describe Datagouv::SyncRunner do
     end
 
     it 'logs the outcome without a remote_id suffix' do
-      expect(Rails.logger).to receive(:info).with("Datagouv::SyncRunner: #{endpoint.uid} -> deleted")
+      allow(Rails.logger).to receive(:info)
+      expect(Rails.logger).to receive(:info).with("SyncRunner: #{endpoint.uid} -> deleted")
 
       run
     end
@@ -83,7 +99,7 @@ RSpec.describe Datagouv::SyncRunner do
     let(:other_result) { Datagouv::SyncFiche::Result.new(status: :failed, uid: other_endpoint.uid, remote_id: nil) }
 
     before do
-      allow(Datagouv::SyncFiche).to receive(:new).with(other_endpoint, index: index).and_return(other_sync_fiche)
+      allow(Datagouv::SyncFiche).to receive(:new).with(other_endpoint, index: index, logger: Rails.logger).and_return(other_sync_fiche)
       allow(sync_fiche).to receive(:call).and_return(result)
       allow(other_sync_fiche).to receive(:call).and_return(other_result)
     end


### PR DESCRIPTION
## Summary

Follow-up on debugging \"job executed successfully but nothing seems to have synced\" in production.

Turned out `Datagouv::SyncFichesJob`'s own start/end lines went to the dedicated `log/datagouv.log`, but `SyncRunner`/`SyncFiche` logged per-endpoint results, the dataservice-index match count, and failures to `Rails.logger` instead — a different destination. Checking `log/datagouv.log` (the obviously-named place to look) only ever showed "start" / "end (success)", with none of the detail needed to tell whether anything actually changed.

- Injects the job's logger down through `SyncRunner` into `SyncFiche` so every datagouv-related log line lands in `log/datagouv.log`.
- `SyncFichesJob` now logs when it skips a run because the lock is already held — previously silent, indistinguishable from "nothing to sync."
- `SyncRunner` now also logs how many existing remote dataservices the index matched against, and a per-run summary of results by status (e.g. `74 endpoints processed - unchanged: 70, created: 3, updated: 1`), on top of the existing per-endpoint line.

## Test plan
- [x] Added specs for the lock-skip log line and the new match-count/summary log lines
- [x] Full `datagouv` spec suite + rubocop clean