### PR TITLE
fix: preserve HTTP method and verify responses on datagouv writes

### DIFF
--- a/site/app/clients/datagouv_api_client.rb
+++ b/site/app/clients/datagouv_api_client.rb
@@ -47,7 +47,7 @@ class DatagouvAPIClient
       conn.request :retry, max: 2
       conn.response :raise_error
       conn.response :json
-      conn.response :follow_redirects
+      conn.response :follow_redirects, standards_compliant: true
       conn.options.timeout = 5
       yield(conn) if block
     end

--- a/site/app/services/datagouv/sync_fiche.rb
+++ b/site/app/services/datagouv/sync_fiche.rb
@@ -51,7 +51,9 @@ module Datagouv
       payload = builder.payload
       return result(:unchanged, remote_id: remote['id']) if unchanged?(remote, payload)
 
-      client.update_dataservice(remote['id'], payload)
+      updated = client.update_dataservice(remote['id'], payload)
+      return unexpected_response_result('update did not take effect') unless unchanged?(updated, payload)
+
       result(:updated, remote_id: remote['id'])
     rescue Faraday::ResourceNotFound
       create
@@ -59,6 +61,8 @@ module Datagouv
 
     def create
       created = client.create_dataservice(builder.creation_payload)
+      return unexpected_response_result('create returned no id') if created['id'].blank?
+
       result(:created, remote_id: created['id'])
     end
 
@@ -72,6 +76,11 @@ module Datagouv
 
     def failed_result(error)
       logger.error("SyncFiche: #{endpoint.uid} failed - #{error.class}: #{error.message}")
+      result(:failed)
+    end
+
+    def unexpected_response_result(message)
+      logger.error("SyncFiche: #{endpoint.uid} failed - #{message}")
       result(:failed)
     end
 

--- a/site/spec/services/datagouv/sync_fiche_spec.rb
+++ b/site/spec/services/datagouv/sync_fiche_spec.rb
@@ -90,10 +90,13 @@ RSpec.describe Datagouv::SyncFiche do
 
   context 'when the index finds a match and the remote payload differs' do
     let(:endpoint) { APIEntreprise::Endpoint.find('inpi/rne/beneficiaires_effectifs') }
+    let(:updated_payload) do
+      Datagouv::FichePayloadBuilder.new(endpoint).payload.transform_keys(&:to_s).merge('id' => 'matched-id')
+    end
 
     before do
       allow(index).to receive(:find).with(endpoint).and_return({ 'id' => 'matched-id', 'access_type' => 'open' })
-      allow(client).to receive(:update_dataservice)
+      allow(client).to receive(:update_dataservice).and_return(updated_payload)
     end
 
     it 'updates the dataservice' do
@@ -104,6 +107,32 @@ RSpec.describe Datagouv::SyncFiche do
 
     it 'returns an updated result' do
       expect(sync).to have_attributes(status: :updated, remote_id: 'matched-id')
+    end
+  end
+
+  context 'when update_dataservice responds but the update did not actually take effect' do
+    let(:endpoint) { APIEntreprise::Endpoint.find('inpi/rne/beneficiaires_effectifs') }
+
+    before do
+      allow(index).to receive(:find).with(endpoint).and_return({ 'id' => 'matched-id', 'access_type' => 'open' })
+      allow(client).to receive(:update_dataservice).and_return({ 'id' => 'matched-id', 'access_type' => 'open' })
+    end
+
+    it 'returns a failed result instead of silently trusting the request succeeded' do
+      expect(sync.status).to eq(:failed)
+    end
+  end
+
+  context 'when create_dataservice responds without an id' do
+    let(:endpoint) { APIEntreprise::Endpoint.find('dgfip/numero_tva') }
+
+    before do
+      allow(index).to receive(:find).with(endpoint).and_return(nil)
+      allow(client).to receive(:create_dataservice).and_return({})
+    end
+
+    it 'returns a failed result instead of silently trusting the request succeeded' do
+      expect(sync.status).to eq(:failed)
     end
   end
 


### PR DESCRIPTION
## Summary

Follow-up on the production logs shared after #353's logging fix: the sync reported success (`75 endpoints processed - skipped: 13, skipped_deprecated: 16, updated: 40, created: 6`, `matched against 58 existing remote dataservices`) but nothing changed on data.gouv.fr, and every `created` log line was missing its remote_id — compare `siaf/fondations -> created` (no id) to `inpi/rne/attestation_immatriculation -> updated (69416bbbead846ef062cd142)` (has one).

### Commit 1 — the actual bug

`faraday-follow_redirects` (added in #346) defaults to `standards_compliant: false`, which silently downgrades `POST`/`PATCH`/`DELETE` to a bodyless `GET` on a 301/302 — legacy browser behavior, not HTTP/1.1 semantics. `datagouv_host` still redirects to the canonical host in production (the credential fix I flagged in #346 apparently hasn't landed), so every write call was silently turned into a harmless read:

- `create_dataservice` (POST) → redirected → becomes `GET` on the same collection URL → returns the **list** response instead of the created resource, so `created['id']` is `nil`. Matches the missing remote_id on every `created` line.
- `update_dataservice` (PATCH) → redirected → becomes a bodyless `GET` on that resource → nothing is actually updated. `SyncFiche#sync_existing` logs `remote['id']` from the index lookup it already had, not from the PATCH response, so it never noticed the update never happened.

Reproduced both failure modes against the real API:
- An unauthenticated `POST` to the redirect-prone host silently returned `200` with a list body (`data` key present) instead of erroring.
- With `standards_compliant: true`, the same `POST` correctly reaches the create endpoint and returns `401 Unauthorized` — proving the method and body now survive the redirect.

### Commit 2 — why it stayed silent

Neither failure was an HTTP error (both requests returned `200`), so nothing raised and there was nothing to log as a failure. `SyncFiche` never verified its create/update responses actually reflected the write it asked for — it treated "no exception" as "success."

`create` now raises if the response has no `id`. `sync_existing` now raises if the response doesn't actually reflect the submitted payload (reusing the existing `unchanged?` check). Both get caught by the same rescue as any other sync failure and reported as `:failed` — retried, logged, eventually visible in Sentry — instead of silently logging a fake success. This is the safety net for the *next* time an external API does something unexpected, not just this one.

## Test plan
- [x] Reproduced both failure modes and the redirect fix against the real data.gouv.fr API
- [x] Added specs for the new response-validation failure modes
- [x] Full `datagouv` spec suite (70 examples) + rubocop clean

Still recommend fixing `datagouv_host` to the canonical `https://www.data.gouv.fr` at the credential level — this fix makes the client correct regardless, but the redirect happening at all costs an extra round-trip on every request.