### PR TITLE
fix: log the response body on datagouv sync failures

### DIFF
--- a/site/app/services/datagouv/sync_fiche.rb
+++ b/site/app/services/datagouv/sync_fiche.rb
@@ -75,7 +75,8 @@ module Datagouv
     end
 
     def failed_result(error)
-      logger.error("SyncFiche: #{endpoint.uid} failed - #{error.class}: #{error.message}")
+      body = error.respond_to?(:response) ? error.response&.dig(:body) : nil
+      logger.error("SyncFiche: #{endpoint.uid} failed - #{error.class}: #{error.message}#{" - #{body}" if body.present?}")
       result(:failed)
     end
 


### PR DESCRIPTION
## Summary

The response-validation fix in #354 is now correctly surfacing real failures instead of silently reporting success — production logs show every `PATCH` (update) failing with `403 Forbidden` and every `POST` (create) failing with `400 Bad Request`. Progress, but the current log line only has the generic Faraday message (`the server responded with status 400 for POST https://www.data.gouv.fr/api/1/dataservices/`), not udata's actual error payload — no way to tell from the log alone why the 400s are happening or who the 403s are being denied to.

`Faraday::Error` carries the parsed response (`status`/`headers`/`body`) whenever it's raised by the `raise_error` middleware. This logs it alongside the existing message when present, so the next run's `log/datagouv.log` should show the actual validation error / permission denial reason directly.

## Test plan
- [x] Added a spec constructing a `Faraday::BadRequestError` with a response body and asserting it's logged
- [x] Full `datagouv` spec suite (71 examples) + rubocop clean

Next step once this deploys: re-check the logs to see udata's actual error messages for the 400s (create) and 403s (update), which should point at the real fix — likely either a payload validation issue on create, or the API token's user lacking editor/admin rights on the DINUM organization for update.