### PR TITLE
Harden token management for DataSubvention

### DIFF
--- a/siade/app/interactors/abstract_get_token.rb
+++ b/siade/app/interactors/abstract_get_token.rb
@@ -2,10 +2,18 @@ class AbstractGetToken < MakeRequest::Post
   MAX_AUTH_ATTEMPTS = 5
   AUTH_RETRY_DELAY = 0.2
 
+  def self.invalidate_cached_token!
+    new.invalidate_cached_token!
+  end
+
   def call
     return if use_mocked_data?
 
     context.token = token_from_cache || retrieve_and_save_token
+  end
+
+  def invalidate_cached_token!
+    cache.write(cache_key, nil)
   end
 
   protected

--- a/siade/app/interactors/data_subvention/subventions/authenticate.rb
+++ b/siade/app/interactors/data_subvention/subventions/authenticate.rb
@@ -11,7 +11,9 @@ class DataSubvention::Subventions::Authenticate < AbstractGetToken
   end
 
   def expires_in(response)
-    JSON.parse(response.body).dig('user', 'jwt', 'expirateDate')
+    expiration_date = JSON.parse(response.body).dig('user', 'jwt', 'expirateDate')
+
+    Time.zone.parse(expiration_date.to_s).to_i - Time.now.to_i
   end
 
   def client_url

--- a/siade/app/interactors/data_subvention/subventions/make_request.rb
+++ b/siade/app/interactors/data_subvention/subventions/make_request.rb
@@ -8,10 +8,7 @@ class DataSubvention::Subventions::MakeRequest < MakeRequest::Get
 
     return response unless stale_token_rejected?
 
-    context.token_renewed = true
-
-    DataSubvention::Subventions::Authenticate.invalidate_cached_token!
-    DataSubvention::Subventions::Authenticate.call!(context)
+    reauthenticate
 
     super
   end
@@ -33,6 +30,13 @@ class DataSubvention::Subventions::MakeRequest < MakeRequest::Get
 
   def stale_token_rejected?
     context.token_renewed.blank? && http_unauthorized?
+  end
+
+  def reauthenticate
+    context.token_renewed = true
+
+    DataSubvention::Subventions::Authenticate.invalidate_cached_token!
+    DataSubvention::Subventions::Authenticate.call!(context)
   end
 
   def data_subvention_token

--- a/siade/app/interactors/data_subvention/subventions/make_request.rb
+++ b/siade/app/interactors/data_subvention/subventions/make_request.rb
@@ -1,5 +1,20 @@
 class DataSubvention::Subventions::MakeRequest < MakeRequest::Get
+  include ResourceHelpers
+
   protected
+
+  def api_call_with_error_handling
+    response = super
+
+    return response unless stale_token_rejected?
+
+    context.token_renewed = true
+
+    DataSubvention::Subventions::Authenticate.invalidate_cached_token!
+    DataSubvention::Subventions::Authenticate.call!(context)
+
+    super
+  end
 
   def request_uri
     URI("#{data_subvention_url}/association/#{context.params[:siren_or_siret_or_rna]}/grants")
@@ -15,6 +30,10 @@ class DataSubvention::Subventions::MakeRequest < MakeRequest::Get
   end
 
   private
+
+  def stale_token_rejected?
+    context.token_renewed.blank? && http_unauthorized?
+  end
 
   def data_subvention_token
     context.token

--- a/siade/spec/interactors/data_subvention/subventions/authenticate_spec.rb
+++ b/siade/spec/interactors/data_subvention/subventions/authenticate_spec.rb
@@ -13,6 +13,30 @@ RSpec.describe DataSubvention::Subventions::Authenticate, type: :interactor do
     end
   end
 
+  context 'when the provider replies with an expiration date' do
+    let(:expiration_date) { 2.days.from_now }
+    let(:payload) do
+      JSON.parse(read_payload_file('data_subvention/subventions/authenticate.json')).tap { |body|
+        body['user']['jwt']['expirateDate'] = expiration_date.iso8601(3)
+      }.to_json
+    end
+
+    before do
+      stub_request(:post, "#{Siade.credentials[:data_subvention_url]}/auth/login")
+        .to_return(status: 200, body: payload)
+    end
+
+    it 'caches the token up to that date' do
+      expect(EncryptedCache.instance).to receive(:write).with(
+        :'data_subvention/subventions/authenticate',
+        'data_subvention_token',
+        expires_in: be_within(5).of(2.days.to_i - 10)
+      )
+
+      subject
+    end
+  end
+
   context 'when provider is down and replies with valid JSON missing the user/jwt structure' do
     before do
       stub_request(:post, "#{Siade.credentials[:data_subvention_url]}/auth/login")

--- a/siade/spec/interactors/data_subvention/subventions/make_request_spec.rb
+++ b/siade/spec/interactors/data_subvention/subventions/make_request_spec.rb
@@ -26,5 +26,45 @@ RSpec.describe DataSubvention::Subventions::MakeRequest, type: :make_request do
 
       its(:response) { is_expected.to be_a(Net::HTTPOK) }
     end
+
+    context 'when the provider rejected the cached token' do
+      let(:id) { valid_siren }
+      let(:token) { 'stale_data_subvention_token' }
+
+      let!(:stubbed_rejected_request) { stub_datasubvention_subventions_stale_token(id:) }
+      let!(:stubbed_authenticate) { stub_datasubvention_subventions_authenticate }
+      let!(:stubbed_request) { stub_datasubvention_subventions_valid(id:) }
+
+      it { is_expected.to be_a_success }
+
+      its(:response) { is_expected.to be_a(Net::HTTPOK) }
+
+      it 'replays the call once with a freshly retrieved token' do
+        subject
+
+        expect(stubbed_rejected_request).to have_been_made.once
+        expect(stubbed_authenticate).to have_been_made.once
+        expect(stubbed_request).to have_been_made.once
+      end
+    end
+
+    context 'when the provider keeps rejecting a freshly retrieved token' do
+      let(:id) { valid_siren }
+      let(:token) { 'stale_data_subvention_token' }
+
+      let!(:stubbed_authenticate) { stub_datasubvention_subventions_authenticate }
+      let!(:stubbed_rejected_request) { stub_datasubvention_subventions_stale_token(id:) }
+      let!(:stubbed_rejected_retry) { stub_datasubvention_subventions_stale_token(id:, token: 'data_subvention_token') }
+
+      it 'does not loop over authentication' do
+        subject
+
+        expect(stubbed_authenticate).to have_been_made.once
+        expect(stubbed_rejected_request).to have_been_made.once
+        expect(stubbed_rejected_retry).to have_been_made.once
+      end
+
+      its(:response) { is_expected.to be_a(Net::HTTPUnauthorized) }
+    end
   end
 end

--- a/siade/spec/support/provider_stubs/data_subvention.rb
+++ b/siade/spec/support/provider_stubs/data_subvention.rb
@@ -29,6 +29,20 @@ module ProviderStubs::DataSubvention
       )
   end
 
+  def stub_datasubvention_subventions_stale_token(id: valid_siren, token: 'stale_data_subvention_token')
+    stub_request(:get, "#{Siade.credentials[:data_subvention_url]}/association/#{id}/grants")
+      .with(
+        headers: {
+          'x-access-token' => token,
+          'Content-Type' => 'application/json'
+        }
+      )
+      .to_return(
+        status: 401,
+        body: '{"message":"User not logged"}'
+      )
+  end
+
   def stub_datasubvention_subventions_valid(id: valid_siren, token: 'data_subvention_token')
     stub_request(:get, "#{Siade.credentials[:data_subvention_url]}/association/#{id}/grants")
       .with(


### PR DESCRIPTION
Fix sentry issue https://errors.data.gouv.fr/organizations/sentry/issues/296912/, checked the source code from DataSubvention.

Not a big issue, not currently used by any consumers right now.

More info in commit messages.