### PR TITLE
Allow CNOUS `campaignYear` on upcoming campaigns

### DIFF
--- a/commons/endpoints/_swagger_shared/cnous.yml
+++ b/commons/endpoints/_swagger_shared/cnous.yml
@@ -184,9 +184,11 @@ cnous:
         description: |+
           **Année de référence de la campagne scolaire** (paramètre optionnel).
 
-          Année de début de la campagne scolaire recherchée. Par exemple, l'année scolaire 2025-2026 est représentée par `2025`.
+          Année de début de la campagne scolaire recherchée : l'année `N` correspond à l'année scolaire `N`/`N+1`. Par exemple, l'année scolaire 2025-2026 est représentée par `2025`.
 
           Les données sont disponibles à partir de la campagne 2021-2022. La fiabilité des données augmente avec les années, notamment car les imports régionaux étaient moins fréquents lors des premières campagnes.
+
+          Aucune borne haute n'est appliquée : la campagne en cours, comme une campagne à venir, peut être interrogée en anticipation, par exemple pour instruire dès le printemps des demandes portant sur la rentrée suivante. Les bourses régionales de la campagne suivante sont disponibles à partir du mois de mai, les bourses nationales à partir du mois de juillet. La base contient environ 85% des boursiers en octobre et est considérée comme complète en fin novembre : une campagne récente peut donc renvoyer un dossier absent ou partiel alors que l'étudiant est bien boursier.
 
           En l'absence de ce paramètre, l'API recherche une bourse valide pour l'étudiant ; si plusieurs résultats existent, elle renvoie la bourse la plus récente en priorité.
         minimum: 2021

--- a/commons/endpoints/api_particulier/cnous_student_scholarship.yml
+++ b/commons/endpoints/api_particulier/cnous_student_scholarship.yml
@@ -52,8 +52,9 @@ fiche:
 
         **Paramètre additionnel optionnel** :
         `campaignYear` permet de cibler une année scolaire précise lors de la recherche du dossier étudiant.
-        La valeur correspond à l'**année de début de la campagne scolaire** (exemple : `campaignYear=2025` pour l'année scolaire 2025-2026).
+        La valeur correspond à l'**année de début de la campagne scolaire** : l'année `N` désigne l'année scolaire `N`/`N+1` (exemple : `campaignYear=2025` pour l'année scolaire 2025-2026).
         Les données sont disponibles à partir de la campagne 2021-2022.
+        Aucune borne haute n'est appliquée : la campagne en cours comme une campagne à venir peuvent être interrogées en anticipation, avant d'être complètes. Les bourses régionales remontent à partir de mai, les bourses nationales à partir de juillet : une campagne récente peut donc renvoyer un dossier absent ou partiel alors que l'étudiant est bien boursier.
         En l'absence de ce paramètre, l'API renvoie la bourse valide la plus récente.
     data: &cnous_data
       description: |+

--- a/commons/swagger/openapi-particulier.yaml
+++ b/commons/swagger/openapi-particulier.yaml
@@ -11446,9 +11446,11 @@ paths:
         description: |
           **Année de référence de la campagne scolaire** (paramètre optionnel).
 
-          Année de début de la campagne scolaire recherchée. Par exemple, l'année scolaire 2025-2026 est représentée par `2025`.
+          Année de début de la campagne scolaire recherchée : l'année `N` correspond à l'année scolaire `N`/`N+1`. Par exemple, l'année scolaire 2025-2026 est représentée par `2025`.
 
           Les données sont disponibles à partir de la campagne 2021-2022. La fiabilité des données augmente avec les années, notamment car les imports régionaux étaient moins fréquents lors des premières campagnes.
+
+          Aucune borne haute n'est appliquée : la campagne en cours, comme une campagne à venir, peut être interrogée en anticipation, par exemple pour instruire dès le printemps des demandes portant sur la rentrée suivante. Les bourses régionales de la campagne suivante sont disponibles à partir du mois de mai, les bourses nationales à partir du mois de juillet. La base contient environ 85% des boursiers en octobre et est considérée comme complète en fin novembre : une campagne récente peut donc renvoyer un dossier absent ou partiel alors que l'étudiant est bien boursier.
 
           En l'absence de ce paramètre, l'API recherche une bourse valide pour l'étudiant ; si plusieurs résultats existent, elle renvoie la bourse la plus récente en priorité.
         example: 2024
@@ -11842,9 +11844,11 @@ paths:
         description: |
           **Année de référence de la campagne scolaire** (paramètre optionnel).
 
-          Année de début de la campagne scolaire recherchée. Par exemple, l'année scolaire 2025-2026 est représentée par `2025`.
+          Année de début de la campagne scolaire recherchée : l'année `N` correspond à l'année scolaire `N`/`N+1`. Par exemple, l'année scolaire 2025-2026 est représentée par `2025`.
 
           Les données sont disponibles à partir de la campagne 2021-2022. La fiabilité des données augmente avec les années, notamment car les imports régionaux étaient moins fréquents lors des premières campagnes.
+
+          Aucune borne haute n'est appliquée : la campagne en cours, comme une campagne à venir, peut être interrogée en anticipation, par exemple pour instruire dès le printemps des demandes portant sur la rentrée suivante. Les bourses régionales de la campagne suivante sont disponibles à partir du mois de mai, les bourses nationales à partir du mois de juillet. La base contient environ 85% des boursiers en octobre et est considérée comme complète en fin novembre : une campagne récente peut donc renvoyer un dossier absent ou partiel alors que l'étudiant est bien boursier.
 
           En l'absence de ce paramètre, l'API recherche une bourse valide pour l'étudiant ; si plusieurs résultats existent, elle renvoie la bourse la plus récente en priorité.
         example: 2024
@@ -12194,9 +12198,11 @@ paths:
         description: |
           **Année de référence de la campagne scolaire** (paramètre optionnel).
 
-          Année de début de la campagne scolaire recherchée. Par exemple, l'année scolaire 2025-2026 est représentée par `2025`.
+          Année de début de la campagne scolaire recherchée : l'année `N` correspond à l'année scolaire `N`/`N+1`. Par exemple, l'année scolaire 2025-2026 est représentée par `2025`.
 
           Les données sont disponibles à partir de la campagne 2021-2022. La fiabilité des données augmente avec les années, notamment car les imports régionaux étaient moins fréquents lors des premières campagnes.
+
+          Aucune borne haute n'est appliquée : la campagne en cours, comme une campagne à venir, peut être interrogée en anticipation, par exemple pour instruire dès le printemps des demandes portant sur la rentrée suivante. Les bourses régionales de la campagne suivante sont disponibles à partir du mois de mai, les bourses nationales à partir du mois de juillet. La base contient environ 85% des boursiers en octobre et est considérée comme complète en fin novembre : une campagne récente peut donc renvoyer un dossier absent ou partiel alors que l'étudiant est bien boursier.
 
           En l'absence de ce paramètre, l'API recherche une bourse valide pour l'étudiant ; si plusieurs résultats existent, elle renvoie la bourse la plus récente en priorité.
         example: 2024
@@ -12704,9 +12710,11 @@ paths:
         description: |
           **Année de référence de la campagne scolaire** (paramètre optionnel).
 
-          Année de début de la campagne scolaire recherchée. Par exemple, l'année scolaire 2025-2026 est représentée par `2025`.
+          Année de début de la campagne scolaire recherchée : l'année `N` correspond à l'année scolaire `N`/`N+1`. Par exemple, l'année scolaire 2025-2026 est représentée par `2025`.
 
           Les données sont disponibles à partir de la campagne 2021-2022. La fiabilité des données augmente avec les années, notamment car les imports régionaux étaient moins fréquents lors des premières campagnes.
+
+          Aucune borne haute n'est appliquée : la campagne en cours, comme une campagne à venir, peut être interrogée en anticipation, par exemple pour instruire dès le printemps des demandes portant sur la rentrée suivante. Les bourses régionales de la campagne suivante sont disponibles à partir du mois de mai, les bourses nationales à partir du mois de juillet. La base contient environ 85% des boursiers en octobre et est considérée comme complète en fin novembre : une campagne récente peut donc renvoyer un dossier absent ou partiel alors que l'étudiant est bien boursier.
 
           En l'absence de ce paramètre, l'API recherche une bourse valide pour l'étudiant ; si plusieurs résultats existent, elle renvoie la bourse la plus récente en priorité.
         example: 2024
@@ -13107,9 +13115,11 @@ paths:
         description: |
           **Année de référence de la campagne scolaire** (paramètre optionnel).
 
-          Année de début de la campagne scolaire recherchée. Par exemple, l'année scolaire 2025-2026 est représentée par `2025`.
+          Année de début de la campagne scolaire recherchée : l'année `N` correspond à l'année scolaire `N`/`N+1`. Par exemple, l'année scolaire 2025-2026 est représentée par `2025`.
 
           Les données sont disponibles à partir de la campagne 2021-2022. La fiabilité des données augmente avec les années, notamment car les imports régionaux étaient moins fréquents lors des premières campagnes.
+
+          Aucune borne haute n'est appliquée : la campagne en cours, comme une campagne à venir, peut être interrogée en anticipation, par exemple pour instruire dès le printemps des demandes portant sur la rentrée suivante. Les bourses régionales de la campagne suivante sont disponibles à partir du mois de mai, les bourses nationales à partir du mois de juillet. La base contient environ 85% des boursiers en octobre et est considérée comme complète en fin novembre : une campagne récente peut donc renvoyer un dossier absent ou partiel alors que l'étudiant est bien boursier.
 
           En l'absence de ce paramètre, l'API recherche une bourse valide pour l'étudiant ; si plusieurs résultats existent, elle renvoie la bourse la plus récente en priorité.
         example: 2024
@@ -13466,9 +13476,11 @@ paths:
         description: |
           **Année de référence de la campagne scolaire** (paramètre optionnel).
 
-          Année de début de la campagne scolaire recherchée. Par exemple, l'année scolaire 2025-2026 est représentée par `2025`.
+          Année de début de la campagne scolaire recherchée : l'année `N` correspond à l'année scolaire `N`/`N+1`. Par exemple, l'année scolaire 2025-2026 est représentée par `2025`.
 
           Les données sont disponibles à partir de la campagne 2021-2022. La fiabilité des données augmente avec les années, notamment car les imports régionaux étaient moins fréquents lors des premières campagnes.
+
+          Aucune borne haute n'est appliquée : la campagne en cours, comme une campagne à venir, peut être interrogée en anticipation, par exemple pour instruire dès le printemps des demandes portant sur la rentrée suivante. Les bourses régionales de la campagne suivante sont disponibles à partir du mois de mai, les bourses nationales à partir du mois de juillet. La base contient environ 85% des boursiers en octobre et est considérée comme complète en fin novembre : une campagne récente peut donc renvoyer un dossier absent ou partiel alors que l'étudiant est bien boursier.
 
           En l'absence de ce paramètre, l'API recherche une bourse valide pour l'étudiant ; si plusieurs résultats existent, elle renvoie la bourse la plus récente en priorité.
         example: 2024

--- a/siade/app/interactors/cnous/validate_campaign_year.rb
+++ b/siade/app/interactors/cnous/validate_campaign_year.rb
@@ -14,10 +14,6 @@ class CNOUS::ValidateCampaignYear < ValidateParamInteractor
 
     return false unless /\A\d{4}\z/.match?(raw)
 
-    raw.to_i.between?(MIN_CAMPAIGN_YEAR, max_campaign_year)
-  end
-
-  def max_campaign_year
-    Date.current.year - 1
+    raw.to_i >= MIN_CAMPAIGN_YEAR
   end
 end

--- a/siade/config/errors.yml
+++ b/siade/config/errors.yml
@@ -280,7 +280,7 @@
 
 - code: '00368'
   title: 'Entité non traitable'
-  detail: "L'année de campagne (campaignYear) n'est pas correctement formatée: doit être comprise entre 2021 et l'année courante - 1"
+  detail: "L'année de campagne (campaignYear) n'est pas correctement formatée: doit être une année sur 4 chiffres supérieure ou égale à 2021"
 
 - code: '00370'
   title: 'Entité non traitable'

--- a/siade/spec/interactors/cnous/validate_campaign_year_spec.rb
+++ b/siade/spec/interactors/cnous/validate_campaign_year_spec.rb
@@ -33,18 +33,22 @@ RSpec.describe CNOUS::ValidateCampaignYear, type: :validate_param_interactor do
     it { is_expected.to be_a_success }
   end
 
-  context 'when campaign_year equals current year - 1' do
+  context 'when campaign_year equals a past year' do
     let(:campaign_year) { '2025' }
 
     it { is_expected.to be_a_success }
   end
 
-  context 'when campaign_year equals current year' do
+  context 'when campaign_year equals the ongoing campaign year' do
     let(:campaign_year) { '2026' }
 
-    it { is_expected.to be_a_failure }
+    it { is_expected.to be_a_success }
+  end
 
-    its(:errors) { is_expected.to include(instance_of(UnprocessableEntityError)) }
+  context 'when campaign_year is a future year' do
+    let(:campaign_year) { '2027' }
+
+    it { is_expected.to be_a_success }
   end
 
   context 'when campaign_year is not a 4-digit string' do
@@ -55,7 +59,7 @@ RSpec.describe CNOUS::ValidateCampaignYear, type: :validate_param_interactor do
     its(:errors) { is_expected.to include(instance_of(UnprocessableEntityError)) }
   end
 
-  context 'when campaign_year is an integer in range' do
+  context 'when campaign_year is an integer' do
     let(:campaign_year) { 2024 }
 
     it { is_expected.to be_a_success }

--- a/site/config/changelogs.yml
+++ b/site/config/changelogs.yml
@@ -1,3 +1,11 @@
+- date: 2026-08-25
+  scope: api_particulier
+  title: "CNOUS étudiant boursier : `campaignYear` accepte la campagne en cours et à venir"
+  description: |
+    Le paramètre `campaignYear` de l'endpoint [étudiant boursier CNOUS](<%= endpoint_path(uid: 'cnous/statut_etudiant_boursier') %>) **n'est plus limité aux campagnes passées**. Jusqu'ici, seules les années jusqu'à `année courante - 1` étaient acceptées, les suivantes étant rejetées en erreur 422. La borne haute est supprimée : la campagne en cours comme une campagne à venir peuvent désormais être interrogées. Cela débloque les instructions anticipées — tarification solidaire des transports, aides départementales et régionales — dont les demandes sont déposées plusieurs mois avant la rentrée scolaire concernée. Seule la borne basse de 2021, première campagne disponible côté CNOUS, est conservée.
+
+    Pour rappel, l'année `N` désigne l'**année scolaire `N`/`N+1`** (`campaignYear=2026` pour l'année scolaire 2026-2027). Les bourses régionales de la campagne suivante remontent dès **mai**, les bourses nationales dès **juillet**. Attention, une campagne récente n'est pas complète pour autant : la base contient environ 85% des boursiers en octobre et n'est considérée comme complète que fin novembre. Un dossier absent ou partiel ne signifie donc pas que l'étudiant n'est pas boursier.
+
 - date: 2026-08-17
   scope: api_entreprise
   title: "Données fondations (SIAF) : nouvelle API disponible en environnement de test"


### PR DESCRIPTION
The upper bound of `current_year - 1` introduced along with the parameter assumed a campaign was only worth querying once consolidated. That assumption is wrong on two counts. The year switch happens at the end of the school year, so records for the next campaign start landing in the upstream dataset from May for the regional scholarships and from July for the national ones. More importantly, several consumer use cases — solidarity transport pricing, departmental and regional aids — instruct applications months before the school year they cover, and legitimately need to query a campaign that has not started yet. Rejecting anything from the current year onwards with a 422 blocked those consumers outright.

The upper bound is removed entirely: the upstream API is the authority on which campaigns it actually holds, and an empty answer is a more honest outcome than a validation error on a year we guessed was too recent. The lower bound of 2021 is kept, since no earlier data exists upstream.

The fiche and the OpenAPI description are reworded accordingly: year `N` designates the `N`/`N+1` school year, the ongoing campaign and upcoming ones can be queried in anticipation, and a missing or partial record on a recent campaign does not mean the student has no scholarship — the dataset holds roughly 85% of the recipients in October and is only considered complete by late November. The changelog carries the same warning for consumers who relied on the previous behaviour.

No scope change and no version bump: the parameter signature is unchanged, the validation merely loosens. Regenerating the Ruby and Node SDK scaffolding produces no diff, so no client release is needed.

Closes https://linear.app/pole-api/issue/API-7240