### PR TITLE
Warn about the empty student base in August

### DIFF
--- a/commons/endpoints/api_particulier/education_nationale_statut_eleve.yml
+++ b/commons/endpoints/api_particulier/education_nationale_statut_eleve.yml
@@ -48,6 +48,16 @@ fiche:
         Les informations, même si elles évoluent principalement lors de la rentrée scolaire en septembre, peuvent changer en cours d'année (déménagements, etc.).
 
         {:.fr-highlight.fr-highlight--caution}
+        > ⚠️ **Base élève vide de mi-août au lendemain de la rentrée scolaire**
+        >
+        > Cette période correspond à la mise à jour des données pour la nouvelle année scolaire ; des indisponibilités temporaires concernent alors les données de scolarité et de bourse :
+        >
+        > - **élèves du premier degré** : l'API renvoie systématiquement une **erreur 404** ;
+        > - **élèves boursiers du second degré** : une **erreur 404 peut être renvoyée lorsque l'appel porte également sur les données de bourse**. Les données de **scolarité** restent quant à elles disponibles, actualisées dès le 6 juillet pour l'année scolaire suivante.
+        >
+        > Pendant cette période, une **erreur 404 ne doit pas être interprétée comme l'absence de scolarité de l'élève ou de son statut de boursier**.
+
+        {:.fr-highlight.fr-highlight--caution}
         > Attention, si un élève est indiqué "non-boursier" avant mi-octobre, il ne faut pas prendre en compte cette information. Le **statut non-boursier est véritablement fiable à partir de mi-octobre**. [En savoir plus](#fiabilite-statut-boursier-octobre).
     parameters_details:
       description: |+


### PR DESCRIPTION
Between mid-August and the day after the start of the school year, the provider rebuilds its base for the new school year. During that window the API returns a 404 systematically for first-degree pupils, and may return a 404 for second-degree pupils when the call also covers scholarship data — while schooling data alone stays available, refreshed from 6 July for the upcoming school year.

Integrators were reading these 404 as "the pupil is not enrolled" or "the pupil is not a scholarship holder", which is wrong during that period. Surface the caveat as a DSFR caution highlight in the update rules, next to the existing mid-October scholarship reliability warning, so it is shared by the V.5, V.4 and V.3 fiches through the common anchor.

Ref: https://linear.app/pole-api/issue/API-7285