### PR TITLE
Clarify birth name label in call modalities

### DIFF
--- a/commons/endpoints/api_particulier/cnaf_msa_allocation_education_enfant_handicape.yml
+++ b/commons/endpoints/api_particulier/cnaf_msa_allocation_education_enfant_handicape.yml
@@ -60,7 +60,7 @@ fiche:
           <div class="fr-collapse" id="accordion-106">
           <div class="fr-mb-0">
           <ul>
-            <li>Nom de naissance<sup>1</sup>, nom d'usage, prénoms<sup>3</sup>, sexe<sup>4</sup>, date de naissance de l'allocataire<sup>2</sup>, code COG du pays de naissance<sup>1</sup>&nbsp;;</li>
+            <li>Nom de famille (nom de naissance)<sup>1</sup>, nom d'usage, prénoms<sup>3</sup>, sexe<sup>4</sup>, date de naissance de l'allocataire<sup>2</sup>, code COG du pays de naissance<sup>1</sup>&nbsp;;</li>
             <li>Commune de naissance <em>(<a href="#poids-parametres-identification">fortement recommandé</a>)</em>&nbsp;:
             <ul>
               <li>

--- a/commons/endpoints/api_particulier/cnaf_msa_prestation_de_service_unique.yml
+++ b/commons/endpoints/api_particulier/cnaf_msa_prestation_de_service_unique.yml
@@ -84,7 +84,7 @@ fiche:
           <div class="fr-collapse" id="accordion-106">
           <div class="fr-mb-0">
           <ul>
-            <li>Nom de naissance<sup>1</sup>, nom d'usage, prénoms<sup>3</sup>, sexe<sup>4</sup>, date de naissance de l'allocataire<sup>2</sup>, code COG du pays de naissance<sup>1</sup>&nbsp;;</li>
+            <li>Nom de famille (nom de naissance)<sup>1</sup>, nom d'usage, prénoms<sup>3</sup>, sexe<sup>4</sup>, date de naissance de l'allocataire<sup>2</sup>, code COG du pays de naissance<sup>1</sup>&nbsp;;</li>
             <li>Commune de naissance <em>(<a href="#poids-parametres-identification">fortement recommandé</a>)</em>&nbsp;: peut être renseignée de deux façons différentes :
             <ul>
               <li class="fr-text--sm fr-mb-0">

--- a/commons/endpoints/api_particulier/cnaf_msa_quotient_familial.yml
+++ b/commons/endpoints/api_particulier/cnaf_msa_quotient_familial.yml
@@ -78,7 +78,7 @@ fiche:
           <div class="fr-collapse" id="accordion-106">
           <div class="fr-mb-0">
           <ul>
-            <li>Nom de naissance<sup>1</sup>, nom d'usage, prénoms<sup>3</sup>, sexe<sup>4</sup>, date de naissance de l'allocataire<sup>2</sup>, code COG du pays de naissance<sup>1</sup>&nbsp;;</li>
+            <li>Nom de famille (nom de naissance)<sup>1</sup>, nom d'usage, prénoms<sup>3</sup>, sexe<sup>4</sup>, date de naissance de l'allocataire<sup>2</sup>, code COG du pays de naissance<sup>1</sup>&nbsp;;</li>
             <li>Commune de naissance <em>(<a href="#poids-parametres-identification">fortement recommandé</a>)</em>&nbsp;: peut être renseignée de deux façons différentes :
             <ul>
               <li class="fr-text--sm fr-mb-0">

--- a/commons/endpoints/api_particulier/cnav_allocation_adulte_handicape.yml
+++ b/commons/endpoints/api_particulier/cnav_allocation_adulte_handicape.yml
@@ -34,7 +34,7 @@ fiche:
         **Avec les données d'identité** : 
           
           {:.fr-mb-0}
-          - Nom de naissance<sup>1</sup>, nom d'usage, prénoms<sup>3</sup>, sexe<sup>4</sup>, date de naissance de l'allocataire<sup>2</sup>, code COG du pays de naissance<sup>1</sup>&nbsp;;
+          - Nom de famille (nom de naissance)<sup>1</sup>, nom d'usage, prénoms<sup>3</sup>, sexe<sup>4</sup>, date de naissance de l'allocataire<sup>2</sup>, code COG du pays de naissance<sup>1</sup>&nbsp;;
           - Commune de naissance _([fortement recommandé](#poids-parametres-identification))_&nbsp;:
               - *Si le lieu de naissance est en France,* la commune de naissance peut être saisie de deux façons différentes :
                   - {:.fr-text--sm .fr-mb-0} Option 1 : Code COG de la commune de naissance. [En savoir plus](#renseigner-lieu-de-naissance)&nbsp;;

--- a/commons/endpoints/api_particulier/cnav_allocation_rentree_scolaire.yml
+++ b/commons/endpoints/api_particulier/cnav_allocation_rentree_scolaire.yml
@@ -27,7 +27,7 @@ fiche:
         **Avec les données d'identité** :
 
           {:.fr-mb-0}
-          - Nom de naissance, nom d'usage, prénoms, sexe, date de naissance de l'allocataire, code COG du pays de naissance&nbsp;;
+          - Nom de famille (nom de naissance), nom d'usage, prénoms, sexe, date de naissance de l'allocataire, code COG du pays de naissance&nbsp;;
           - Commune de naissance _(fortement recommandé)_.
     data:
       description: |+

--- a/commons/endpoints/api_particulier/cnav_allocation_soutien_familial.yml
+++ b/commons/endpoints/api_particulier/cnav_allocation_soutien_familial.yml
@@ -31,7 +31,7 @@ fiche:
         **Avec les données d'identité** : 
           
           {:.fr-mb-0}
-          - Nom de naissance<sup>1</sup>, nom d'usage, prénoms<sup>3</sup>, sexe<sup>4</sup>, date de naissance de l'allocataire<sup>2</sup>, code COG du pays de naissance<sup>1</sup>&nbsp;;
+          - Nom de famille (nom de naissance)<sup>1</sup>, nom d'usage, prénoms<sup>3</sup>, sexe<sup>4</sup>, date de naissance de l'allocataire<sup>2</sup>, code COG du pays de naissance<sup>1</sup>&nbsp;;
           - Commune de naissance _([fortement recommandé](#poids-parametres-identification))_&nbsp;:
               - *Si le lieu de naissance est en France,* la commune de naissance peut être saisie de deux façons différentes :
                   - {:.fr-text--sm .fr-mb-0} Option 1 : Code COG de la commune de naissance. [En savoir plus](#renseigner-lieu-de-naissance)&nbsp;;

--- a/commons/endpoints/api_particulier/cnav_complementaire_sante_solidaire.yml
+++ b/commons/endpoints/api_particulier/cnav_complementaire_sante_solidaire.yml
@@ -36,7 +36,7 @@ fiche:
         **Avec les données d'identité** : 
           
           {:.fr-mb-0}
-          - Nom de naissance<sup>1</sup>, nom d'usage, prénoms<sup>3</sup>, sexe<sup>4</sup>, date de naissance de l'allocataire<sup>2</sup>, code COG du pays de naissance<sup>1</sup>&nbsp;;
+          - Nom de famille (nom de naissance)<sup>1</sup>, nom d'usage, prénoms<sup>3</sup>, sexe<sup>4</sup>, date de naissance de l'allocataire<sup>2</sup>, code COG du pays de naissance<sup>1</sup>&nbsp;;
           - Commune de naissance _([fortement recommandé](#poids-parametres-identification))_&nbsp;:
               - *Si le lieu de naissance est en France,* la commune de naissance peut être saisie de deux façons différentes :
                   - {:.fr-text--sm .fr-mb-0} Option 1 : Code COG de la commune de naissance. [En savoir plus](#renseigner-lieu-de-naissance)&nbsp;;

--- a/commons/endpoints/api_particulier/cnav_prime_activite.yml
+++ b/commons/endpoints/api_particulier/cnav_prime_activite.yml
@@ -34,7 +34,7 @@ fiche:
         **Avec les données d'identité** : 
           
           {:.fr-mb-0}
-          - Nom de naissance<sup>1</sup>, nom d'usage, prénoms<sup>3</sup>, sexe<sup>4</sup>, date de naissance de l'allocataire<sup>2</sup>, code COG du pays de naissance<sup>1</sup>&nbsp;;
+          - Nom de famille (nom de naissance)<sup>1</sup>, nom d'usage, prénoms<sup>3</sup>, sexe<sup>4</sup>, date de naissance de l'allocataire<sup>2</sup>, code COG du pays de naissance<sup>1</sup>&nbsp;;
           - Commune de naissance _([fortement recommandé](#poids-parametres-identification))_&nbsp;:
               - *Si le lieu de naissance est en France,* la commune de naissance peut être saisie de deux façons différentes :
                   - {:.fr-text--sm .fr-mb-0} Option 1 : Code COG de la commune de naissance. [En savoir plus](#renseigner-lieu-de-naissance)&nbsp;;

--- a/commons/endpoints/api_particulier/cnav_revenu_solidarite_active.yml
+++ b/commons/endpoints/api_particulier/cnav_revenu_solidarite_active.yml
@@ -34,7 +34,7 @@ fiche:
         **Avec les données d'identité** : 
           
           {:.fr-mb-0}
-          - Nom de naissance<sup>1</sup>, nom d'usage, prénoms<sup>3</sup>, sexe<sup>4</sup>, date de naissance de l'allocataire<sup>2</sup>, code COG du pays de naissance<sup>1</sup>&nbsp;;
+          - Nom de famille (nom de naissance)<sup>1</sup>, nom d'usage, prénoms<sup>3</sup>, sexe<sup>4</sup>, date de naissance de l'allocataire<sup>2</sup>, code COG du pays de naissance<sup>1</sup>&nbsp;;
           - Commune de naissance _([fortement recommandé](#poids-parametres-identification))_&nbsp;: peut être renseignée de deux façons différentes :
               - {:.fr-text--sm .fr-mb-0} Option 1 : Code COG de la commune de naissance si le lieu de naissance est en France. [En savoir plus](#renseigner-lieu-de-naissance)&nbsp;;
               - {:.fr-text--sm .fr-mb-0} Option 2 : Nom de la commune de naissance et code du département de naissance. Pour cette option, la date de naissance est obligatoire. [En savoir plus](#renseigner-lieu-de-naissance).

--- a/commons/endpoints/api_particulier/dsnj_service_national.yml
+++ b/commons/endpoints/api_particulier/dsnj_service_national.yml
@@ -57,7 +57,7 @@ fiche:
         <div class="fr-collapse" id="accordion-106">
         <div class="fr-mb-0">
         <ul>
-        <li>Nom de naissance<sup>*</sup>, nom d'usage, prénoms<sup>1</sup>, sexe<sup>*</sup>, date de naissance de l'allocataire<sup>**</sup>&nbsp;;</li>
+        <li>Nom de famille (nom de naissance)<sup>*</sup>, nom d'usage, prénoms<sup>1</sup>, sexe<sup>*</sup>, date de naissance de l'allocataire<sup>**</sup>&nbsp;;</li>
         <li>Lieu de naissance&nbsp;:
         <ul>
         <li>

--- a/commons/endpoints/api_particulier/v2_cnaf_msa_quotient_familial_v2.yml
+++ b/commons/endpoints/api_particulier/v2_cnaf_msa_quotient_familial_v2.yml
@@ -72,7 +72,7 @@ fiche:
           <div class="fr-collapse" id="accordion-106">
           <div class="fr-mb-0">
           <ul>
-            <li>Nom de naissance<sup>*</sup>, nom d'usage, prénoms<sup>1</sup>, sexe<sup>*</sup>, date de naissance de l'allocataire<sup>**</sup>&nbsp;;</li>
+            <li>Nom de famille (nom de naissance)<sup>*</sup>, nom d'usage, prénoms<sup>1</sup>, sexe<sup>*</sup>, date de naissance de l'allocataire<sup>**</sup>&nbsp;;</li>
             <li>Lieu de naissance&nbsp;:
             <ul>
               <li>

--- a/commons/endpoints/api_particulier/v2_cnav_allocation_adulte_handicape.yml
+++ b/commons/endpoints/api_particulier/v2_cnav_allocation_adulte_handicape.yml
@@ -33,7 +33,7 @@ fiche:
         **Avec les données d'identité** : 
           
           {:.fr-mb-0}
-          - Nom de naissance<sup>\*</sup>, nom d'usage, prénoms<sup>1</sup>, sexe<sup>\*</sup>, date de naissance de l'allocataire<sup>\**</sup>&nbsp;;
+          - Nom de famille (nom de naissance)<sup>\*</sup>, nom d'usage, prénoms<sup>1</sup>, sexe<sup>\*</sup>, date de naissance de l'allocataire<sup>\**</sup>&nbsp;;
           - Lieu de naissance&nbsp;: 
               - *Si le lieu de naissance est en France,* la commune de naissance est obligatoire, elle peut être saisie de deux façons différentes :
                   - {:.fr-text--sm .fr-mb-0} Option 1 : Code COG de la commune de naissance<sup>\*</sup>. [En savoir plus](#renseigner-lieu-de-naissance)&nbsp;;

--- a/commons/endpoints/api_particulier/v2_cnav_allocation_soutien_familial.yml
+++ b/commons/endpoints/api_particulier/v2_cnav_allocation_soutien_familial.yml
@@ -30,7 +30,7 @@ fiche:
         **Avec les données d'identité** : 
           
           {:.fr-mb-0}
-          - Nom de naissance<sup>\*</sup>, nom d'usage, prénoms<sup>1</sup>, sexe<sup>\*</sup>, date de naissance de l'allocataire<sup>\**</sup>&nbsp;;
+          - Nom de famille (nom de naissance)<sup>\*</sup>, nom d'usage, prénoms<sup>1</sup>, sexe<sup>\*</sup>, date de naissance de l'allocataire<sup>\**</sup>&nbsp;;
           - Lieu de naissance&nbsp;: 
               - *Si le lieu de naissance est en France,* la commune de naissance est obligatoire, elle peut être saisie de deux façons différentes :
                   - {:.fr-text--sm .fr-mb-0} Option 1 : Code COG de la commune de naissance<sup>\*</sup>. [En savoir plus](#renseigner-lieu-de-naissance)&nbsp;;

--- a/commons/endpoints/api_particulier/v2_cnav_complementaire_sante_solidaire.yml
+++ b/commons/endpoints/api_particulier/v2_cnav_complementaire_sante_solidaire.yml
@@ -28,7 +28,7 @@ fiche:
         **Avec les données d'identité** : 
           
           {:.fr-mb-0}
-          - Nom de naissance<sup>\*</sup>, nom d'usage, prénoms<sup>1</sup>, sexe<sup>\*</sup>, date de naissance de l'allocataire<sup>\**</sup>&nbsp;;
+          - Nom de famille (nom de naissance)<sup>\*</sup>, nom d'usage, prénoms<sup>1</sup>, sexe<sup>\*</sup>, date de naissance de l'allocataire<sup>\**</sup>&nbsp;;
           - Lieu de naissance&nbsp;: 
               - *Si le lieu de naissance est en France,* la commune de naissance est obligatoire, elle peut être saisie de deux façons différentes :
                   - {:.fr-text--sm .fr-mb-0} Option 1 : Code COG de la commune de naissance<sup>\*</sup>. [En savoir plus](#renseigner-lieu-de-naissance)&nbsp;;

--- a/commons/endpoints/api_particulier/v2_cnav_prime_activite.yml
+++ b/commons/endpoints/api_particulier/v2_cnav_prime_activite.yml
@@ -33,7 +33,7 @@ fiche:
         **Avec les données d'identité** : 
           
           {:.fr-mb-0}
-          - Nom de naissance<sup>\*</sup>, nom d'usage, prénoms<sup>1</sup>, sexe<sup>\*</sup>, date de naissance de l'allocataire<sup>\**</sup>&nbsp;;
+          - Nom de famille (nom de naissance)<sup>\*</sup>, nom d'usage, prénoms<sup>1</sup>, sexe<sup>\*</sup>, date de naissance de l'allocataire<sup>\**</sup>&nbsp;;
           - Lieu de naissance&nbsp;: 
               - *Si le lieu de naissance est en France,* la commune de naissance est obligatoire, elle peut être saisie de deux façons différentes :
                   - {:.fr-text--sm .fr-mb-0} Option 1 : Code COG de la commune de naissance<sup>\*</sup>. [En savoir plus](#renseigner-lieu-de-naissance)&nbsp;;

--- a/commons/endpoints/api_particulier/v2_cnav_revenu_solidarite_active.yml
+++ b/commons/endpoints/api_particulier/v2_cnav_revenu_solidarite_active.yml
@@ -33,7 +33,7 @@ fiche:
         **Avec les données d'identité** : 
           
           {:.fr-mb-0}
-          - Nom de naissance<sup>\*</sup>, nom d'usage, prénoms<sup>1</sup>, sexe<sup>\*</sup>, date de naissance de l'allocataire<sup>\**</sup>, code COG du pays de naissance<sup>\*</sup>.
+          - Nom de famille (nom de naissance)<sup>\*</sup>, nom d'usage, prénoms<sup>1</sup>, sexe<sup>\*</sup>, date de naissance de l'allocataire<sup>\**</sup>, code COG du pays de naissance<sup>\*</sup>.
           - Commune de naissance qui peut être renseignée de deux façons différentes :
               - {:.fr-text--sm .fr-mb-0} Option 1 : Code COG<sup>\*</sup> de la commune de naissance si le lieu de naissance est en France. [En savoir plus](#renseigner-lieu-de-naissance)&nbsp;;
               - {:.fr-text--sm .fr-mb-0} Option 2 : Nom<sup>\*</sup> de la commune de naissance et code<sup>\*</sup> du département de naissance. Pour cette option, la date de naissance est obligatoire. [En savoir plus](#renseigner-lieu-de-naissance).


### PR DESCRIPTION
Follow-up to bdcf9c9c73, which renamed `nom de naissance` to `nom de famille` only in the FranceConnect fiches pratiques.

The "Modalités d'appel" section of the endpoint fiches lists the identity pivot parameters. Naming that parameter `nom de naissance` alone already misleads some callers, and naming it `nom de famille` alone would raise the opposite question (married name or birth name?). Spelling out `Nom de famille (nom de naissance)` keeps the FranceConnect wording while removing the ambiguity for the business audience of these fiches.

Scope is limited to the identity pivot parameter list: the dated 04.06.2024 provider messages and the FAQ entries are left untouched, as they quote historical or algorithmic wording rather than label a call parameter.

Closes https://linear.app/pole-api/issue/API-7239