### PR TITLE
Move post-call errors under their provider prefix

### DIFF
--- a/commons/swagger/openapi-particulier.yaml
+++ b/commons/swagger/openapi-particulier.yaml
@@ -1190,19 +1190,19 @@ paths:
           content:
             application/json:
               examples:
-                impossible_d_identifier_l_allocataire_00355:
+                identite_non_reconnue_par_le_fournisseur_de_donnees_36560:
                   value:
                     errors:
-                    - code: '00355'
-                      title: Impossible d'identifier l'allocataire
-                      detail: Les paramètres fournis ne permettent pas d'identifier
-                        un allocataire.
+                    - code: '36560'
+                      title: Identité non reconnue par le fournisseur de données
+                      detail: Les paramètres d'identité fournis ne correspondent à
+                        aucune personne connue du fournisseur de données.
                       source:
                       meta:
                         provider: Sécurité sociale
-                  summary: Impossible d'identifier l'allocataire
-                  description: Les paramètres fournis ne permettent pas d'identifier
-                    un allocataire.
+                  summary: Identité non reconnue par le fournisseur de données
+                  description: Les paramètres d'identité fournis ne correspondent
+                    à aucune personne connue du fournisseur de données.
                 ambiguous_delegation_error:
                   value:
                     errors:
@@ -1615,19 +1615,19 @@ paths:
           content:
             application/json:
               examples:
-                impossible_d_identifier_l_allocataire_00355:
+                identite_non_reconnue_par_le_fournisseur_de_donnees_36560:
                   value:
                     errors:
-                    - code: '00355'
-                      title: Impossible d'identifier l'allocataire
-                      detail: Les paramètres fournis ne permettent pas d'identifier
-                        un allocataire.
+                    - code: '36560'
+                      title: Identité non reconnue par le fournisseur de données
+                      detail: Les paramètres d'identité fournis ne correspondent à
+                        aucune personne connue du fournisseur de données.
                       source:
                       meta:
                         provider: Sécurité sociale
-                  summary: Impossible d'identifier l'allocataire
-                  description: Les paramètres fournis ne permettent pas d'identifier
-                    un allocataire.
+                  summary: Identité non reconnue par le fournisseur de données
+                  description: Les paramètres d'identité fournis ne correspondent
+                    à aucune personne connue du fournisseur de données.
                 ambiguous_delegation_error:
                   value:
                     errors:
@@ -2088,19 +2088,19 @@ paths:
           content:
             application/json:
               examples:
-                impossible_d_identifier_l_allocataire_00355:
+                identite_non_reconnue_par_le_fournisseur_de_donnees_36560:
                   value:
                     errors:
-                    - code: '00355'
-                      title: Impossible d'identifier l'allocataire
-                      detail: Les paramètres fournis ne permettent pas d'identifier
-                        un allocataire.
+                    - code: '36560'
+                      title: Identité non reconnue par le fournisseur de données
+                      detail: Les paramètres d'identité fournis ne correspondent à
+                        aucune personne connue du fournisseur de données.
                       source:
                       meta:
                         provider: Sécurité sociale
-                  summary: Impossible d'identifier l'allocataire
-                  description: Les paramètres fournis ne permettent pas d'identifier
-                    un allocataire.
+                  summary: Identité non reconnue par le fournisseur de données
+                  description: Les paramètres d'identité fournis ne correspondent
+                    à aucune personne connue du fournisseur de données.
                 ambiguous_delegation_error:
                   value:
                     errors:
@@ -2529,19 +2529,19 @@ paths:
           content:
             application/json:
               examples:
-                impossible_d_identifier_l_allocataire_00355:
+                identite_non_reconnue_par_le_fournisseur_de_donnees_36560:
                   value:
                     errors:
-                    - code: '00355'
-                      title: Impossible d'identifier l'allocataire
-                      detail: Les paramètres fournis ne permettent pas d'identifier
-                        un allocataire.
+                    - code: '36560'
+                      title: Identité non reconnue par le fournisseur de données
+                      detail: Les paramètres d'identité fournis ne correspondent à
+                        aucune personne connue du fournisseur de données.
                       source:
                       meta:
                         provider: Sécurité sociale
-                  summary: Impossible d'identifier l'allocataire
-                  description: Les paramètres fournis ne permettent pas d'identifier
-                    un allocataire.
+                  summary: Identité non reconnue par le fournisseur de données
+                  description: Les paramètres d'identité fournis ne correspondent
+                    à aucune personne connue du fournisseur de données.
                 ambiguous_delegation_error:
                   value:
                     errors:
@@ -2996,19 +2996,19 @@ paths:
           content:
             application/json:
               examples:
-                impossible_d_identifier_l_allocataire_00355:
+                identite_non_reconnue_par_le_fournisseur_de_donnees_36560:
                   value:
                     errors:
-                    - code: '00355'
-                      title: Impossible d'identifier l'allocataire
-                      detail: Les paramètres fournis ne permettent pas d'identifier
-                        un allocataire.
+                    - code: '36560'
+                      title: Identité non reconnue par le fournisseur de données
+                      detail: Les paramètres d'identité fournis ne correspondent à
+                        aucune personne connue du fournisseur de données.
                       source:
                       meta:
                         provider: Sécurité sociale
-                  summary: Impossible d'identifier l'allocataire
-                  description: Les paramètres fournis ne permettent pas d'identifier
-                    un allocataire.
+                  summary: Identité non reconnue par le fournisseur de données
+                  description: Les paramètres d'identité fournis ne correspondent
+                    à aucune personne connue du fournisseur de données.
                 ambiguous_delegation_error:
                   value:
                     errors:
@@ -3430,19 +3430,19 @@ paths:
           content:
             application/json:
               examples:
-                impossible_d_identifier_l_allocataire_00355:
+                identite_non_reconnue_par_le_fournisseur_de_donnees_36560:
                   value:
                     errors:
-                    - code: '00355'
-                      title: Impossible d'identifier l'allocataire
-                      detail: Les paramètres fournis ne permettent pas d'identifier
-                        un allocataire.
+                    - code: '36560'
+                      title: Identité non reconnue par le fournisseur de données
+                      detail: Les paramètres d'identité fournis ne correspondent à
+                        aucune personne connue du fournisseur de données.
                       source:
                       meta:
                         provider: Sécurité sociale
-                  summary: Impossible d'identifier l'allocataire
-                  description: Les paramètres fournis ne permettent pas d'identifier
-                    un allocataire.
+                  summary: Identité non reconnue par le fournisseur de données
+                  description: Les paramètres d'identité fournis ne correspondent
+                    à aucune personne connue du fournisseur de données.
                 ambiguous_delegation_error:
                   value:
                     errors:
@@ -3890,19 +3890,19 @@ paths:
           content:
             application/json:
               examples:
-                impossible_d_identifier_l_allocataire_00355:
+                identite_non_reconnue_par_le_fournisseur_de_donnees_36560:
                   value:
                     errors:
-                    - code: '00355'
-                      title: Impossible d'identifier l'allocataire
-                      detail: Les paramètres fournis ne permettent pas d'identifier
-                        un allocataire.
+                    - code: '36560'
+                      title: Identité non reconnue par le fournisseur de données
+                      detail: Les paramètres d'identité fournis ne correspondent à
+                        aucune personne connue du fournisseur de données.
                       source:
                       meta:
                         provider: Sécurité sociale
-                  summary: Impossible d'identifier l'allocataire
-                  description: Les paramètres fournis ne permettent pas d'identifier
-                    un allocataire.
+                  summary: Identité non reconnue par le fournisseur de données
+                  description: Les paramètres d'identité fournis ne correspondent
+                    à aucune personne connue du fournisseur de données.
                 ambiguous_delegation_error:
                   value:
                     errors:
@@ -4317,19 +4317,19 @@ paths:
           content:
             application/json:
               examples:
-                impossible_d_identifier_l_allocataire_00355:
+                identite_non_reconnue_par_le_fournisseur_de_donnees_36560:
                   value:
                     errors:
-                    - code: '00355'
-                      title: Impossible d'identifier l'allocataire
-                      detail: Les paramètres fournis ne permettent pas d'identifier
-                        un allocataire.
+                    - code: '36560'
+                      title: Identité non reconnue par le fournisseur de données
+                      detail: Les paramètres d'identité fournis ne correspondent à
+                        aucune personne connue du fournisseur de données.
                       source:
                       meta:
                         provider: Sécurité sociale
-                  summary: Impossible d'identifier l'allocataire
-                  description: Les paramètres fournis ne permettent pas d'identifier
-                    un allocataire.
+                  summary: Identité non reconnue par le fournisseur de données
+                  description: Les paramètres d'identité fournis ne correspondent
+                    à aucune personne connue du fournisseur de données.
                 ambiguous_delegation_error:
                   value:
                     errors:
@@ -4799,19 +4799,19 @@ paths:
           content:
             application/json:
               examples:
-                impossible_d_identifier_l_allocataire_00355:
+                identite_non_reconnue_par_le_fournisseur_de_donnees_36560:
                   value:
                     errors:
-                    - code: '00355'
-                      title: Impossible d'identifier l'allocataire
-                      detail: Les paramètres fournis ne permettent pas d'identifier
-                        un allocataire.
+                    - code: '36560'
+                      title: Identité non reconnue par le fournisseur de données
+                      detail: Les paramètres d'identité fournis ne correspondent à
+                        aucune personne connue du fournisseur de données.
                       source:
                       meta:
                         provider: Sécurité sociale
-                  summary: Impossible d'identifier l'allocataire
-                  description: Les paramètres fournis ne permettent pas d'identifier
-                    un allocataire.
+                  summary: Identité non reconnue par le fournisseur de données
+                  description: Les paramètres d'identité fournis ne correspondent
+                    à aucune personne connue du fournisseur de données.
                 ambiguous_delegation_error:
                   value:
                     errors:
@@ -5248,19 +5248,19 @@ paths:
           content:
             application/json:
               examples:
-                impossible_d_identifier_l_allocataire_00355:
+                identite_non_reconnue_par_le_fournisseur_de_donnees_36560:
                   value:
                     errors:
-                    - code: '00355'
-                      title: Impossible d'identifier l'allocataire
-                      detail: Les paramètres fournis ne permettent pas d'identifier
-                        un allocataire.
+                    - code: '36560'
+                      title: Identité non reconnue par le fournisseur de données
+                      detail: Les paramètres d'identité fournis ne correspondent à
+                        aucune personne connue du fournisseur de données.
                       source:
                       meta:
                         provider: Sécurité sociale
-                  summary: Impossible d'identifier l'allocataire
-                  description: Les paramètres fournis ne permettent pas d'identifier
-                    un allocataire.
+                  summary: Identité non reconnue par le fournisseur de données
+                  description: Les paramètres d'identité fournis ne correspondent
+                    à aucune personne connue du fournisseur de données.
                 ambiguous_delegation_error:
                   value:
                     errors:
@@ -6922,19 +6922,19 @@ paths:
           content:
             application/json:
               examples:
-                impossible_d_identifier_l_allocataire_00355:
+                identite_non_reconnue_par_le_fournisseur_de_donnees_36560:
                   value:
                     errors:
-                    - code: '00355'
-                      title: Impossible d'identifier l'allocataire
-                      detail: Les paramètres fournis ne permettent pas d'identifier
-                        un allocataire.
+                    - code: '36560'
+                      title: Identité non reconnue par le fournisseur de données
+                      detail: Les paramètres d'identité fournis ne correspondent à
+                        aucune personne connue du fournisseur de données.
                       source:
                       meta:
                         provider: Sécurité sociale
-                  summary: Impossible d'identifier l'allocataire
-                  description: Les paramètres fournis ne permettent pas d'identifier
-                    un allocataire.
+                  summary: Identité non reconnue par le fournisseur de données
+                  description: Les paramètres d'identité fournis ne correspondent
+                    à aucune personne connue du fournisseur de données.
                 ambiguous_delegation_error:
                   value:
                     errors:
@@ -7359,19 +7359,19 @@ paths:
           content:
             application/json:
               examples:
-                impossible_d_identifier_l_allocataire_00355:
+                identite_non_reconnue_par_le_fournisseur_de_donnees_36560:
                   value:
                     errors:
-                    - code: '00355'
-                      title: Impossible d'identifier l'allocataire
-                      detail: Les paramètres fournis ne permettent pas d'identifier
-                        un allocataire.
+                    - code: '36560'
+                      title: Identité non reconnue par le fournisseur de données
+                      detail: Les paramètres d'identité fournis ne correspondent à
+                        aucune personne connue du fournisseur de données.
                       source:
                       meta:
                         provider: Sécurité sociale
-                  summary: Impossible d'identifier l'allocataire
-                  description: Les paramètres fournis ne permettent pas d'identifier
-                    un allocataire.
+                  summary: Identité non reconnue par le fournisseur de données
+                  description: Les paramètres d'identité fournis ne correspondent
+                    à aucune personne connue du fournisseur de données.
                 ambiguous_delegation_error:
                   value:
                     errors:
@@ -8190,19 +8190,19 @@ paths:
           content:
             application/json:
               examples:
-                impossible_d_identifier_l_allocataire_00355:
+                identite_non_reconnue_par_le_fournisseur_de_donnees_35560:
                   value:
                     errors:
-                    - code: '00355'
-                      title: Impossible d'identifier l'allocataire
-                      detail: Les paramètres fournis ne permettent pas d'identifier
-                        un allocataire.
+                    - code: '35560'
+                      title: Identité non reconnue par le fournisseur de données
+                      detail: Les paramètres d'identité fournis ne correspondent à
+                        aucune personne connue du fournisseur de données.
                       source:
                       meta:
                         provider: CNAF & MSA
-                  summary: Impossible d'identifier l'allocataire
-                  description: Les paramètres fournis ne permettent pas d'identifier
-                    un allocataire.
+                  summary: Identité non reconnue par le fournisseur de données
+                  description: Les paramètres d'identité fournis ne correspondent
+                    à aucune personne connue du fournisseur de données.
                 ambiguous_delegation_error:
                   value:
                     errors:
@@ -8867,19 +8867,19 @@ paths:
           content:
             application/json:
               examples:
-                impossible_d_identifier_l_allocataire_00355:
+                identite_non_reconnue_par_le_fournisseur_de_donnees_35560:
                   value:
                     errors:
-                    - code: '00355'
-                      title: Impossible d'identifier l'allocataire
-                      detail: Les paramètres fournis ne permettent pas d'identifier
-                        un allocataire.
+                    - code: '35560'
+                      title: Identité non reconnue par le fournisseur de données
+                      detail: Les paramètres d'identité fournis ne correspondent à
+                        aucune personne connue du fournisseur de données.
                       source:
                       meta:
                         provider: CNAF & MSA
-                  summary: Impossible d'identifier l'allocataire
-                  description: Les paramètres fournis ne permettent pas d'identifier
-                    un allocataire.
+                  summary: Identité non reconnue par le fournisseur de données
+                  description: Les paramètres d'identité fournis ne correspondent
+                    à aucune personne connue du fournisseur de données.
                 ambiguous_delegation_error:
                   value:
                     errors:
@@ -9350,19 +9350,19 @@ paths:
           content:
             application/json:
               examples:
-                impossible_d_identifier_l_allocataire_00355:
+                identite_non_reconnue_par_le_fournisseur_de_donnees_36560:
                   value:
                     errors:
-                    - code: '00355'
-                      title: Impossible d'identifier l'allocataire
-                      detail: Les paramètres fournis ne permettent pas d'identifier
-                        un allocataire.
+                    - code: '36560'
+                      title: Identité non reconnue par le fournisseur de données
+                      detail: Les paramètres d'identité fournis ne correspondent à
+                        aucune personne connue du fournisseur de données.
                       source:
                       meta:
                         provider: Sécurité sociale
-                  summary: Impossible d'identifier l'allocataire
-                  description: Les paramètres fournis ne permettent pas d'identifier
-                    un allocataire.
+                  summary: Identité non reconnue par le fournisseur de données
+                  description: Les paramètres d'identité fournis ne correspondent
+                    à aucune personne connue du fournisseur de données.
                 ambiguous_delegation_error:
                   value:
                     errors:
@@ -9787,19 +9787,19 @@ paths:
           content:
             application/json:
               examples:
-                impossible_d_identifier_l_allocataire_00355:
+                identite_non_reconnue_par_le_fournisseur_de_donnees_36560:
                   value:
                     errors:
-                    - code: '00355'
-                      title: Impossible d'identifier l'allocataire
-                      detail: Les paramètres fournis ne permettent pas d'identifier
-                        un allocataire.
+                    - code: '36560'
+                      title: Identité non reconnue par le fournisseur de données
+                      detail: Les paramètres d'identité fournis ne correspondent à
+                        aucune personne connue du fournisseur de données.
                       source:
                       meta:
                         provider: Sécurité sociale
-                  summary: Impossible d'identifier l'allocataire
-                  description: Les paramètres fournis ne permettent pas d'identifier
-                    un allocataire.
+                  summary: Identité non reconnue par le fournisseur de données
+                  description: Les paramètres d'identité fournis ne correspondent
+                    à aucune personne connue du fournisseur de données.
                 ambiguous_delegation_error:
                   value:
                     errors:
@@ -10340,19 +10340,20 @@ paths:
           content:
             application/json:
               examples:
-                entite_non_traitable_00366:
+                parametres_de_civilite_refuses_par_le_fournisseur_de_donnees_26561:
                   value:
                     errors:
-                    - code: '00366'
-                      title: Entité non traitable
-                      detail: Un ou plusieurs paramètres de civilité ne sont pas correctement
-                        formatés
+                    - code: '26561'
+                      title: Paramètres de civilité refusés par le fournisseur de
+                        données
+                      detail: Un ou plusieurs paramètres de civilité ont été refusés
+                        par le fournisseur de données.
                       source:
                       meta:
                         provider: CNOUS
-                  summary: Entité non traitable
-                  description: Un ou plusieurs paramètres de civilité ne sont pas
-                    correctement formatés
+                  summary: Paramètres de civilité refusés par le fournisseur de données
+                  description: Un ou plusieurs paramètres de civilité ont été refusés
+                    par le fournisseur de données.
                 ambiguous_delegation_error:
                   value:
                     errors:
@@ -10792,19 +10793,20 @@ paths:
           content:
             application/json:
               examples:
-                entite_non_traitable_00366:
+                parametres_de_civilite_refuses_par_le_fournisseur_de_donnees_26561:
                   value:
                     errors:
-                    - code: '00366'
-                      title: Entité non traitable
-                      detail: Un ou plusieurs paramètres de civilité ne sont pas correctement
-                        formatés
+                    - code: '26561'
+                      title: Paramètres de civilité refusés par le fournisseur de
+                        données
+                      detail: Un ou plusieurs paramètres de civilité ont été refusés
+                        par le fournisseur de données.
                       source:
                       meta:
                         provider: CNOUS
-                  summary: Entité non traitable
-                  description: Un ou plusieurs paramètres de civilité ne sont pas
-                    correctement formatés
+                  summary: Paramètres de civilité refusés par le fournisseur de données
+                  description: Un ou plusieurs paramètres de civilité ont été refusés
+                    par le fournisseur de données.
                 ambiguous_delegation_error:
                   value:
                     errors:
@@ -11193,17 +11195,19 @@ paths:
           content:
             application/json:
               examples:
-                entite_non_traitable_00360:
+                identifiant_refuse_par_le_fournisseur_de_donnees_26562:
                   value:
                     errors:
-                    - code: '00360'
-                      title: Entité non traitable
-                      detail: Le numéro d'INE n'est pas correctement formatté
+                    - code: '26562'
+                      title: Identifiant refusé par le fournisseur de données
+                      detail: L'identifiant fourni a été refusé par le fournisseur
+                        de données.
                       source:
                       meta:
                         provider: CNOUS
-                  summary: Entité non traitable
-                  description: Le numéro d'INE n'est pas correctement formatté
+                  summary: Identifiant refusé par le fournisseur de données
+                  description: L'identifiant fourni a été refusé par le fournisseur
+                    de données.
                 ambiguous_delegation_error:
                   value:
                     errors:
@@ -16102,18 +16106,18 @@ paths:
           content:
             application/json:
               examples:
-                entite_non_traitable_00391:
+                identite_ambigue_pour_le_fournisseur_de_donnees_31563:
                   value:
                     errors:
-                    - code: '00391'
-                      title: Entité non traitable
+                    - code: '31563'
+                      title: Identité ambiguë pour le fournisseur de données
                       detail: Les paramètres d'identité correspondent à plusieurs
                         personnes. Nous ne pouvons pas fournir les informations de
                         service civique pour cet individu.
                       source:
                       meta:
                         provider: GIP-MDS
-                  summary: Entité non traitable
+                  summary: Identité ambiguë pour le fournisseur de données
                   description: Les paramètres d'identité correspondent à plusieurs
                     personnes. Nous ne pouvons pas fournir les informations de service
                     civique pour cet individu.

--- a/siade/app/controllers/api_particulier/v2/cnav/quotient_familial_v2_controller.rb
+++ b/siade/app/controllers/api_particulier/v2/cnav/quotient_familial_v2_controller.rb
@@ -38,7 +38,7 @@ class APIParticulier::V2::CNAV::QuotientFamilialV2Controller < APIParticulier::V
 
   def format_wrong_parameter_error(error)
     {
-      error: error.field == :sngi ? 'not_found' : 'bad_request',
+      error: error.unidentified_person? ? 'not_found' : 'bad_request',
       reason: error.detail,
       message: error.detail
     }

--- a/siade/app/errors/application_error.rb
+++ b/siade/app/errors/application_error.rb
@@ -50,6 +50,10 @@ class ApplicationError
     fail NotImplementedError
   end
 
+  def unidentified_person?
+    false
+  end
+
   protected
 
   def error_entry

--- a/siade/app/errors/provider_unprocessable_entity_error.rb
+++ b/siade/app/errors/provider_unprocessable_entity_error.rb
@@ -1,0 +1,35 @@
+class ProviderUnprocessableEntityError < AbstractGenericProviderError
+  SUBCODES = {
+    unidentified_person: '560',
+    rejected_civility: '561',
+    rejected_identifier: '562',
+    ambiguous_identity: '563',
+    unusable_identity: '564'
+  }.freeze
+
+  def self.build_example(provider_name:, reason:, **)
+    new(provider_name, reason)
+  end
+
+  attr_reader :reason
+
+  def initialize(provider_name, reason, message = nil)
+    super(provider_name, message)
+
+    @reason = reason.to_sym
+  end
+
+  def subcode
+    SUBCODES.fetch(reason) do
+      raise KeyError, "#{reason} is not a valid reason name"
+    end
+  end
+
+  def kind
+    :wrong_parameter
+  end
+
+  def unidentified_person?
+    reason == :unidentified_person
+  end
+end

--- a/siade/app/errors/unprocessable_entity_error.rb
+++ b/siade/app/errors/unprocessable_entity_error.rb
@@ -1,20 +1,17 @@
 class UnprocessableEntityError < ApplicationError
-  def self.build_example(field:, provider_name: nil, from_provider: false, **)
-    new(field, provider: (provider_name if from_provider))
+  def self.build_example(field:, **)
+    new(field)
   end
 
-  attr_reader :field, :provider
+  attr_reader :field
 
-  def initialize(field, meta: {}, provider: nil)
+  def initialize(field, meta: {})
     @field = field.to_sym
     @meta = meta
-    @provider = provider
   end
 
   def meta
-    return extra_meta if provider.blank?
-
-    { provider: }.merge(extra_meta)
+    @meta || {}
   end
 
   # rubocop:disable Metrics/MethodLength
@@ -48,7 +45,6 @@ class UnprocessableEntityError < ApplicationError
       annee: '00353',
       annee_cnav: '00356',
       mois: '00354',
-      sngi: '00355',
       # MESRI / MEN / CNOUS
       ine: '00360',
       family_name: '00361',
@@ -57,7 +53,6 @@ class UnprocessableEntityError < ApplicationError
       birth_date: '00363',
       gender: '00364',
       birth_place: '00365',
-      civility: '00366',
       campaign_year: '00368',
       # DGFIP usager
       tax_number: '00370',
@@ -66,7 +61,6 @@ class UnprocessableEntityError < ApplicationError
       identifiant: '00380',
       # GIP-MDS
       gip_mds_depth: '00390',
-      gip_mds_too_many_individus: '00391',
       insee_country_code: '00400',
       request_id: '00401',
       # MEN
@@ -101,11 +95,5 @@ class UnprocessableEntityError < ApplicationError
 
   def kind
     :wrong_parameter
-  end
-
-  private
-
-  def extra_meta
-    @meta || {}
   end
 end

--- a/siade/app/interactors/cnav/validate_response.rb
+++ b/siade/app/interactors/cnav/validate_response.rb
@@ -1,6 +1,8 @@
 class CNAV::ValidateResponse < ValidateResponse
-  raises UnprocessableEntityError, field: :sngi, from_provider: true
-  raises UnprocessableEntityError, field: :civility, from_provider: true
+  SNGI_UNIDENTIFIED_MESSAGE = "Les paramètres fournis ne permettent pas d'identifier un allocataire.".freeze
+
+  raises ProviderUnprocessableEntityError, reason: :unidentified_person
+  raises ProviderUnprocessableEntityError, reason: :rejected_civility
 
   def call
     resource_not_found! if http_not_found?
@@ -26,7 +28,7 @@ class CNAV::ValidateResponse < ValidateResponse
   end
 
   def sub_provider_error!
-    return unprocessable_entity!(:sngi) if sub_provider_error_from_sngi?
+    return unprocessable_entity!(:unidentified_person, SNGI_UNIDENTIFIED_MESSAGE) if sub_provider_error_from_sngi?
 
     fail_with_error!(build_qfv2_error(::NotFoundError, 'CNAF & MSA', "L'allocataire n'est pas référencé auprès des caisses éligibles", 'Allocataire non référencé')) if sub_provider_error_from_rncps?
   end
@@ -47,7 +49,7 @@ class CNAV::ValidateResponse < ValidateResponse
   def unprocessable_entity_error!
     track_unexpected_bad_request! unless EXPECTED_BAD_REQUEST_CODES.include?(error_code_from_body)
 
-    unprocessable_entity!(:civility, meta: {
+    unprocessable_entity!(:rejected_civility, meta: {
       provider_error_code: error_code_from_body,
       provider_error_message: error_message_from_body
     })

--- a/siade/app/interactors/cnous/validate_response.rb
+++ b/siade/app/interactors/cnous/validate_response.rb
@@ -1,7 +1,7 @@
 class CNOUS::ValidateResponse < ValidateResponse
   raises ProviderConflictError
-  raises UnprocessableEntityError, field: :ine, from_provider: true
-  raises UnprocessableEntityError, field: :civility, from_provider: true
+  raises ProviderUnprocessableEntityError, reason: :rejected_identifier
+  raises ProviderUnprocessableEntityError, reason: :rejected_civility
 
   # rubocop:disable Metrics/CyclomaticComplexity
   def call
@@ -44,7 +44,7 @@ class CNOUS::ValidateResponse < ValidateResponse
   end
 
   def params_kind
-    context.params[:ine].present? ? :ine : :civility
+    context.params[:ine].present? ? :rejected_identifier : :rejected_civility
   end
 
   def monitoring_service

--- a/siade/app/interactors/france_connect/data_fetcher_through_access_token/validate_response.rb
+++ b/siade/app/interactors/france_connect/data_fetcher_through_access_token/validate_response.rb
@@ -6,12 +6,7 @@ require 'uri'
 class FranceConnect::DataFetcherThroughAccessToken::ValidateResponse < FranceConnect::ValidateResponse
   raises InvalidFranceConnectAccessTokenError, type: :malformed_token
   raises InvalidFranceConnectAccessTokenError, type: :not_found_or_expired
-  raises UnprocessableEntityError, field: :nom_naissance, from_provider: true
-  raises UnprocessableEntityError, field: :prenoms, from_provider: true
-  raises UnprocessableEntityError, field: :annee_date_naissance, from_provider: true
-  raises UnprocessableEntityError, field: :mois_date_naissance, from_provider: true
-  raises UnprocessableEntityError, field: :jour_date_naissance, from_provider: true
-  raises UnprocessableEntityError, field: :date_naissance, from_provider: true
+  raises ProviderUnprocessableEntityError, reason: :unusable_identity
 
   def call
     handle_invalid_token_error if [400, 401].include?(http_code)

--- a/siade/app/interactors/france_connect/validate_response.rb
+++ b/siade/app/interactors/france_connect/validate_response.rb
@@ -38,7 +38,7 @@ class FranceConnect::ValidateResponse < ValidateResponse
     return if organizer.success?
 
     track_invalid_parameters_error_for_france_connect(organizer)
-    unprocessable_entity!(organizer.errors.first.field)
+    unprocessable_entity!(:unusable_identity, organizer.errors.first.detail)
   end
 
   def scopes_flatten_without_aliases

--- a/siade/app/interactors/gip_mds/service_civique/validate_response.rb
+++ b/siade/app/interactors/gip_mds/service_civique/validate_response.rb
@@ -1,5 +1,5 @@
 class GIPMDS::ServiceCivique::ValidateResponse < ValidateResponse
-  raises UnprocessableEntityError, field: :gip_mds_too_many_individus, from_provider: true
+  raises ProviderUnprocessableEntityError, reason: :ambiguous_identity
 
   def call
     monitor_multiple_contracts if multiple_contracts?
@@ -63,7 +63,10 @@ class GIPMDS::ServiceCivique::ValidateResponse < ValidateResponse
   end
 
   def too_many_individus!
-    unprocessable_entity!(:gip_mds_too_many_individus)
+    unprocessable_entity!(
+      :ambiguous_identity,
+      "Les paramètres d'identité correspondent à plusieurs personnes. Nous ne pouvons pas fournir les informations de service civique pour cet individu."
+    )
   end
 
   def error_code

--- a/siade/app/interactors/validate_response.rb
+++ b/siade/app/interactors/validate_response.rb
@@ -94,8 +94,8 @@ class ValidateResponse < ApplicationInteractor
     context.fail!
   end
 
-  def unprocessable_entity!(field, meta: {})
-    fail_with_error!(::UnprocessableEntityError.new(field, meta:, provider: context.provider_name))
+  def unprocessable_entity!(reason, message = nil, meta: {})
+    fail_with_error!(::ProviderUnprocessableEntityError.new(context.provider_name, reason, message).add_meta(meta))
   end
 
   def resource_not_found!(resource = nil)

--- a/siade/config/errors.yml
+++ b/siade/config/errors.yml
@@ -58,6 +58,28 @@
 - subcode: '020'
   title: 'Maintenance du fournisseur de données'
 
+## Entrées rejetées par le fournisseur de données (422 post-appel)
+
+- subcode: '560'
+  title: "Identité non reconnue par le fournisseur de données"
+  detail: "Les paramètres d'identité fournis ne correspondent à aucune personne connue du fournisseur de données."
+
+- subcode: '561'
+  title: "Paramètres de civilité refusés par le fournisseur de données"
+  detail: "Un ou plusieurs paramètres de civilité ont été refusés par le fournisseur de données."
+
+- subcode: '562'
+  title: "Identifiant refusé par le fournisseur de données"
+  detail: "L'identifiant fourni a été refusé par le fournisseur de données."
+
+- subcode: '563'
+  title: "Identité ambiguë pour le fournisseur de données"
+  detail: "Les paramètres d'identité fournis correspondent à plusieurs personnes chez le fournisseur de données."
+
+- subcode: '564'
+  title: "Identité inexploitable renvoyée par le fournisseur de données"
+  detail: "L'identité renvoyée par le fournisseur de données est incomplète ou invalide."
+
 
 - code: '00100'
   title: 'Privilèges insuffisants'
@@ -270,10 +292,6 @@
   title: 'Entité non traitable'
   detail: "Le lieu de naissance n'est pas correctement formaté"
 
-- code: '00366'
-  title: 'Entité non traitable'
-  detail: "Un ou plusieurs paramètres de civilité ne sont pas correctement formatés"
-
 - code: '00367'
   title: 'Entité non traitable'
   detail: "Le ou les prénoms sont manquants."
@@ -297,10 +315,6 @@
 - code: '00390'
   title: 'Entité non traitable'
   detail: "La valeur de la profondeur n'est pas valide: celle-ci doit être comprise entre 1 et 13"
-
-- code: '00391'
-  title: 'Entité non traitable'
-  detail: "Les paramètres d'identité correspondent à plusieurs personnes. Nous ne pouvons pas fournir les informations de service civique pour cet individu."
 
 - code: '00400'
   title: 'Entité non traitable'
@@ -488,10 +502,6 @@
 - code: '00354'
   title: 'Entité non traitable'
   detail: "Le mois demandé est incorrect ou est dans le futur."
-
-- code: '00355'
-  title: Impossible d'identifier l'allocataire
-  detail: "Les paramètres fournis ne permettent pas d'identifier un allocataire."
 
 ## BDF
 

--- a/siade/nomenclature-errors.md
+++ b/siade/nomenclature-errors.md
@@ -48,8 +48,47 @@ Liste non-exhaustive (la liste se trouve dans [`ErrorsBackend`](app/services/err
 - `19` = ADEME
 - `20` = API Geo
 
-La valeur `00` correspond aux erreurs relative à l'API Entreprise et n'implique
-pas de fournisseur de données.
+La valeur `00` correspond aux erreurs relatives à l'API Entreprise et
+**n'implique pas de fournisseur de données**.
+
+### Règle : le préfixe indique qui a rendu le verdict
+
+Le préfixe répond à la question « **un fournisseur de données a-t-il été
+sollicité ?** », pas à la question « où est la cause ? ». Cette dernière est
+déjà portée par le statut HTTP.
+
+- `00XXX` ⟺ **aucun appel fournisseur n'a eu lieu**. L'erreur a été décidée par
+  nos seuls moyens : validation de paramètres, authentification, habilitations.
+  Elle est déterministe : à paramètres identiques, la réponse ne changera pas.
+- `XXYYY` (`XX` ≠ `00`) ⟺ **un fournisseur a été appelé**, et c'est lui qui a
+  rendu le verdict. `meta.provider` nomme ce fournisseur. La réponse n'est pas
+  déterministe dans le temps : les données du fournisseur peuvent évoluer.
+
+Le statut HTTP reste, lui, l'indicateur de l'action attendue de l'appelant :
+
+| Statut | Signification pour l'appelant |
+| ------ | ----------------------------- |
+| `422`  | La requête est inexploitable : corriger la saisie et rappeler |
+| `404`  | La requête est bonne, la donnée n'existe pas : clore le dossier |
+| `502`  | Panne du fournisseur : réessayer plus tard |
+
+Un `422` peut donc parfaitement porter un préfixe fournisseur : c'est le cas
+lorsque seul le fournisseur est capable de dire que l'entrée transmise ne
+correspond à personne (échec d'appariement SNGI, civilité refusée, critères
+d'identité ambigus). Ces erreurs sont construites par
+[`ProviderUnprocessableEntityError`](app/errors/provider_unprocessable_entity_error.rb),
+qui dérive le code **et** `meta.provider` du même `provider_name`, rendant
+l'invariant impossible à violer.
+
+Concrètement : une erreur émise depuis un `ValidateParams` porte le préfixe
+`00`, une erreur émise depuis un `ValidateResponse` porte un préfixe
+fournisseur. La règle est vérifiée par
+[`spec/services/errors_nomenclature_spec.rb`](spec/services/errors_nomenclature_spec.rb).
+
+> Exception héritée : les codes `50001` à `50004` (jetons FranceConnect)
+> utilisent un préfixe `50` non attribué dans `ErrorsBackend`. Ils sont
+> explicitement listés dans le spec de conformité en attendant leur propre
+> reclassement.
 
 ### Codes erreur (YYY)
 
@@ -126,6 +165,9 @@ Ces erreurs sont comprises entre `000` et `049`.
 
 ##### 0003Z Erreurs associés aux entrées non traitables
 
+Ces erreurs sont détectées **avant tout appel fournisseur**, par validation
+locale des paramètres.
+
 - `00301` = Siren non valide
 - `00302` = Siret non valide
 - `00303` = Siret ou numéro RNA non valide
@@ -143,3 +185,15 @@ Ces erreurs sont comprises entre `000` et `049`.
 L'ensemble de ces erreurs sont définis dans le fichier
 [`errors.yml`](./config/errors.yml), et leur sous code commencent au minimum à
 la valeur `500`
+
+##### XX56Z Entrées rejetées par le fournisseur de données
+
+Sous-codes partagés par tous les fournisseurs, pour les entrées que seul le
+fournisseur peut invalider. Ils produisent un `422`, avec le préfixe du
+fournisseur interrogé.
+
+- `XX560` = Identité non reconnue par le fournisseur de données
+- `XX561` = Paramètres de civilité refusés par le fournisseur de données
+- `XX562` = Identifiant refusé par le fournisseur de données
+- `XX563` = Identité ambiguë pour le fournisseur de données
+- `XX564` = Identité inexploitable renvoyée par le fournisseur de données

--- a/siade/spec/errors/provider_unprocessable_entity_error_spec.rb
+++ b/siade/spec/errors/provider_unprocessable_entity_error_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe ProviderUnprocessableEntityError, type: :error do
+  described_class::SUBCODES.each_key do |reason|
+    it_behaves_like 'a valid error' do
+      let(:instance) { described_class.new('CNAV', reason) }
+    end
+  end
+
+  it 'builds its code from the queried provider' do
+    expect(described_class.new('CNAF & MSA', :unidentified_person).code).to eq('35560')
+    expect(described_class.new('Sécurité sociale', :unidentified_person).code).to eq('36560')
+  end
+
+  it 'names the queried provider in meta' do
+    expect(described_class.new('CNOUS', :rejected_identifier).meta).to eq(provider: 'CNOUS')
+  end
+
+  it 'keeps a 422 status' do
+    expect(Errors::HTTPStatusForKind.call(described_class.new('CNAV', :rejected_civility).kind))
+      .to eq(:unprocessable_content)
+  end
+
+  it 'raises on an unknown reason' do
+    expect { described_class.new('CNAV', :whatever).code }.to raise_error(KeyError)
+  end
+
+  describe '#unidentified_person?' do
+    it { expect(described_class.new('CNAV', :unidentified_person)).to be_unidentified_person }
+    it { expect(described_class.new('CNAV', :rejected_civility)).not_to be_unidentified_person }
+    it { expect(UnprocessableEntityError.new(:siren)).not_to be_unidentified_person }
+  end
+end

--- a/siade/spec/errors/unprocessable_entity_error_spec.rb
+++ b/siade/spec/errors/unprocessable_entity_error_spec.rb
@@ -4,40 +4,6 @@ RSpec.describe UnprocessableEntityError, type: :error do
   end
 
   it_behaves_like 'a valid error' do
-    let(:instance) { described_class.new(:gip_mds_too_many_individus) }
-  end
-
-  it_behaves_like 'a valid error' do
-    let(:instance) { described_class.new(:sngi, provider: 'CNAF & MSA') }
-  end
-
-  describe '#meta' do
-    it 'stays empty when no data provider was queried' do
-      expect(described_class.new(:siren).meta).to eq({})
-    end
-
-    it 'exposes the queried data provider' do
-      expect(described_class.new(:sngi, provider: 'CNAF & MSA').meta).to eq(provider: 'CNAF & MSA')
-    end
-
-    it 'keeps the provider first, ahead of the caller supplied meta' do
-      instance = described_class.new(:civility, meta: { provider_error_code: 40_013 }, provider: 'CNAV')
-
-      expect(instance.meta).to eq(provider: 'CNAV', provider_error_code: 40_013)
-    end
-  end
-
-  describe '.build_example' do
-    it 'omits the provider for an error raised before any provider call' do
-      example = described_class.build_example(field: :siren, provider_name: 'INSEE')
-
-      expect(example.meta).to eq({})
-    end
-
-    it 'fills the provider in for an error raised from a provider response' do
-      example = described_class.build_example(field: :sngi, provider_name: 'CNAF & MSA', from_provider: true)
-
-      expect(example.meta).to eq(provider: 'CNAF & MSA')
-    end
+    let(:instance) { described_class.new(:gip_mds_depth) }
   end
 end

--- a/siade/spec/interactors/cnav/validate_response_spec.rb
+++ b/siade/spec/interactors/cnav/validate_response_spec.rb
@@ -34,13 +34,11 @@ RSpec.describe CNAV::ValidateResponse, type: :validate_response do
 
         it { is_expected.to be_a_failure }
 
-        its(:errors) { is_expected.to include(instance_of(UnprocessableEntityError)) }
+        its(:errors) { is_expected.to include(instance_of(ProviderUnprocessableEntityError)) }
 
-        it 'returns a SNGI error' do
+        it 'returns a SNGI error carrying the queried provider' do
+          expect(subject.errors.first.code).to eq('37560')
           expect(subject.errors.first.detail).to include('Les paramètres fournis ne permettent pas')
-        end
-
-        it 'exposes the queried provider in meta' do
           expect(subject.errors.first.meta).to eq(provider: 'CNAV')
         end
       end
@@ -177,7 +175,7 @@ RSpec.describe CNAV::ValidateResponse, type: :validate_response do
 
     it { is_expected.to be_a_failure }
 
-    its(:errors) { is_expected.to include(instance_of(UnprocessableEntityError)) }
+    its(:errors) { is_expected.to include(instance_of(ProviderUnprocessableEntityError)) }
 
     context 'with expected error code' do
       it 'does not track to monitoring' do

--- a/siade/spec/interactors/cnous/validate_response_spec.rb
+++ b/siade/spec/interactors/cnous/validate_response_spec.rb
@@ -85,10 +85,14 @@ RSpec.describe CNOUS::ValidateResponse, type: :validate_response do
 
       it { is_expected.to be_a_failure }
 
-      its(:errors) { is_expected.to include(instance_of(UnprocessableEntityError)) }
+      its(:errors) { is_expected.to include(instance_of(ProviderUnprocessableEntityError)) }
 
       it 'exposes the queried provider in meta' do
         expect(subject.errors.first.meta).to eq(provider: 'MESRI')
+      end
+
+      it 'builds its code from the queried provider' do
+        expect(subject.errors.first.code).to eq('25562')
       end
     end
 

--- a/siade/spec/interactors/france_connect/data_fetcher_through_access_token/validate_response_spec.rb
+++ b/siade/spec/interactors/france_connect/data_fetcher_through_access_token/validate_response_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe FranceConnect::DataFetcherThroughAccessToken::ValidateResponse, t
 
         it { is_expected.to be_a_failure }
 
-        its(:errors) { is_expected.to include(instance_of(UnprocessableEntityError)) }
+        its(:errors) { is_expected.to include(instance_of(ProviderUnprocessableEntityError)) }
 
         it 'tracks errors' do
           expect(MonitoringService.instance).to receive(:track)

--- a/siade/spec/interactors/france_connect/validate_response_spec.rb
+++ b/siade/spec/interactors/france_connect/validate_response_spec.rb
@@ -57,10 +57,14 @@ RSpec.describe FranceConnect::ValidateResponse do
 
       it { is_expected.to be_a_failure }
 
-      its(:errors) { is_expected.to include(instance_of(UnprocessableEntityError)) }
+      its(:errors) { is_expected.to include(instance_of(ProviderUnprocessableEntityError)) }
 
       it 'exposes the queried provider in meta' do
         expect(subject.errors.first.meta).to eq(provider: 'FranceConnect')
+      end
+
+      it 'builds its code from the queried provider' do
+        expect(subject.errors.first.code).to eq('51564')
       end
 
       it 'tracks errors' do

--- a/siade/spec/interactors/gip_mds/service_civique/validate_response_spec.rb
+++ b/siade/spec/interactors/gip_mds/service_civique/validate_response_spec.rb
@@ -50,10 +50,14 @@ RSpec.describe GIPMDS::ServiceCivique::ValidateResponse, type: :validate_respons
 
     it { is_expected.to be_a_failure }
 
-    its(:errors) { is_expected.to include(instance_of(UnprocessableEntityError)) }
+    its(:errors) { is_expected.to include(instance_of(ProviderUnprocessableEntityError)) }
 
     it 'exposes the queried provider in meta' do
       expect(subject.errors.first.meta).to eq(provider: 'GIP-MDS')
+    end
+
+    it 'builds its code from the queried provider' do
+      expect(subject.errors.first.code).to eq('31563')
     end
   end
 

--- a/siade/spec/organizers/cnav/allocation_adulte_handicape_spec.rb
+++ b/siade/spec/organizers/cnav/allocation_adulte_handicape_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe CNAV::AllocationAdulteHandicape, type: :retriever_organizer do
 
           it 'returns 422 message for SNGI' do
             expect(subject).to be_a_failure
-            expect(subject.errors).to include(instance_of(UnprocessableEntityError))
+            expect(subject.errors).to include(instance_of(ProviderUnprocessableEntityError))
             expect(subject.errors.first.detail).to eq("Les paramètres fournis ne permettent pas d'identifier un allocataire.")
           end
         end

--- a/siade/spec/organizers/cnav/allocation_enfant_handicape_spec.rb
+++ b/siade/spec/organizers/cnav/allocation_enfant_handicape_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe CNAV::AllocationEnfantHandicape, type: :retriever_organizer do
 
           it 'returns 422 message for SNGI' do
             expect(subject).to be_a_failure
-            expect(subject.errors).to include(instance_of(UnprocessableEntityError))
+            expect(subject.errors).to include(instance_of(ProviderUnprocessableEntityError))
             expect(subject.errors.first.detail).to eq("Les paramètres fournis ne permettent pas d'identifier un allocataire.")
           end
         end

--- a/siade/spec/organizers/cnav/allocation_soutien_familial_spec.rb
+++ b/siade/spec/organizers/cnav/allocation_soutien_familial_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe CNAV::AllocationSoutienFamilial, type: :retriever_organizer do
 
           it 'returns 422 message for SNGI' do
             expect(subject).to be_a_failure
-            expect(subject.errors).to include(instance_of(UnprocessableEntityError))
+            expect(subject.errors).to include(instance_of(ProviderUnprocessableEntityError))
             expect(subject.errors.first.detail).to eq("Les paramètres fournis ne permettent pas d'identifier un allocataire.")
           end
         end

--- a/siade/spec/organizers/cnav/complementaire_sante_solidaire_spec.rb
+++ b/siade/spec/organizers/cnav/complementaire_sante_solidaire_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe CNAV::ComplementaireSanteSolidaire, type: :retriever_organizer do
 
           it 'returns 422 message for SNGI' do
             expect(subject).to be_a_failure
-            expect(subject.errors).to include(instance_of(UnprocessableEntityError))
+            expect(subject.errors).to include(instance_of(ProviderUnprocessableEntityError))
             expect(subject.errors.first.detail).to eq("Les paramètres fournis ne permettent pas d'identifier un allocataire.")
           end
         end

--- a/siade/spec/organizers/cnav/prime_activite_spec.rb
+++ b/siade/spec/organizers/cnav/prime_activite_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe CNAV::PrimeActivite, type: :retriever_organizer do
 
           it 'returns 422 message for SNGI' do
             expect(subject).to be_a_failure
-            expect(subject.errors).to include(instance_of(UnprocessableEntityError))
+            expect(subject.errors).to include(instance_of(ProviderUnprocessableEntityError))
             expect(subject.errors.first.detail).to eq("Les paramètres fournis ne permettent pas d'identifier un allocataire.")
           end
         end

--- a/siade/spec/organizers/cnav/quotient_familial_v2_spec.rb
+++ b/siade/spec/organizers/cnav/quotient_familial_v2_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe CNAV::QuotientFamilialV2, type: :retriever_organizer do
 
           it 'returns 422 message for SNGI' do
             expect(subject).to be_a_failure
-            expect(subject.errors).to include(instance_of(UnprocessableEntityError))
+            expect(subject.errors).to include(instance_of(ProviderUnprocessableEntityError))
             expect(subject.errors.first.detail).to eq("Les paramètres fournis ne permettent pas d'identifier un allocataire.")
           end
         end

--- a/siade/spec/organizers/cnav/revenu_solidarite_active_spec.rb
+++ b/siade/spec/organizers/cnav/revenu_solidarite_active_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe CNAV::RevenuSolidariteActive, type: :retriever_organizer do
 
           it 'returns 422 message for SNGI' do
             expect(subject).to be_a_failure
-            expect(subject.errors).to include(instance_of(UnprocessableEntityError))
+            expect(subject.errors).to include(instance_of(ProviderUnprocessableEntityError))
             expect(subject.errors.first.detail).to eq("Les paramètres fournis ne permettent pas d'identifier un allocataire.")
           end
         end

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_adulte_handicape_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_adulte_handicape_with_civility_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'API Particulier CNAV: allocation adulte handicape with civility'
                 stub_sngi_404('allocation_adulte_handicape')
               end
 
-              build_rswag_example(UnprocessableEntityError.new(:sngi, provider: 'Sécurité sociale'))
+              build_rswag_example(ProviderUnprocessableEntityError.new('Sécurité sociale', :unidentified_person))
 
               schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_adulte_handicape_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_adulte_handicape_with_france_connect_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'API Particulier: CNAV: Allocation Adulte Handicape with FranceCo
                 stub_sngi_404('allocation_adulte_handicape')
               end
 
-              build_rswag_example(UnprocessableEntityError.new(:sngi, provider: 'Sécurité sociale'))
+              build_rswag_example(ProviderUnprocessableEntityError.new('Sécurité sociale', :unidentified_person))
 
               schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_enfant_handicape/allocation_enfant_handicape_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_enfant_handicape/allocation_enfant_handicape_with_civility_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'API Particulier CNAV: Allocation enfant handicapé (AEEH) with c
                 stub_sngi_404('allocation_enfant_handicape')
               end
 
-              build_rswag_example(UnprocessableEntityError.new(:sngi, provider: 'Sécurité sociale'))
+              build_rswag_example(ProviderUnprocessableEntityError.new('Sécurité sociale', :unidentified_person))
 
               schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_enfant_handicape/allocation_enfant_handicape_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_enfant_handicape/allocation_enfant_handicape_with_france_connect_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'API Particulier: CNAV: Allocation enfant handicapé (AEEH) with 
                 stub_sngi_404('allocation_enfant_handicape')
               end
 
-              build_rswag_example(UnprocessableEntityError.new(:sngi, provider: 'Sécurité sociale'))
+              build_rswag_example(ProviderUnprocessableEntityError.new('Sécurité sociale', :unidentified_person))
 
               schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_rentree_scolaire/allocation_rentree_scolaire_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_rentree_scolaire/allocation_rentree_scolaire_with_civility_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe 'API Particulier CNAV: Allocation de rentrée scolaire (ARS) with
                 stub_sngi_404('allocation_rentree_scolaire')
               end
 
-              build_rswag_example(UnprocessableEntityError.new(:sngi, provider: 'Sécurité sociale'))
+              build_rswag_example(ProviderUnprocessableEntityError.new('Sécurité sociale', :unidentified_person))
 
               schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_rentree_scolaire/allocation_rentree_scolaire_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_rentree_scolaire/allocation_rentree_scolaire_with_france_connect_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'API Particulier: CNAV: Allocation de rentrée scolaire (ARS) wit
                 stub_sngi_404('allocation_rentree_scolaire')
               end
 
-              build_rswag_example(UnprocessableEntityError.new(:sngi, provider: 'Sécurité sociale'))
+              build_rswag_example(ProviderUnprocessableEntityError.new('Sécurité sociale', :unidentified_person))
 
               schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_soutien_familial_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_soutien_familial_with_civility_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'API Particulier CNAV: allocation soutien familial with civility'
                 stub_sngi_404('allocation_soutien_familial')
               end
 
-              build_rswag_example(UnprocessableEntityError.new(:sngi, provider: 'Sécurité sociale'))
+              build_rswag_example(ProviderUnprocessableEntityError.new('Sécurité sociale', :unidentified_person))
 
               schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_soutien_familial_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/allocation_soutien_familial_with_france_connect_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'API Particulier: CNAV: Allocation Soutien Familial with FranceCo
                 stub_sngi_404('allocation_soutien_familial')
               end
 
-              build_rswag_example(UnprocessableEntityError.new(:sngi, provider: 'Sécurité sociale'))
+              build_rswag_example(ProviderUnprocessableEntityError.new('Sécurité sociale', :unidentified_person))
 
               schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/complementaire_sante_solidaire_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/complementaire_sante_solidaire_with_civility_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'API Particulier CNAV: complementaire sante solidaire with civili
                 stub_sngi_404('complementaire_sante_solidaire')
               end
 
-              build_rswag_example(UnprocessableEntityError.new(:sngi, provider: 'Sécurité sociale'))
+              build_rswag_example(ProviderUnprocessableEntityError.new('Sécurité sociale', :unidentified_person))
 
               schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/complementaire_sante_solidaire_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/complementaire_sante_solidaire_with_france_connect_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'API Particulier: CNAV: Complementaire Sante Solidaire with Franc
                 stub_sngi_404('complementaire_sante_solidaire')
               end
 
-              build_rswag_example(UnprocessableEntityError.new(:sngi, provider: 'Sécurité sociale'))
+              build_rswag_example(ProviderUnprocessableEntityError.new('Sécurité sociale', :unidentified_person))
 
               schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/prime_activite_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/prime_activite_with_civility_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'API Particulier CNAV: prime activite with civility', api: :parti
                 stub_sngi_404('prime_activite')
               end
 
-              build_rswag_example(UnprocessableEntityError.new(:sngi, provider: 'Sécurité sociale'))
+              build_rswag_example(ProviderUnprocessableEntityError.new('Sécurité sociale', :unidentified_person))
 
               schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/prime_activite_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/prime_activite_with_france_connect_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'API Particulier: CNAV: Prime Activite with FranceConnect', api: 
                 stub_sngi_404('prime_activite')
               end
 
-              build_rswag_example(UnprocessableEntityError.new(:sngi, provider: 'Sécurité sociale'))
+              build_rswag_example(ProviderUnprocessableEntityError.new('Sécurité sociale', :unidentified_person))
 
               schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/quotient_familial_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/quotient_familial_with_civility_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe 'API Particulier CNAV: Quotient Familial with civility', api: :pa
                 stub_sngi_404('quotient_familial_v2')
               end
 
-              build_rswag_example(UnprocessableEntityError.new(:sngi, provider: 'CNAF & MSA'))
+              build_rswag_example(ProviderUnprocessableEntityError.new('CNAF & MSA', :unidentified_person))
 
               schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/quotient_familial_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/quotient_familial_with_france_connect_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'API Particulier: CNAV: Quotient Familial with FranceConnect', ap
                 stub_sngi_404('quotient_familial_v2')
               end
 
-              build_rswag_example(UnprocessableEntityError.new(:sngi, provider: 'CNAF & MSA'))
+              build_rswag_example(ProviderUnprocessableEntityError.new('CNAF & MSA', :unidentified_person))
 
               schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/revenu_solidarite_active_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/revenu_solidarite_active_with_civility_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'API Particulier CNAV: Revenu de solidarité active with civility
                 stub_sngi_404('revenu_solidarite_active')
               end
 
-              build_rswag_example(UnprocessableEntityError.new(:sngi, provider: 'Sécurité sociale'))
+              build_rswag_example(ProviderUnprocessableEntityError.new('Sécurité sociale', :unidentified_person))
 
               schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/revenu_solidarite_active_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/revenu_solidarite_active_with_france_connect_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'API Particulier: CNAV: Revenu Solidarite Active with FranceConne
                 stub_sngi_404('revenu_solidarite_active')
               end
 
-              build_rswag_example(UnprocessableEntityError.new(:sngi, provider: 'Sécurité sociale'))
+              build_rswag_example(ProviderUnprocessableEntityError.new('Sécurité sociale', :unidentified_person))
 
               schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/requests/api_particulier/v3_and_more/cnous/v3/etudiant_boursier_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnous/v3/etudiant_boursier_with_civility_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe 'API Particulier: CNOUS: Etudiant Boursier with Civility', api: :
           response '422', 'Paramètres invalides' do
             schema '$ref' => '#/components/schemas/Error'
 
-            build_rswag_example(UnprocessableEntityError.new(:civility, provider: 'CNOUS'))
+            build_rswag_example(ProviderUnprocessableEntityError.new('CNOUS', :rejected_civility))
 
             run_test!
           end

--- a/siade/spec/requests/api_particulier/v3_and_more/cnous/v3/etudiant_boursier_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnous/v3/etudiant_boursier_with_france_connect_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe 'API Particulier: CNOUS: Statut Etudiant with FranceConnect', api
           response '422', 'Paramètres invalides' do
             schema '$ref' => '#/components/schemas/Error'
 
-            build_rswag_example(UnprocessableEntityError.new(:civility, provider: 'CNOUS'))
+            build_rswag_example(ProviderUnprocessableEntityError.new('CNOUS', :rejected_civility))
 
             run_test!
           end

--- a/siade/spec/requests/api_particulier/v3_and_more/cnous/v3/etudiant_boursier_with_ine_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnous/v3/etudiant_boursier_with_ine_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe 'API Particulier: CNOUS: Statut Etudiant with INE', api: :particu
           response '422', 'Paramètres invalides' do
             schema '$ref' => '#/components/schemas/Error'
 
-            build_rswag_example(UnprocessableEntityError.new(:ine, provider: 'CNOUS'))
+            build_rswag_example(ProviderUnprocessableEntityError.new('CNOUS', :rejected_identifier))
 
             run_test!
           end

--- a/siade/spec/requests/api_particulier/v3_and_more/gip_mds/service_civique/service_civique_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/gip_mds/service_civique/service_civique_with_civility_spec.rb
@@ -71,7 +71,11 @@ RSpec.describe 'GIPMDS: Servicecivique With Civility', api: :particulier, type: 
           before { stub_gip_mds_service_civique_too_many_individus }
 
           response '422', 'Entité non traitable' do
-            build_rswag_example(UnprocessableEntityError.new(:gip_mds_too_many_individus, provider: 'GIP-MDS'))
+            build_rswag_example(ProviderUnprocessableEntityError.new(
+              'GIP-MDS',
+              :ambiguous_identity,
+              "Les paramètres d'identité correspondent à plusieurs personnes. Nous ne pouvons pas fournir les informations de service civique pour cet individu."
+            ))
 
             schema '$ref' => '#/components/schemas/Error'
 

--- a/siade/spec/services/errors_nomenclature_spec.rb
+++ b/siade/spec/services/errors_nomenclature_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe 'errors nomenclature' do # rubocop:disable RSpec/DescribeClass
+  # `00` is documented as "no data provider involved". A handful of legacy
+  # FranceConnect token codes predate that rule and use an unallocated `50`
+  # prefix; they are pending a reclassification of their own.
+  LEGACY_UNALLOCATED_PREFIX_CODES = %w[50001 50002 50003 50004].freeze
+
+  let(:backend) { ErrorsBackend.instance }
+
+  before { Rails.application.eager_load! }
+
+  describe 'every configured code belongs to a known data provider' do
+    it 'has no code whose prefix is unallocated' do
+      configured_codes = YAML.load_file(Rails.root.join('config/errors.yml'), aliases: true)
+        .filter_map { |entry| entry['code']&.to_s }
+
+      unallocated = configured_codes
+        .reject { |code| LEGACY_UNALLOCATED_PREFIX_CODES.include?(code) }
+        .reject { |code| backend.provider_from_code(code) }
+
+      expect(unallocated).to be_empty,
+        "codes with an unallocated provider prefix: #{unallocated.inspect}"
+    end
+  end
+
+  describe 'an error raised from a provider response names that provider' do
+    it 'has no `00` prefixed error declared on a ValidateResponse' do
+      offenders = ValidateResponse.descendants.flat_map do |validator|
+        ErrorRegistry.direct_declarations_for(validator).filter_map do |declaration|
+          code = declaration.error_class.build_example(provider_name: 'CNAV', **declaration.options).code
+
+          "#{validator}: #{declaration.error_class} -> #{code}" if code.start_with?('00')
+        end
+      end
+
+      expect(offenders).to be_empty, <<~MESSAGE
+        A `00` prefix means "no data provider was queried". These errors are emitted
+        from a ValidateResponse, hence after a provider round trip, so they must carry
+        that provider's prefix (see ProviderUnprocessableEntityError):
+
+        #{offenders.join("\n")}
+      MESSAGE
+    end
+  end
+end


### PR DESCRIPTION
The nomenclature says `00` means "no data provider involved", yet eleven
codes carrying that prefix are emitted from a ValidateResponse, hence
after a provider round trip. The previous commit made those errors name
their provider in `meta`; this one fixes the code itself, so that the
prefix stops lying.

State the rule the codebase was already half-following: the prefix
answers "was a data provider queried?", not "where is the cause?". The
latter is already carried by the HTTP status, which is what tells the
caller what to do next — 422 fix your input, 404 close the case, 502
retry later. Both axes were encoding the cause, so neither encoded
provenance, and the redundancy is what let `00355` look legitimate.

A 422 may therefore carry a provider prefix. That is precisely the case
when only the provider can tell that the submitted input matches nobody:
SNGI matching failure, civility rejected by the provider, identity
criteria too ambiguous. ProviderUnprocessableEntityError derives the
code and `meta.provider` from the same `provider_name`, exactly like the
other AbstractGenericProviderError descendants, which makes the
invariant unbreakable rather than merely agreed upon.

Five shared subcodes are allocated in the XX56Z range, so every provider
reuses the same semantics:

  560 identity not recognised by the provider
  561 civility parameters rejected by the provider
  562 identifier rejected by the provider
  563 identity ambiguous for the provider
  564 unusable identity returned by the provider

Code changes, all of them 422 responses:

  00355 -> 35560 / 36560   CNAV, SNGI matching failure
  00366 -> 35561 / 36561   CNAV, provider side civility rejection
  00366 -> 26561           CNOUS, provider side civility rejection
  00360 -> 26562           CNOUS, INE rejected
  00391 -> 31563           GIP-MDS, several individuals matched
  00420..00425 -> 51564    FranceConnect, unusable returned identity

00360 and 00420 to 00425 keep existing: they are still emitted before
any call, by our own parameter validation. Splitting them is the point —
a single code used to cover both a caller typo and a provider verdict,
two situations with opposite retry semantics.

Wordings are preserved wherever they were already accurate, so the v2
legacy payloads are untouched, and its `not_found` mapping now keys on
`unidentified_person?` instead of the removed `field` reader.

spec/services/errors_nomenclature_spec.rb enforces both halves of the
rule: no code may carry an unallocated prefix, and no `00` code may be
declared on a ValidateResponse. The legacy FranceConnect token codes
50001 to 50004, whose `50` prefix is not mapped to any provider, are
explicitly listed there pending a reclassification of their own.

This supersedes the `provider:` option added to UnprocessableEntityError
in the previous commit: the migrated errors now get `meta.provider` for
free from AbstractGenericProviderError, so the option is removed.

