### PR TITLE
Drop the false child-in-household QF requirement

### DIFF
--- a/commons/endpoints/api_particulier/cnaf_msa_quotient_familial.yml
+++ b/commons/endpoints/api_particulier/cnaf_msa_quotient_familial.yml
@@ -19,9 +19,6 @@ fiche:
         - ✅ les régimes spéciaux suivants : artiste-auteur-compositeur, France Télécom, industries électriques et gazières, marin du commerce et pêche, mines (régime général), poste, RATP, SNCF, navigation intérieure en cas d'accord local et les pensions des autres régimes.
 
 
-        {:.fr-highlight.fr-highlight--caution}
-        > **La présence d'au moins un enfant dans le foyer fiscal est obligatoire** pour que le quotient familial soit calculé et renvoyé par l'API.
-
         **Ne sont pas concernés par cette API**, les bénéficiaires des régimes suivants :
 
         - ❌ le régime des titulaires de l'Assemblée nationale et du Sénat ;

--- a/commons/endpoints/api_particulier/v2_cnaf_msa_quotient_familial_v2.yml
+++ b/commons/endpoints/api_particulier/v2_cnaf_msa_quotient_familial_v2.yml
@@ -20,9 +20,6 @@ fiche:
         - ✅ les régimes spéciaux suivants : artiste-auteur-compositeur, France Télécom, industries électriques et gazières, marin du commerce et pêche, mines (régime général), poste, RATP, SNCF, navigation intérieure en cas d'accord local et les pensions des autres régimes.
 
 
-        {:.fr-highlight.fr-highlight--caution}
-        > **La présence d'au moins un enfant dans le foyer fiscal est obligatoire** pour que le quotient familial soit calculé et renvoyé par l'API.
-
         **Ne sont pas concernés par cette API**, les bénéficiaires des régimes suivants :
 
         - ❌ le régime des titulaires de l'Assemblée nationale et du Sénat ;


### PR DESCRIPTION
The provider told us this constraint does not exist: a quotient familial is computed and returned even without a child in the household. Remove the warning from both QF fiches while waiting for a wording the CNAF validates.

Closes https://linear.app/pole-api/issue/API-7339