### PR TITLE
Quotient familial: stop defaulting the period to the current month

### DIFF
--- a/commons/endpoints/_swagger_shared/cnav.yml
+++ b/commons/endpoints/_swagger_shared/cnav.yml
@@ -223,11 +223,11 @@ cnav:
   quotient_familial_v2:
     parameters:
       annee:
-        description: "Année du quotient familial recherché. Si l'année n'est pas renseignée, l'année utilisée par défaut est celle en cours. L'API permet d'accéder à un historique de maximum 2 ans."
+        description: "Année du quotient familial recherché, à fournir avec `mois`. Si ni `mois` ni `annee` ne sont renseignés, le dernier quotient familial connu est renvoyé ; si un seul des deux est renseigné, l'API renvoie une erreur 422. L'API permet d'accéder à un historique de maximum 2 ans."
         type: integer
         example: 2023
       mois:
-        description: "Mois du quotient familial recherché. Si le mois n'est pas renseigné, le mois utilisé par défaut est celui en cours."
+        description: "Mois du quotient familial recherché, à fournir avec `annee`. Si ni `mois` ni `annee` ne sont renseignés, le dernier quotient familial connu est renvoyé ; si un seul des deux est renseigné, l'API renvoie une erreur 422."
         type: integer
         example: 12
     title: Quotient familial CAF & MSA
@@ -382,19 +382,13 @@ cnav:
             title: "Année effective du QF"
             type: integer
             description: "Ce champ indique l'année effective du quotient familial appelé. C'est-à-dire l'année à laquelle s'applique le quotient familial. Cette année peut être différente de l'année de calcul du quotient si ce dernier a été recalculé suite à la réception d'informations rectifiant la situation de l'allocataire.
-              \n\n
-              - Si aucune année et aucun mois n'ont été renseignés en paramètres d'appel, le quotient familial retourné sera celui du mois de l'année en cours.
-              - Si aucune année n'a été renseignée et que le mois est renseigné, le quotient familial retourné sera celui du mois spécifié pour l'année en cours. En revanche, si la date finalement composée avec cette règle s'avère dans le futur (mois postérieur au moins en cours), l'API renvoie un erreur 400.
-              "
+              \n\n Si aucune période n'a été demandée (ni `mois` ni `annee`), ce champ vaut l'année en cours au moment de l'appel ; le quotient familial renvoyé est alors le dernier connu du fournisseur, dont la période de calcul est donnée par `annee_calcul` et `mois_calcul`."
             example: 2023
           mois:
             title: "Mois effectif du QF"
             type: integer
             description: "Mois effectif du quotient familial. C'est-à-dire le mois auquel s'applique le quotient familial. Ce mois peut être différent du mois de calcul du quotient si ce dernier a été recalculé suite à la réception d'informations rectifiant la situation de l'allocataire.
-              \n\n
-              - Si aucun mois et aucune année n'ont été renseignés en paramètres d'appel, le quotient familial retourné sera celui du mois de l'année en cours.
-              - Si le mois est renseigné mais qu'aucune année n'est saisie, le quotient familial retourné sera celui du mois spécifié pour l'année en cours. En revanche, si la date finalement composée avec cette règle s'avère dans le futur (mois postérieur au moins en cours), l'API renvoie un erreur 400.
-              - Si aucun mois n'a été renseigné mais que l'année a été spécifiée en paramètres d'appel, le quotient familial retourné sera celui du mois en cours pour l'année spécifiée."
+              \n\n Si aucune période n'a été demandée (ni `mois` ni `annee`), ce champ vaut le mois en cours au moment de l'appel ; le quotient familial renvoyé est alors le dernier connu du fournisseur, dont la période de calcul est donnée par `annee_calcul` et `mois_calcul`."
             example: 6
           annee_calcul:
             title: "Année du calcul du QF"
@@ -716,11 +710,11 @@ cnav:
       parameters:
         <<: *cnav_identite_pivot
         annee:
-          description: "Année du quotient familial recherché. Si l'année n'est pas renseignée, l'année utilisée par défaut est celle en cours. L'API permet d'accéder à un historique de maximum 2 ans."
+          description: "Année du quotient familial recherché, à fournir avec `mois`. Si ni `mois` ni `annee` ne sont renseignés, le dernier quotient familial connu est renvoyé ; si un seul des deux est renseigné, l'API renvoie une erreur 400. L'API permet d'accéder à un historique de maximum 2 ans."
           type: integer
           example: 2023
         mois:
-          description: "Mois du quotient familial recherché. Si le mois n'est pas renseigné, le mois utilisé par défaut est celui en cours."
+          description: "Mois du quotient familial recherché, à fournir avec `annee`. Si ni `mois` ni `annee` ne sont renseignés, le dernier quotient familial connu est renvoyé ; si un seul des deux est renseigné, l'API renvoie une erreur 400."
           type: integer
           example: 12
       attributes:
@@ -883,21 +877,13 @@ cnav:
           title: "Année effective du QF"
           type: integer
           description: "Année effective du quotient familial appelé.
-            \n\n
-            - Si aucune année et aucun mois n'ont été renseignés en paramètres d'appel, le quotient familial retourné sera celui du mois de l'année en cours.
-            - Si aucune année, ni aucun mois sont renseignés, l'appel est effectué par défaut avec l'année et le mois en cours.
-            - Si aucune année n'a été renseignée, et que le mois est renseigné, le quotient familial retourné sera celui du mois spécifié pour l'année en cours. En revanche, si la date finalement composée avec cette règle s'avère dans le futur (mois postérieur au moins en cours), l'API renvoie un erreur 400.
-            "
+            \n\n Si aucune période n'a été demandée (ni `mois` ni `annee`), ce champ vaut l'année en cours au moment de l'appel ; le quotient familial renvoyé est alors le dernier connu du fournisseur, dont la période de calcul est donnée par `annee_calcul` et `mois_calcul`."
           example: 2023
         mois:
           title: "Mois effectif du QF"
           type: integer
           description: "Mois effectif du quotient familial.
-            \n\n
-            - Si aucun mois n'est renseigné, le mois en cours est utilisé par défaut.
-            - Si le mois renseigné est postérieur au mois en cours, et qu'il compose une date dans le futur avec l'année appelée, l'API renvoie une erreur 400.
-            \n
-            - Si aucun mois n'a été renseigné mais que l'année a été spécifiée en paramètres d'appel, le quotient familial retourné sera celui du mois en cours pour l'année spécifiée."
+            \n\n Si aucune période n'a été demandée (ni `mois` ni `annee`), ce champ vaut le mois en cours au moment de l'appel ; le quotient familial renvoyé est alors le dernier connu du fournisseur, dont la période de calcul est donnée par `annee_calcul` et `mois_calcul`."
           example: 6
         annee_calcul:
           title: "Année du calcul du QF"

--- a/commons/endpoints/api_particulier/cnaf_msa_quotient_familial.yml
+++ b/commons/endpoints/api_particulier/cnaf_msa_quotient_familial.yml
@@ -38,13 +38,13 @@ fiche:
         - une fois par mois, après le premier week-end du mois, pour les allocataires CAF ;
         - en temps réel lorsqu'il y a un changement de situation pour les allocataires MSA.
         
-        **Le mois remonté est le mois en cours (M)**. Le calcul du quotient familial du mois M est basé sur les ressources du mois M-1. 
+        **Par défaut, le dernier quotient familial connu est remonté** (le QF CAF d'un mois n'est publié qu'après le premier week-end du mois suivant) ; un mois précis s'obtient en renseignant `mois` et `annee` ensemble. Le calcul du quotient familial du mois M est basé sur les ressources du mois M-1. 
 
         {:.fr-highlight}
         > 💡 Pour les collectivités effectuant une mise à jour annuelle des ressources en janvier, les appels doivent donc être effectués en février car c'est en février que le calcul intègre les ressources de janvier. 
     data:
       description: |+
-        **Cette API délivre les données suivantes du mois en cours** :
+        **Cette API délivre les données suivantes** :
         - **la [composition familiale](#composition-familiale)** du particulier : données d'identité de l'allocataire, du conjoint et des enfants ;
         - **le quotient familial CAF ou MSA** du particulier.
         - **l'adresse** du particulier au format de La Poste. ⚠️ _Cette adresse est déclarative. Si l'usager a changé d'adresse et n'a pas actualisé son adresse auprès de la CAF ou de la MSA, l'information sera donc obsolète._
@@ -131,7 +131,7 @@ fiche:
       - q: <a name="variation-qf"></a> Le quotient familial d'une même date peut-il changer au cours du temps ?
         a: |+
           **Le quotient familial CAF ou MSA d'un même mois peut changer**. Il est recalculé fréquemment au cours du temps par la CAF et la MSA. En effet, la situation de la personne peut évoluer : _perte d'un emploi, évolution des ressources, arrivée d'un enfant, majorité d'un enfant, modification de la législation, évolution des allocations logement etc._
-          **Cette variation apparaît notamment entre le quotient familial du mois appelé en début de mois ou en fin de mois**. **Le mois remonté par l'API est, par défaut, le mois en cours (M)**. Le calcul du QF M est basé sur les ressources du mois M-1.
+          **Cette variation apparaît notamment entre le quotient familial du mois appelé en début de mois ou en fin de mois**. **Par défaut, l'API remonte le dernier quotient familial connu**. Le calcul du QF d'un mois M est basé sur les ressources du mois M-1.
 
           **De plus, la date du calcul du quotient familial diffère** selon qu'il s'agit du quotient de la CAF ou de la MSA. La fréquence et la date de mise à jour sont également différentes :
           - La MSA met à jour les données en temps réel, à chaque changement ;

--- a/commons/endpoints/api_particulier/v2_cnaf_msa_quotient_familial_v2.yml
+++ b/commons/endpoints/api_particulier/v2_cnaf_msa_quotient_familial_v2.yml
@@ -36,14 +36,14 @@ fiche:
         Les données sont **mises à jour** :
         - **une fois par mois, après le premier week-end du mois, pour les allocataires CAF**
         - **en temps réel lorsqu'il y a un changement de situation pour les allocataires MSA**
-        Le mois remonté est le mois m-1. Par exemple, au mois de janvier, c'est le quotient familial du mois de décembre de l'année précédente qui est remonté. Il faut donc attendre le mois de février pour accéder au quotient familial du mois de janvier. Cette API opérée par la CNAV (Caisse nationale d'assurance vieillesse) est reliée au système d'information de la Caisse nationale des allocations familiales (CNAF) et à celui de la mutualité sociale agricole (MSA).
+        Par défaut, le dernier quotient familial connu est remonté : au début d'un mois, c'est généralement celui du mois précédent, la CAF publiant le QF d'un mois après son premier week-end. Cette API opérée par la CNAV (Caisse nationale d'assurance vieillesse) est reliée au système d'information de la Caisse nationale des allocations familiales (CNAF) et à celui de la mutualité sociale agricole (MSA).
 
         ⚠️ **Les informations obtenues sont représentatives de la situation connue par la CNAF et la MSA au moment de l'appel**, il est donc possible qu'un quotient familial appelé pour un mois donné à un instant T, soit différent s'il est redemandé à un instant T+. [En savoir plus](faq_entry_1_api_particulier_endpoint_cnav_quotient_familial_v2).
     data:
       description: |+
         **Cette API délivre** :
         - **la composition familiale** du particulier, [en savoir plus](#composition-familiale) ;
-        - **le quotient familial CAF ou MSA** du particulier. Par défaut, le quotient familial du **mois précédent, M-1** est transmis. Le QF de l'allocataire est disponible pour les 24 mois précédents en précisant le mois et l'année dans l'appel, [sa valeur peut varier au cours du temps](#variation-qf) suite à un recalcul  ;
+        - **le quotient familial CAF ou MSA** du particulier. Par défaut, le **dernier quotient familial connu** est transmis. Le QF de l'allocataire est disponible pour les 24 mois précédents en précisant le mois et l'année dans l'appel, [sa valeur peut varier au cours du temps](#variation-qf) suite à un recalcul  ;
         - **l'adresse** du particulier au format de La Poste. ⚠️ Cette adresse est déclarative. Si l'usager a changé d'adresse et n'a pas actualisé son adresse auprès de la CAF ou de la MSA, l'information sera donc obsolète. 
 
         {:.fr-highlight}
@@ -134,7 +134,7 @@ fiche:
       - q: <a name="variation-qf"></a> Le quotient familial d'une même date peut-il changer au cours du temps ?
         a: |+
           **Le quotient familial CAF ou MSA d'un même mois peut changer**. Il est recalculé fréquemment au cours du temps par la CAF et la MSA. En effet, la situation de la personne peut évoluer : _perte d'un emploi, évolution des ressources, arrivée d'un enfant, majorité d'un enfant, modification de la législation, évolution des allocations logement etc._
-          **Cette variation apparaît notamment entre le quotient familial du mois appelé en début de mois ou en fin de mois**. **Le mois remonté par l'API est, par défaut, le mois M-1.**
+          **Cette variation apparaît notamment entre le quotient familial du mois appelé en début de mois ou en fin de mois**. **Par défaut, l'API remonte le dernier quotient familial connu.**
 
           **De plus, la date du calcul du quotient familial diffère** selon qu'il s'agit du quotient de la CAF ou de la MSA. La fréquence et la date de mise à jour sont également différentes : 
           - La MSA met à jour les données en temps réel, à chaque changement ;

--- a/commons/swagger/api_particulier_open_api_static/v2.yaml
+++ b/commons/swagger/api_particulier_open_api_static/v2.yaml
@@ -1258,17 +1258,20 @@ paths:
         required: false
       - name: annee
         in: query
-        description: Année du quotient familial recherché. Si l'année n'est pas renseignée,
-          l'année utilisée par défaut est celle en cours. L'API permet d'accéder à
-          un historique de maximum 2 ans.
+        description: Année du quotient familial recherché, à fournir avec `mois`.
+          Si ni `mois` ni `annee` ne sont renseignés, le dernier quotient familial
+          connu est renvoyé ; si un seul des deux est renseigné, l'API renvoie une
+          erreur 400. L'API permet d'accéder à un historique de maximum 2 ans.
         example: 2023
         required: false
         schema:
           type: integer
       - name: mois
         in: query
-        description: Mois du quotient familial recherché. Si le mois n'est pas renseigné,
-          le mois utilisé par défaut est celui en cours.
+        description: Mois du quotient familial recherché, à fournir avec `annee`.
+          Si ni `mois` ni `annee` ne sont renseignés, le dernier quotient familial
+          connu est renvoyé ; si un seul des deux est renseigné, l'API renvoie une
+          erreur 400.
         example: 12
         required: false
         schema:
@@ -1518,26 +1521,19 @@ paths:
                     title: Année effective du QF
                     type: integer
                     description: "Année effective du quotient familial appelé. \n\n
-                      - Si aucune année et aucun mois n'ont été renseignés en paramètres
-                      d'appel, le quotient familial retourné sera celui du mois de
-                      l'année en cours. - Si aucune année, ni aucun mois sont renseignés,
-                      l'appel est effectué par défaut avec l'année et le mois en cours.
-                      - Si aucune année n'a été renseignée, et que le mois est renseigné,
-                      le quotient familial retourné sera celui du mois spécifié pour
-                      l'année en cours. En revanche, si la date finalement composée
-                      avec cette règle s'avère dans le futur (mois postérieur au moins
-                      en cours), l'API renvoie un erreur 400. "
+                      Si aucune période n'a été demandée (ni `mois` ni `annee`), ce
+                      champ vaut l'année en cours au moment de l'appel ; le quotient
+                      familial renvoyé est alors le dernier connu du fournisseur, dont
+                      la période de calcul est donnée par `annee_calcul` et `mois_calcul`."
                     example: 2023
                   mois:
                     title: Mois effectif du QF
                     type: integer
-                    description: "Mois effectif du quotient familial. \n\n - Si aucun
-                      mois n'est renseigné, le mois en cours est utilisé par défaut.
-                      - Si le mois renseigné est postérieur au mois en cours, et qu'il
-                      compose une date dans le futur avec l'année appelée, l'API renvoie
-                      une erreur 400. \n - Si aucun mois n'a été renseigné mais que
-                      l'année a été spécifiée en paramètres d'appel, le quotient familial
-                      retourné sera celui du mois en cours pour l'année spécifiée."
+                    description: "Mois effectif du quotient familial. \n\n Si aucune
+                      période n'a été demandée (ni `mois` ni `annee`), ce champ vaut le
+                      mois en cours au moment de l'appel ; le quotient familial renvoyé
+                      est alors le dernier connu du fournisseur, dont la période de calcul
+                      est donnée par `annee_calcul` et `mois_calcul`."
                     example: 6
           x-operationId: api_particulier_v2_cnav_quotient_familial_v2
         '400':
@@ -1552,6 +1548,11 @@ paths:
                       dans le futur.
                     message: L'année demandée n'est pas correctement formatée ou est
                       dans le futur.
+                Période incomplète:
+                  value:
+                    error: bad_request
+                    reason: Les paramètres mois et annee doivent être fournis ensemble.
+                    message: Les paramètres mois et annee doivent être fournis ensemble.
               schema:
                 "$ref": "#/components/schemas/Error"
         '404':

--- a/commons/swagger/openapi-particulier.yaml
+++ b/commons/swagger/openapi-particulier.yaml
@@ -7805,17 +7805,20 @@ paths:
         required: false
       - name: annee
         in: query
-        description: Année du quotient familial recherché. Si l'année n'est pas renseignée,
-          l'année utilisée par défaut est celle en cours. L'API permet d'accéder à
-          un historique de maximum 2 ans.
+        description: Année du quotient familial recherché, à fournir avec `mois`.
+          Si ni `mois` ni `annee` ne sont renseignés, le dernier quotient familial
+          connu est renvoyé ; si un seul des deux est renseigné, l'API renvoie une
+          erreur 422. L'API permet d'accéder à un historique de maximum 2 ans.
         example: 2023
         required: false
         schema:
           type: integer
       - name: mois
         in: query
-        description: Mois du quotient familial recherché. Si le mois n'est pas renseigné,
-          le mois utilisé par défaut est celui en cours.
+        description: Mois du quotient familial recherché, à fournir avec `annee`.
+          Si ni `mois` ni `annee` ne sont renseignés, le dernier quotient familial
+          connu est renvoyé ; si un seul des deux est renseigné, l'API renvoie une
+          erreur 422.
         example: 12
         required: false
         schema:
@@ -8109,15 +8112,12 @@ paths:
                               le quotient familial. Cette année peut être différente
                               de l'année de calcul du quotient si ce dernier a été
                               recalculé suite à la réception d'informations rectifiant
-                              la situation de l'allocataire. \n\n - Si aucune année
-                              et aucun mois n'ont été renseignés en paramètres d'appel,
-                              le quotient familial retourné sera celui du mois de
-                              l'année en cours. - Si aucune année n'a été renseignée
-                              et que le mois est renseigné, le quotient familial retourné
-                              sera celui du mois spécifié pour l'année en cours. En
-                              revanche, si la date finalement composée avec cette
-                              règle s'avère dans le futur (mois postérieur au moins
-                              en cours), l'API renvoie un erreur 400. "
+                              la situation de l'allocataire. \n\n Si aucune période
+                              n'a été demandée (ni `mois` ni `annee`), ce champ vaut
+                              l'année en cours au moment de l'appel ; le quotient
+                              familial renvoyé est alors le dernier connu du fournisseur,
+                              dont la période de calcul est donnée par `annee_calcul`
+                              et `mois_calcul`."
                             example: 2023
                           mois:
                             title: Mois effectif du QF
@@ -8126,18 +8126,12 @@ paths:
                               le mois auquel s'applique le quotient familial. Ce mois
                               peut être différent du mois de calcul du quotient si
                               ce dernier a été recalculé suite à la réception d'informations
-                              rectifiant la situation de l'allocataire. \n\n - Si
-                              aucun mois et aucune année n'ont été renseignés en paramètres
-                              d'appel, le quotient familial retourné sera celui du
-                              mois de l'année en cours. - Si le mois est renseigné
-                              mais qu'aucune année n'est saisie, le quotient familial
-                              retourné sera celui du mois spécifié pour l'année en
-                              cours. En revanche, si la date finalement composée avec
-                              cette règle s'avère dans le futur (mois postérieur au
-                              moins en cours), l'API renvoie un erreur 400. - Si aucun
-                              mois n'a été renseigné mais que l'année a été spécifiée
-                              en paramètres d'appel, le quotient familial retourné
-                              sera celui du mois en cours pour l'année spécifiée."
+                              rectifiant la situation de l'allocataire. \n\n Si aucune
+                              période n'a été demandée (ni `mois` ni `annee`), ce
+                              champ vaut le mois en cours au moment de l'appel ; le
+                              quotient familial renvoyé est alors le dernier connu
+                              du fournisseur, dont la période de calcul est donnée
+                              par `annee_calcul` et `mois_calcul`."
                             example: 6
                           annee_calcul:
                             title: Année du calcul du QF
@@ -8186,10 +8180,20 @@ paths:
                 - links
                 - meta
         '422':
-          description: Impossible d'identifier l'allocataire
+          description: Paramètres invalides ou allocataire non identifiable
           content:
             application/json:
               examples:
+                entite_non_traitable_00357:
+                  value:
+                    errors:
+                    - code: '00357'
+                      title: Entité non traitable
+                      detail: Les paramètres mois et annee doivent être fournis ensemble.
+                      source:
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Les paramètres mois et annee doivent être fournis ensemble.
                 identite_non_reconnue_par_le_fournisseur_de_donnees_35560:
                   value:
                     errors:
@@ -8485,17 +8489,20 @@ paths:
           type: string
       - name: annee
         in: query
-        description: Année du quotient familial recherché. Si l'année n'est pas renseignée,
-          l'année utilisée par défaut est celle en cours. L'API permet d'accéder à
-          un historique de maximum 2 ans.
+        description: Année du quotient familial recherché, à fournir avec `mois`.
+          Si ni `mois` ni `annee` ne sont renseignés, le dernier quotient familial
+          connu est renvoyé ; si un seul des deux est renseigné, l'API renvoie une
+          erreur 422. L'API permet d'accéder à un historique de maximum 2 ans.
         example: 2023
         required: false
         schema:
           type: integer
       - name: mois
         in: query
-        description: Mois du quotient familial recherché. Si le mois n'est pas renseigné,
-          le mois utilisé par défaut est celui en cours.
+        description: Mois du quotient familial recherché, à fournir avec `annee`.
+          Si ni `mois` ni `annee` ne sont renseignés, le dernier quotient familial
+          connu est renvoyé ; si un seul des deux est renseigné, l'API renvoie une
+          erreur 422.
         example: 12
         required: false
         schema:
@@ -8786,15 +8793,12 @@ paths:
                               le quotient familial. Cette année peut être différente
                               de l'année de calcul du quotient si ce dernier a été
                               recalculé suite à la réception d'informations rectifiant
-                              la situation de l'allocataire. \n\n - Si aucune année
-                              et aucun mois n'ont été renseignés en paramètres d'appel,
-                              le quotient familial retourné sera celui du mois de
-                              l'année en cours. - Si aucune année n'a été renseignée
-                              et que le mois est renseigné, le quotient familial retourné
-                              sera celui du mois spécifié pour l'année en cours. En
-                              revanche, si la date finalement composée avec cette
-                              règle s'avère dans le futur (mois postérieur au moins
-                              en cours), l'API renvoie un erreur 400. "
+                              la situation de l'allocataire. \n\n Si aucune période
+                              n'a été demandée (ni `mois` ni `annee`), ce champ vaut
+                              l'année en cours au moment de l'appel ; le quotient
+                              familial renvoyé est alors le dernier connu du fournisseur,
+                              dont la période de calcul est donnée par `annee_calcul`
+                              et `mois_calcul`."
                             example: 2023
                           mois:
                             title: Mois effectif du QF
@@ -8803,18 +8807,12 @@ paths:
                               le mois auquel s'applique le quotient familial. Ce mois
                               peut être différent du mois de calcul du quotient si
                               ce dernier a été recalculé suite à la réception d'informations
-                              rectifiant la situation de l'allocataire. \n\n - Si
-                              aucun mois et aucune année n'ont été renseignés en paramètres
-                              d'appel, le quotient familial retourné sera celui du
-                              mois de l'année en cours. - Si le mois est renseigné
-                              mais qu'aucune année n'est saisie, le quotient familial
-                              retourné sera celui du mois spécifié pour l'année en
-                              cours. En revanche, si la date finalement composée avec
-                              cette règle s'avère dans le futur (mois postérieur au
-                              moins en cours), l'API renvoie un erreur 400. - Si aucun
-                              mois n'a été renseigné mais que l'année a été spécifiée
-                              en paramètres d'appel, le quotient familial retourné
-                              sera celui du mois en cours pour l'année spécifiée."
+                              rectifiant la situation de l'allocataire. \n\n Si aucune
+                              période n'a été demandée (ni `mois` ni `annee`), ce
+                              champ vaut le mois en cours au moment de l'appel ; le
+                              quotient familial renvoyé est alors le dernier connu
+                              du fournisseur, dont la période de calcul est donnée
+                              par `annee_calcul` et `mois_calcul`."
                             example: 6
                           annee_calcul:
                             title: Année du calcul du QF
@@ -8863,10 +8861,20 @@ paths:
                 - links
                 - meta
         '422':
-          description: Impossible d'identifier l'allocataire
+          description: Paramètres invalides ou allocataire non identifiable
           content:
             application/json:
               examples:
+                entite_non_traitable_00357:
+                  value:
+                    errors:
+                    - code: '00357'
+                      title: Entité non traitable
+                      detail: Les paramètres mois et annee doivent être fournis ensemble.
+                      source:
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Les paramètres mois et annee doivent être fournis ensemble.
                 identite_non_reconnue_par_le_fournisseur_de_donnees_35560:
                   value:
                     errors:

--- a/commons/swagger/openapi-particulierv2.yaml
+++ b/commons/swagger/openapi-particulierv2.yaml
@@ -1416,17 +1416,20 @@ paths:
         required: false
       - name: annee
         in: query
-        description: Année du quotient familial recherché. Si l'année n'est pas renseignée,
-          l'année utilisée par défaut est celle en cours. L'API permet d'accéder à
-          un historique de maximum 2 ans.
+        description: Année du quotient familial recherché, à fournir avec `mois`.
+          Si ni `mois` ni `annee` ne sont renseignés, le dernier quotient familial
+          connu est renvoyé ; si un seul des deux est renseigné, l'API renvoie une
+          erreur 400. L'API permet d'accéder à un historique de maximum 2 ans.
         example: 2023
         required: false
         schema:
           type: integer
       - name: mois
         in: query
-        description: Mois du quotient familial recherché. Si le mois n'est pas renseigné,
-          le mois utilisé par défaut est celui en cours.
+        description: Mois du quotient familial recherché, à fournir avec `annee`.
+          Si ni `mois` ni `annee` ne sont renseignés, le dernier quotient familial
+          connu est renvoyé ; si un seul des deux est renseigné, l'API renvoie une
+          erreur 400.
         example: 12
         required: false
         schema:
@@ -1684,26 +1687,19 @@ paths:
                     title: Année effective du QF
                     type: integer
                     description: "Année effective du quotient familial appelé. \n\n
-                      - Si aucune année et aucun mois n'ont été renseignés en paramètres
-                      d'appel, le quotient familial retourné sera celui du mois de
-                      l'année en cours. - Si aucune année, ni aucun mois sont renseignés,
-                      l'appel est effectué par défaut avec l'année et le mois en cours.
-                      - Si aucune année n'a été renseignée, et que le mois est renseigné,
-                      le quotient familial retourné sera celui du mois spécifié pour
-                      l'année en cours. En revanche, si la date finalement composée
-                      avec cette règle s'avère dans le futur (mois postérieur au moins
-                      en cours), l'API renvoie un erreur 400. "
+                      Si aucune période n'a été demandée (ni `mois` ni `annee`), ce
+                      champ vaut l'année en cours au moment de l'appel ; le quotient
+                      familial renvoyé est alors le dernier connu du fournisseur,
+                      dont la période de calcul est donnée par `annee_calcul` et `mois_calcul`."
                     example: 2023
                   mois:
                     title: Mois effectif du QF
                     type: integer
-                    description: "Mois effectif du quotient familial. \n\n - Si aucun
-                      mois n'est renseigné, le mois en cours est utilisé par défaut.
-                      - Si le mois renseigné est postérieur au mois en cours, et qu'il
-                      compose une date dans le futur avec l'année appelée, l'API renvoie
-                      une erreur 400. \n - Si aucun mois n'a été renseigné mais que
-                      l'année a été spécifiée en paramètres d'appel, le quotient familial
-                      retourné sera celui du mois en cours pour l'année spécifiée."
+                    description: "Mois effectif du quotient familial. \n\n Si aucune
+                      période n'a été demandée (ni `mois` ni `annee`), ce champ vaut
+                      le mois en cours au moment de l'appel ; le quotient familial
+                      renvoyé est alors le dernier connu du fournisseur, dont la période
+                      de calcul est donnée par `annee_calcul` et `mois_calcul`."
                     example: 6
                   annee_calcul:
                     title: Année du calcul du QF
@@ -1737,6 +1733,11 @@ paths:
                       N-2.
                     message: L'année demandée doit être l'année en cours (N), N-1
                       ou N-2.
+                Période incomplète:
+                  value:
+                    error: bad_request
+                    reason: Les paramètres mois et annee doivent être fournis ensemble.
+                    message: Les paramètres mois et annee doivent être fournis ensemble.
                 Allocataire non identifié:
                   value:
                     error: not_found

--- a/siade/app/errors/unprocessable_entity_error.rb
+++ b/siade/app/errors/unprocessable_entity_error.rb
@@ -44,6 +44,7 @@ class UnprocessableEntityError < ApplicationError
       # CNAV
       annee: '00353',
       annee_cnav: '00356',
+      periode: '00357',
       mois: '00354',
       # MESRI / MEN / CNOUS
       ine: '00360',

--- a/siade/app/interactors/cnav/quotient_familial_v2/make_request.rb
+++ b/siade/app/interactors/cnav/quotient_familial_v2/make_request.rb
@@ -17,7 +17,7 @@ class CNAV::QuotientFamilialV2::MakeRequest < CNAV::MakeRequest
 
   def request_params
     super.merge(
-      anneeDemandee: context.params[:annee].presence || Time.zone.today.year,
+      anneeDemandee: context.params[:annee].presence,
       moisDemande: mois_demande
     ).compact
   end
@@ -25,6 +25,6 @@ class CNAV::QuotientFamilialV2::MakeRequest < CNAV::MakeRequest
   private
 
   def mois_demande
-    Kernel.format('%<month>02d', month: context.params[:mois].presence&.to_i || Time.zone.today.month)
+    Kernel.format('%<month>02d', month: context.params[:mois].to_i) if context.params[:mois].present?
   end
 end

--- a/siade/app/interactors/cnav/quotient_familial_v2/validate_period.rb
+++ b/siade/app/interactors/cnav/quotient_familial_v2/validate_period.rb
@@ -1,0 +1,7 @@
+class CNAV::QuotientFamilialV2::ValidatePeriod < ValidateParamInteractor
+  def call
+    return if param(:mois).present? == param(:annee).present?
+
+    invalid_param!(:periode)
+  end
+end

--- a/siade/app/organizers/cnav/quotient_familial_v2/validate_params.rb
+++ b/siade/app/organizers/cnav/quotient_familial_v2/validate_params.rb
@@ -1,5 +1,6 @@
 class CNAV::QuotientFamilialV2::ValidateParams < ValidateParamsOrganizer
   organize ValidateRecipient,
+    CNAV::QuotientFamilialV2::ValidatePeriod,
     CNAV::QuotientFamilialV2::ValidateYear,
     CNAV::QuotientFamilialV2::ValidateMonth,
     CNAV::ValidateSexeEtatCivil,

--- a/siade/config/errors.yml
+++ b/siade/config/errors.yml
@@ -499,6 +499,10 @@
   title: 'Entité non traitable'
   detail: "L'année demandée doit être l'année en cours (N), N-1 ou N-2."
 
+- code: '00357'
+  title: 'Entité non traitable'
+  detail: "Les paramètres mois et annee doivent être fournis ensemble."
+
 - code: '00354'
   title: 'Entité non traitable'
   detail: "Le mois demandé est incorrect ou est dans le futur."

--- a/siade/spec/interactors/cnav/quotient_familial_v2/make_request_spec.rb
+++ b/siade/spec/interactors/cnav/quotient_familial_v2/make_request_spec.rb
@@ -89,6 +89,31 @@ RSpec.describe CNAV::QuotientFamilialV2::MakeRequest, type: :make_request do
     end
   end
 
+  describe 'without a period' do
+    let(:params) { super().except(:annee, :mois) }
+
+    let!(:stubbed_request) do
+      stub_request(:get, Siade.credentials[:cnav_quotient_familial_v2_url]).with(
+        query: {
+          codeLieuNaissance: '17300',
+          codePaysNaissance: '99100',
+          dateNaissance: '1980-06-12',
+          genre: 'M',
+          listePrenoms: 'JEAN-PASCAL',
+          nomNaissance: 'CHAMPION'
+        }
+      ).to_return(
+        status: 200,
+        body: read_payload_file('cnav/quotient_familial_v2/make_request_valid.json')
+      )
+    end
+
+    it 'lets the provider pick the latest known quotient familial' do
+      make_call
+      expect(stubbed_request).to have_been_requested
+    end
+  end
+
   describe 'with FranceConnect params' do
     let(:params) do
       {

--- a/siade/spec/interactors/cnav/quotient_familial_v2/validate_period_spec.rb
+++ b/siade/spec/interactors/cnav/quotient_familial_v2/validate_period_spec.rb
@@ -1,0 +1,48 @@
+RSpec.describe CNAV::QuotientFamilialV2::ValidatePeriod, type: :validate_param_interactor do
+  subject { described_class.call(params: { mois:, annee: }) }
+
+  context 'when both mois and annee are given' do
+    let(:mois) { 8 }
+    let(:annee) { 2024 }
+
+    it { is_expected.to be_a_success }
+  end
+
+  context 'when neither mois nor annee is given' do
+    let(:mois) { nil }
+    let(:annee) { nil }
+
+    it { is_expected.to be_a_success }
+  end
+
+  shared_examples 'half a period' do
+    it { is_expected.to be_a_failure }
+
+    its(:errors) { is_expected.to include(instance_of(UnprocessableEntityError)) }
+
+    it 'tells the caller both parameters go together' do
+      expect(subject.errors.first.code).to eq('00357')
+    end
+  end
+
+  context 'when only mois is given' do
+    let(:mois) { 8 }
+    let(:annee) { nil }
+
+    it_behaves_like 'half a period'
+  end
+
+  context 'when only annee is given' do
+    let(:mois) { nil }
+    let(:annee) { 2024 }
+
+    it_behaves_like 'half a period'
+  end
+
+  context 'when mois is blank' do
+    let(:mois) { '' }
+    let(:annee) { 2024 }
+
+    it_behaves_like 'half a period'
+  end
+end

--- a/siade/spec/organizers/cnav/quotient_familial_v2/validate_params_spec.rb
+++ b/siade/spec/organizers/cnav/quotient_familial_v2/validate_params_spec.rb
@@ -174,6 +174,21 @@ RSpec.describe CNAV::QuotientFamilialV2::ValidateParams, type: :validate_params 
     its(:errors) { is_expected.to include(instance_of(InvalidRecipientError)) }
   end
 
+  context 'with mois but no annee' do
+    let(:annee) { nil }
+
+    it { is_expected.to be_a_failure }
+
+    its(:errors) { is_expected.to include(instance_of(UnprocessableEntityError)) }
+  end
+
+  context 'with neither mois nor annee' do
+    let(:annee) { nil }
+    let(:mois) { nil }
+
+    it { is_expected.to be_a_success }
+  end
+
   context 'with too ancient year' do
     let(:annee) { 2021 }
 

--- a/siade/spec/requests/api_particulier/v2/cnav/quotient_familial_v2_spec.rb
+++ b/siade/spec/requests/api_particulier/v2/cnav/quotient_familial_v2_spec.rb
@@ -115,6 +115,16 @@ RSpec.describe 'CNAV: Quotient Familial V2', api: :particulierv2, type: %i[reque
                   run_test!
                 end
 
+                context 'Période incomplète' do
+                  let(:annee) { nil }
+
+                  build_rswag_example(UnprocessableEntityError.new(:periode))
+
+                  schema '$ref' => '#/components/schemas/Error'
+
+                  run_test!
+                end
+
                 context 'Allocataire non identifié' do
                   before do
                     stub_sngi_404('quotient_familial_v2')

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/quotient_familial_with_civility_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/quotient_familial_with_civility_spec.rb
@@ -111,8 +111,20 @@ RSpec.describe 'API Particulier CNAV: Quotient Familial with civility', api: :pa
           end
         end
 
+        describe 'when only one of mois and annee is given' do
+          response '422', 'Paramètres invalides ou allocataire non identifiable' do
+            let(:mois) { 8 }
+
+            build_rswag_example(UnprocessableEntityError.new(:periode))
+
+            schema '$ref' => '#/components/schemas/Error'
+
+            run_test!
+          end
+        end
+
         describe 'when the user is not found' do
-          response '422', "Impossible d'identifier l'allocataire" do
+          response '422', 'Paramètres invalides ou allocataire non identifiable' do
             let(:codeCogInseePaysNaissance) { '99623' }
             # rubocop:disable RSpec/ContextWording
             context 'Allocataire non identifié' do

--- a/siade/spec/requests/api_particulier/v3_and_more/cnav/quotient_familial_with_france_connect_spec.rb
+++ b/siade/spec/requests/api_particulier/v3_and_more/cnav/quotient_familial_with_france_connect_spec.rb
@@ -55,8 +55,20 @@ RSpec.describe 'API Particulier: CNAV: Quotient Familial with FranceConnect', ap
           end
         end
 
+        describe 'when only one of mois and annee is given' do
+          response '422', 'Paramètres invalides ou allocataire non identifiable' do
+            let(:mois) { 8 }
+
+            build_rswag_example(UnprocessableEntityError.new(:periode))
+
+            schema '$ref' => '#/components/schemas/Error'
+
+            run_test!
+          end
+        end
+
         describe 'when the user is not found' do
-          response '422', "Impossible d'identifier l'allocataire" do
+          response '422', 'Paramètres invalides ou allocataire non identifiable' do
             let(:codeCogInseePaysNaissance) { '99623' }
             # rubocop:disable RSpec/ContextWording
             context 'Allocataire non identifié' do

--- a/site/config/changelogs.yml
+++ b/site/config/changelogs.yml
@@ -1,3 +1,9 @@
+- date: 2026-08-31
+  scope: api_particulier
+  title: "Quotient familial : le dernier QF connu est renvoyé par défaut"
+  description: |
+    Sur la fiche [quotient familial](<%= endpoint_path(uid: 'cnav/quotient_familial') %>), les paramètres `mois` et `annee` ne sont **plus préremplis avec le mois en cours** lorsqu'ils sont absents : la CAF ou la MSA renvoie alors le **dernier quotient familial connu**, dont le mois peut être antérieur au mois courant (le QF CAF d'un mois n'est publié qu'après son premier week-end). Pour consulter l'historique, `mois` et `annee` doivent être fournis ensemble ; n'en fournir qu'un seul renvoie désormais une erreur (400 en v2, 422 en v3).
+
 - date: 2026-08-25
   scope: api_particulier
   title: "CNOUS étudiant boursier : `campaignYear` accepte la campagne en cours et à venir"


### PR DESCRIPTION
Without `mois`/`annee` the CNAV provider now returns its latest known QF; a half period is rejected as a parameter error (`00357`, 400 on v2 / 422 on v3) before reaching the provider.

- `ValidatePeriod` step in the CNAV QF organizer + catalogue entry
- OpenAPI (source, generated, static v2), fiches + changelog entry

Closes API-7338 → https://linear.app/pole-api/issue/API-7338/api-quotient-familial-ne-plus-preremplir-automatiquement-les