### PR TITLE
Filter INSEE's rotating password in VCR cassettes

### DIFF
--- a/siade/spec/fixtures/cassettes/insee/siege/active_GE_with_token.yml
+++ b/siade/spec/fixtures/cassettes/insee/siege/active_GE_with_token.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<URL_INSEE_AUTH>"
     body:
       encoding: US-ASCII
-      string: client_id=insee_sirene_client_id&client_secret=insee_sirene_client_secret&grant_type=password&username=insee_apim_username&password=insee_apim_password
+      string: client_id=insee_sirene_client_id&client_secret=insee_sirene_client_secret&grant_type=password&username=insee_apim_username&password=<INSEE_PASSWORD>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/siade/spec/fixtures/cassettes/insee/siege/gendarmerie_limousin_with_token.yml
+++ b/siade/spec/fixtures/cassettes/insee/siege/gendarmerie_limousin_with_token.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<URL_INSEE_AUTH>"
     body:
       encoding: US-ASCII
-      string: client_id=insee_sirene_client_id&client_secret=insee_sirene_client_secret&grant_type=password&username=insee_apim_username&password=insee_apim_password
+      string: client_id=insee_sirene_client_id&client_secret=insee_sirene_client_secret&grant_type=password&username=insee_apim_username&password=<INSEE_PASSWORD>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/siade/spec/fixtures/cassettes/insee/siege/non_diffusable_ceased_with_token.yml
+++ b/siade/spec/fixtures/cassettes/insee/siege/non_diffusable_ceased_with_token.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<URL_INSEE_AUTH>"
     body:
       encoding: US-ASCII
-      string: client_id=insee_sirene_client_id&client_secret=insee_sirene_client_secret&grant_type=password&username=insee_apim_username&password=insee_apim_password
+      string: client_id=insee_sirene_client_id&client_secret=insee_sirene_client_secret&grant_type=password&username=insee_apim_username&password=<INSEE_PASSWORD>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/siade/spec/fixtures/cassettes/insee/siege/non_diffusable_with_token.yml
+++ b/siade/spec/fixtures/cassettes/insee/siege/non_diffusable_with_token.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<URL_INSEE_AUTH>"
     body:
       encoding: US-ASCII
-      string: client_id=insee_sirene_client_id&client_secret=insee_sirene_client_secret&grant_type=password&username=insee_apim_username&password=insee_apim_password
+      string: client_id=insee_sirene_client_id&client_secret=insee_sirene_client_secret&grant_type=password&username=insee_apim_username&password=<INSEE_PASSWORD>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/siade/spec/fixtures/cassettes/insee/siege/non_existent_with_token.yml
+++ b/siade/spec/fixtures/cassettes/insee/siege/non_existent_with_token.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<URL_INSEE_AUTH>"
     body:
       encoding: US-ASCII
-      string: client_id=insee_sirene_client_id&client_secret=insee_sirene_client_secret&grant_type=password&username=insee_apim_username&password=insee_apim_password
+      string: client_id=insee_sirene_client_id&client_secret=insee_sirene_client_secret&grant_type=password&username=insee_apim_username&password=<INSEE_PASSWORD>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/siade/spec/fixtures/cassettes/insee/siege/redirected_with_token.yml
+++ b/siade/spec/fixtures/cassettes/insee/siege/redirected_with_token.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<URL_INSEE_AUTH>"
     body:
       encoding: US-ASCII
-      string: client_id=insee_sirene_client_id&client_secret=insee_sirene_client_secret&grant_type=password&username=insee_apim_username&password=insee_apim_password
+      string: client_id=insee_sirene_client_id&client_secret=insee_sirene_client_secret&grant_type=password&username=insee_apim_username&password=<INSEE_PASSWORD>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/siade/spec/fixtures/cassettes/insee/siren/active_GE_with_token.yml
+++ b/siade/spec/fixtures/cassettes/insee/siren/active_GE_with_token.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<URL_INSEE_AUTH>"
     body:
       encoding: US-ASCII
-      string: client_id=insee_sirene_client_id&client_secret=insee_sirene_client_secret&grant_type=password&username=insee_apim_username&password=insee_apim_password
+      string: client_id=insee_sirene_client_id&client_secret=insee_sirene_client_secret&grant_type=password&username=insee_apim_username&password=<INSEE_PASSWORD>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/siade/spec/fixtures/cassettes/insee/siren/non_diffusable_with_token.yml
+++ b/siade/spec/fixtures/cassettes/insee/siren/non_diffusable_with_token.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<URL_INSEE_AUTH>"
     body:
       encoding: US-ASCII
-      string: client_id=insee_sirene_client_id&client_secret=insee_sirene_client_secret&grant_type=password&username=insee_apim_username&password=insee_apim_password
+      string: client_id=insee_sirene_client_id&client_secret=insee_sirene_client_secret&grant_type=password&username=insee_apim_username&password=<INSEE_PASSWORD>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/siade/spec/fixtures/cassettes/insee/siren/non_existent_with_token.yml
+++ b/siade/spec/fixtures/cassettes/insee/siren/non_existent_with_token.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<URL_INSEE_AUTH>"
     body:
       encoding: US-ASCII
-      string: client_id=insee_sirene_client_id&client_secret=insee_sirene_client_secret&grant_type=password&username=insee_apim_username&password=insee_apim_password
+      string: client_id=insee_sirene_client_id&client_secret=insee_sirene_client_secret&grant_type=password&username=insee_apim_username&password=<INSEE_PASSWORD>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/siade/spec/fixtures/cassettes/insee/siren/redirected.yml
+++ b/siade/spec/fixtures/cassettes/insee/siren/redirected.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<URL_INSEE_AUTH>"
     body:
       encoding: US-ASCII
-      string: client_id=insee_sirene_client_id&client_secret=insee_sirene_client_secret&grant_type=password&username=insee_apim_username&password=insee_apim_password
+      string: client_id=insee_sirene_client_id&client_secret=insee_sirene_client_secret&grant_type=password&username=insee_apim_username&password=<INSEE_PASSWORD>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/siade/spec/fixtures/cassettes/insee/siret/active_GE_with_token.yml
+++ b/siade/spec/fixtures/cassettes/insee/siret/active_GE_with_token.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<URL_INSEE_AUTH>"
     body:
       encoding: US-ASCII
-      string: client_id=insee_sirene_client_id&client_secret=insee_sirene_client_secret&grant_type=password&username=insee_apim_username&password=insee_apim_password
+      string: client_id=insee_sirene_client_id&client_secret=insee_sirene_client_secret&grant_type=password&username=insee_apim_username&password=<INSEE_PASSWORD>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/siade/spec/fixtures/cassettes/insee/siret/non_diffusable_ceased.yml
+++ b/siade/spec/fixtures/cassettes/insee/siret/non_diffusable_ceased.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<URL_INSEE_AUTH>"
     body:
       encoding: US-ASCII
-      string: client_id=insee_sirene_client_id&client_secret=insee_sirene_client_secret&grant_type=password&username=insee_apim_username&password=insee_apim_password
+      string: client_id=insee_sirene_client_id&client_secret=insee_sirene_client_secret&grant_type=password&username=insee_apim_username&password=<INSEE_PASSWORD>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/siade/spec/fixtures/cassettes/insee/siret/non_diffusable_with_token.yml
+++ b/siade/spec/fixtures/cassettes/insee/siret/non_diffusable_with_token.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<URL_INSEE_AUTH>"
     body:
       encoding: US-ASCII
-      string: client_id=insee_sirene_client_id&client_secret=insee_sirene_client_secret&grant_type=password&username=insee_apim_username&password=insee_apim_password
+      string: client_id=insee_sirene_client_id&client_secret=insee_sirene_client_secret&grant_type=password&username=insee_apim_username&password=<INSEE_PASSWORD>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/siade/spec/fixtures/cassettes/insee/siret/non_existent_with_token.yml
+++ b/siade/spec/fixtures/cassettes/insee/siret/non_existent_with_token.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<URL_INSEE_AUTH>"
     body:
       encoding: US-ASCII
-      string: client_id=insee_sirene_client_id&client_secret=insee_sirene_client_secret&grant_type=password&username=insee_apim_username&password=insee_apim_password
+      string: client_id=insee_sirene_client_id&client_secret=insee_sirene_client_secret&grant_type=password&username=insee_apim_username&password=<INSEE_PASSWORD>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/siade/spec/fixtures/cassettes/insee/siret/redirected.yml
+++ b/siade/spec/fixtures/cassettes/insee/siret/redirected.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<URL_INSEE_AUTH>"
     body:
       encoding: US-ASCII
-      string: client_id=insee_sirene_client_id&client_secret=insee_sirene_client_secret&grant_type=password&username=insee_apim_username&password=insee_apim_password
+      string: client_id=insee_sirene_client_id&client_secret=insee_sirene_client_secret&grant_type=password&username=insee_apim_username&password=<INSEE_PASSWORD>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/siade/spec/fixtures/cassettes/insee/token.yml
+++ b/siade/spec/fixtures/cassettes/insee/token.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<URL_INSEE_AUTH>"
     body:
       encoding: US-ASCII
-      string: client_id=insee_sirene_client_id&client_secret=insee_sirene_client_secret&grant_type=password&username=insee_apim_username&password=insee_apim_password
+      string: client_id=insee_sirene_client_id&client_secret=insee_sirene_client_secret&grant_type=password&username=insee_apim_username&password=<INSEE_PASSWORD>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/siade/spec/vcr_helper.rb
+++ b/siade/spec/vcr_helper.rb
@@ -38,6 +38,7 @@ VCR.configure do |c|
   c.filter_sensitive_data('<MDP_DGFIP>') { Siade.credentials[:dgfip_mdp].to_s }
   c.filter_sensitive_data('<USER_ID_DGFIP>') { valid_dgfip_user_id }
   c.filter_sensitive_data('<INSEE_TOKEN>') { 'valid insee token' }
+  c.filter_sensitive_data('<INSEE_PASSWORD>') { CGI.escape(INSEE::PasswordDerivation.current_password) }
   c.filter_sensitive_data('<ACOSS_CLIENT_ID>') { Siade.credentials[:acoss_client_id].to_s }
   c.filter_sensitive_data('<ACOSS_CLIENT_SECRET>') { Siade.credentials[:acoss_client_secret].to_s }
   c.filter_sensitive_data('<DOUANES_CLIENT_ID>') { Siade.credentials[:douanes_client_id].to_s }


### PR DESCRIPTION
INSEE::PasswordDerivation::DERIVATION_START (2026-09) has now been reached, so current_password switched from the static test credential to an HMAC-derived value that rotates every bimester. 16 VCR cassettes recorded the OAuth POST body with the old static password, so strict body matching broke for every spec replaying them (500 instead of the expected response).

Rather than pinning tests to a fake pre-rotation date or loosening the body matcher, follow the same pattern already used for every other rotating/sensitive value in this file: register a VCR filter so the cassette stores a placeholder (<INSEE_PASSWORD>) instead of the actual password, and VCR substitutes the current live value back in before matching. This keeps matching exact and needs no future maintenance as the password keeps rotating.

The password's derivation guarantees a special character, which can land on something like '#' that needs URL-encoding in a form body (same class of issue already handled for <LOGIN_DGFIP>), so the filter escapes it with CGI.escape.