### PR TITLE
Show the provider response in the back-office

### DIFF
--- a/siade/app/controllers/api_controller.rb
+++ b/siade/app/controllers/api_controller.rb
@@ -1,5 +1,6 @@
 class APIController < ApplicationController
   include HandleTokens
+  include CanExposeProviderResponse
   include CanLogRequestsInfoForDebugging
   include LogsRenderedError
 

--- a/siade/app/controllers/concerns/can_expose_provider_response.rb
+++ b/siade/app/controllers/concerns/can_expose_provider_response.rb
@@ -1,0 +1,34 @@
+module CanExposeProviderResponse
+  extend ActiveSupport::Concern
+
+  included do
+    after_action :expose_provider_response!, if: :expose_provider_response?
+  end
+
+  private
+
+  def expose_provider_response?
+    ProviderResponseDebuggingService.new(current_user, request).enable? &&
+      json_response? &&
+      provider_raw_response.present?
+  end
+
+  def expose_provider_response!
+    payload = JSON.parse(response.body)
+    payload['meta'] = (payload['meta'] || {}).merge(
+      'provider_response' => ProviderRawResponse.new(provider_raw_response).as_meta
+    )
+
+    response.body = payload.to_json
+  rescue JSON::ParserError, TypeError, NoMethodError
+    nil
+  end
+
+  def provider_raw_response
+    @organizer&.context&.response
+  end
+
+  def json_response?
+    response.media_type.to_s.include?('json')
+  end
+end

--- a/siade/app/controllers/concerns/can_log_requests_info_for_debugging.rb
+++ b/siade/app/controllers/concerns/can_log_requests_info_for_debugging.rb
@@ -20,11 +20,7 @@ module CanLogRequestsInfoForDebugging
   def provider_payload
     return {} unless provider_response?
 
-    {
-      header: provider_response.try(:headers) || {},
-      body: Base64.strict_encode64(provider_response.try(:body) || ''),
-      status: provider_response.try(:status) || ''
-    }
+    ProviderRawResponse.new(provider_response).as_debugging_log
   end
 
   def provider_response?

--- a/siade/app/services/provider_raw_response.rb
+++ b/siade/app/services/provider_raw_response.rb
@@ -1,0 +1,86 @@
+class ProviderRawResponse
+  MAX_EXPOSED_BODY_SIZE = 64.kilobytes
+  BINARY_DETECTION_WINDOW = 8.kilobytes
+  MIN_BASE64_BODY_SIZE = 1.kilobyte
+  BASE64_CONTENT = %r{\A[A-Za-z0-9+/\s]+={0,2}\z}
+
+  def initialize(response)
+    @response = response
+  end
+
+  def status
+    raw_status&.to_i
+  end
+
+  def headers
+    response.try(:headers) ||
+      response.try(:each_header)&.to_h ||
+      {}
+  end
+
+  def body
+    response.try(:body).to_s
+  end
+
+  def body_base64
+    Base64.strict_encode64(body)
+  end
+
+  def as_debugging_log
+    {
+      header: headers,
+      body: body_base64,
+      status:
+    }
+  end
+
+  def as_meta
+    {
+      'status' => status,
+      'headers' => headers,
+      'body' => exposed_body
+    }
+  end
+
+  private
+
+  attr_reader :response
+
+  def raw_status
+    response.try(:status) || response.try(:code)
+  end
+
+  def exposed_body
+    return "[contenu binaire, #{body.bytesize} octets]" if binary?
+
+    truncate(utf8_body)
+  end
+
+  def binary?
+    null_byte?(sample) || null_byte?(decoded_base64_sample)
+  end
+
+  def sample
+    @sample ||= body.byteslice(0, BINARY_DETECTION_WINDOW).to_s.force_encoding(Encoding::ASCII_8BIT)
+  end
+
+  def decoded_base64_sample
+    return '' unless sample.bytesize >= MIN_BASE64_BODY_SIZE && sample.match?(BASE64_CONTENT)
+
+    Base64.decode64(sample)
+  end
+
+  def null_byte?(content)
+    content.include?("\x00")
+  end
+
+  def utf8_body
+    body.dup.force_encoding(Encoding::UTF_8).scrub
+  end
+
+  def truncate(content)
+    return content if content.bytesize <= MAX_EXPOSED_BODY_SIZE
+
+    "#{content.byteslice(0, MAX_EXPOSED_BODY_SIZE).scrub}… [tronqué, #{body.bytesize} octets au total]"
+  end
+end

--- a/siade/app/services/provider_response_debugging_service.rb
+++ b/siade/app/services/provider_response_debugging_service.rb
@@ -1,0 +1,30 @@
+class ProviderResponseDebuggingService
+  HEADER_NAME = 'X-Debug-Provider-Response'.freeze
+  CREDENTIALS_KEY = :debug_provider_response_token_ids
+
+  def initialize(user, request)
+    @user = user
+    @request = request
+  end
+
+  def enable?
+    asked_by_header? && whitelisted_token?
+  end
+
+  private
+
+  attr_reader :user, :request
+
+  def asked_by_header?
+    request.headers[HEADER_NAME].present?
+  end
+
+  def whitelisted_token?
+    user.present? &&
+      whitelisted_token_ids.include?(user.token_id)
+  end
+
+  def whitelisted_token_ids
+    Array(Siade.credentials.fetch(CREDENTIALS_KEY, [])).map(&:to_s)
+  end
+end

--- a/siade/docs/debug/debug_requetes.md
+++ b/siade/docs/debug/debug_requetes.md
@@ -13,3 +13,40 @@ et permet:
 
 Il y a de même un filtrage sur les status, qui exclut principalement les erreurs
 clients (401, 403, 422)
+
+## Réponse fournisseur dans la payload
+
+Pour les jetons que nous détenons (le back-office du site notamment), la
+réponse brute du fournisseur peut être renvoyée dans la payload plutôt que
+d'être seulement écrite dans les logs.
+
+Deux conditions cumulatives :
+
+* le jeton (`jti`) est listé dans le credential
+    `debug_provider_response_token_ids` ;
+* l'appel porte le header `X-Debug-Provider-Response`.
+
+La payload est alors enrichie d'un `meta.provider_response` contenant le
+`status`, les `headers` et le `body` de la réponse du fournisseur, que l'appel
+soit en succès ou en erreur. Le body est renvoyé tel quel : tous les
+fournisseurs ne répondent pas du JSON, et c'est au consommateur de tenter un
+formatage.
+
+Deux cas ne peuvent pas être renvoyés tels quels :
+
+* les réponses binaires (attestations PDF), qu'elles arrivent brutes ou
+    encodées en base64 par le fournisseur — le `Content-Type` ne permet pas de
+    les reconnaître, certains annoncent `application/json` en renvoyant un PDF.
+    Elles sont détectées par la présence d'un octet nul et remplacées par
+    `[contenu binaire, N octets]` ;
+* les réponses de plus de 64 Ko, tronquées en indiquant la taille d'origine.
+
+Le reste est nettoyé de ses octets invalides en UTF-8, sans quoi la payload ne
+pourrait pas être sérialisée en JSON.
+
+Ce header n'est pas documenté publiquement : il est réservé à nos propres
+jetons, et sans entrée dans le credential il n'a aucun effet.
+
+Le credential attend une liste d'ids de jetons (colonne `tokens.id`) : en
+production et staging via `very_ansible`, en développement via
+`config/credentials.yml` (non versionné).

--- a/siade/spec/controllers/api_controller_can_expose_provider_response_spec.rb
+++ b/siade/spec/controllers/api_controller_can_expose_provider_response_spec.rb
@@ -1,0 +1,140 @@
+require 'rails_helper'
+
+RSpec.describe APIController, 'expose provider response' do
+  controller(described_class) do
+    def show
+      organizer
+
+      render json: { data: { message: 'I like tea' }, meta: { existing_meta: true } },
+        status: :ok
+    end
+
+    def errors
+      organizer
+
+      render json: { errors: [{ detail: 'I do not like tea' }] },
+        status: :bad_gateway
+    end
+
+    def binary_body
+      @organizer = OpenStruct.new(
+        context: OpenStruct.new(
+          response: OpenStruct.new(
+            headers: { 'Content-Type' => 'application/pdf' },
+            body: "%PDF-1.4\xC3\x28".dup.force_encoding(Encoding::ASCII_8BIT),
+            status: 200
+          )
+        )
+      )
+
+      render json: { data: { message: 'I like tea' } }, status: :ok
+    end
+
+    def operation_id
+      'whatever'
+    end
+
+    def organizer
+      @organizer ||= OpenStruct.new(
+        context: OpenStruct.new(
+          response: OpenStruct.new(
+            headers: { 'Content-Type' => 'application/json' },
+            body: { 'message' => 'I like providers\' tea' }.to_json,
+            status: 418
+          )
+        )
+      )
+    end
+  end
+
+  subject(:payload) do
+    routes.draw { get 'show' => 'api#show' }
+
+    request.headers[header_name] = header_value if header_value
+
+    get :show, params: { token: }
+
+    response.parsed_body
+  end
+
+  let(:header_name) { ProviderResponseDebuggingService::HEADER_NAME }
+  let(:header_value) { 'true' }
+  let(:token) { yes_jwt }
+  let(:whitelisted_token_ids) { [JwtUser.debugger_id] }
+  let(:expected_provider_response) do
+    {
+      'status' => 418,
+      'headers' => { 'Content-Type' => 'application/json' },
+      'body' => { 'message' => 'I like providers\' tea' }.to_json
+    }
+  end
+
+  before do
+    Siade.credentials[ProviderResponseDebuggingService::CREDENTIALS_KEY] = whitelisted_token_ids
+  end
+
+  after do
+    Siade.credentials.delete(ProviderResponseDebuggingService::CREDENTIALS_KEY)
+  end
+
+  context 'when the token is whitelisted and the header is sent' do
+    it 'exposes the raw provider response in meta' do
+      expect(payload['meta']['provider_response']).to eq(expected_provider_response)
+    end
+
+    it 'keeps the original payload' do
+      expect(payload['data']).to eq({ 'message' => 'I like tea' })
+      expect(payload['meta']['existing_meta']).to be(true)
+    end
+  end
+
+  context 'when the header is not sent' do
+    let(:header_value) { nil }
+
+    it 'does not expose the raw provider response' do
+      expect(payload['meta']).to eq({ 'existing_meta' => true })
+    end
+  end
+
+  context 'when the token is not whitelisted' do
+    let(:whitelisted_token_ids) { ['f5d5cb02-185a-426f-b3f4-99a25ce6cdf4'] }
+
+    it 'does not expose the raw provider response' do
+      expect(payload['meta']).to eq({ 'existing_meta' => true })
+    end
+  end
+
+  context 'when the payload holds errors' do
+    subject(:payload) do
+      routes.draw { get 'errors' => 'api#errors' }
+
+      request.headers[header_name] = header_value
+
+      get :errors, params: { token: }
+
+      response.parsed_body
+    end
+
+    it 'exposes the raw provider response at the root of the document' do
+      expect(payload['meta']['provider_response']).to eq(expected_provider_response)
+      expect(payload['errors']).to eq([{ 'detail' => 'I do not like tea' }])
+    end
+  end
+
+  context 'when the provider body is not valid UTF-8' do
+    subject(:payload) do
+      routes.draw { get 'binary_body' => 'api#binary_body' }
+
+      request.headers[header_name] = header_value
+
+      get :binary_body, params: { token: }
+
+      response.parsed_body
+    end
+
+    it 'renders the scrubbed provider body instead of failing' do
+      expect(payload['meta']['provider_response']['body']).to start_with('%PDF-1.4')
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/siade/spec/services/provider_raw_response_spec.rb
+++ b/siade/spec/services/provider_raw_response_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+
+RSpec.describe ProviderRawResponse do
+  subject(:raw_response) { described_class.new(response) }
+
+  context 'with a Net::HTTP response' do
+    let(:response) do
+      Net::HTTPNotFound.new('1.1', '404', 'Not Found').tap do |net_response|
+        net_response['Content-Type'] = 'application/json'
+        net_response.instance_variable_set(:@body, '{"message":"nope"}')
+        net_response.instance_variable_set(:@read, true)
+      end
+    end
+
+    it 'extracts status, headers and raw body' do
+      expect(raw_response.as_meta).to eq(
+        'status' => 404,
+        'headers' => { 'content-type' => 'application/json' },
+        'body' => '{"message":"nope"}'
+      )
+    end
+  end
+
+  context 'with a response duck typing headers and status' do
+    let(:response) do
+      OpenStruct.new(
+        headers: { 'Content-Type' => 'application/json' },
+        body: '{"message":"tea"}',
+        status: 418
+      )
+    end
+
+    it 'extracts the debugging log payload' do
+      expect(raw_response.as_debugging_log).to eq(
+        header: { 'Content-Type' => 'application/json' },
+        body: Base64.strict_encode64('{"message":"tea"}'),
+        status: 418
+      )
+    end
+  end
+
+  context 'with a response without headers nor status' do
+    let(:response) { OpenStruct.new(body: 'whatever') }
+
+    it 'falls back on empty values' do
+      expect(raw_response.as_meta).to eq(
+        'status' => nil,
+        'headers' => {},
+        'body' => 'whatever'
+      )
+    end
+  end
+
+  context 'with a binary body' do
+    let(:body) { "%PDF-1.7\r\n1 0 obj\x00\x01stream".dup.force_encoding(Encoding::ASCII_8BIT) }
+    let(:response) { OpenStruct.new(body:) }
+
+    it 'describes the body instead of exposing it' do
+      expect(raw_response.as_meta['body']).to eq("[contenu binaire, #{body.bytesize} octets]")
+    end
+  end
+
+  context 'with a binary body the provider encoded in base64' do
+    let(:pdf) { "%PDF-1.7\r\n#{"1 0 obj\x00\x01stream" * 100}".force_encoding(Encoding::ASCII_8BIT) }
+    let(:body) { Base64.strict_encode64(pdf) }
+    let(:response) { OpenStruct.new(body:) }
+
+    it 'describes the body instead of exposing it' do
+      expect(raw_response.as_meta['body']).to eq("[contenu binaire, #{body.bytesize} octets]")
+    end
+  end
+
+  context 'with a long textual body' do
+    let(:body) { 'a' * (described_class::MIN_BASE64_BODY_SIZE * 2) }
+    let(:response) { OpenStruct.new(body:) }
+
+    it 'is not mistaken for base64 encoded binary' do
+      expect(raw_response.as_meta['body']).to eq(body)
+    end
+  end
+
+  context 'with a body larger than the exposed size' do
+    let(:body) { "{\"documents\":\"#{'a' * (described_class::MAX_EXPOSED_BODY_SIZE * 2)}\"}" }
+    let(:response) { OpenStruct.new(body:) }
+
+    it 'truncates it and states the original size' do
+      expect(raw_response.as_meta['body']).to start_with('{"documents":"aaa')
+      expect(raw_response.as_meta['body']).to end_with("… [tronqué, #{body.bytesize} octets au total]")
+      expect(raw_response.as_meta['body'].bytesize).to be < body.bytesize
+    end
+  end
+
+  context 'with a body which is not valid UTF-8' do
+    let(:body) { "%PDF-1.4\xC3\x28".dup.force_encoding(Encoding::ASCII_8BIT) }
+    let(:response) { OpenStruct.new(body:) }
+
+    it 'scrubs the body so it can be rendered as JSON' do
+      expect { raw_response.as_meta.to_json }.not_to raise_error
+      expect(raw_response.as_meta['body']).to start_with('%PDF-1.4')
+    end
+
+    it 'leaves the original body untouched' do
+      raw_response.as_meta
+
+      expect(body.encoding).to eq(Encoding::ASCII_8BIT)
+    end
+  end
+end

--- a/siade/spec/services/provider_response_debugging_service_spec.rb
+++ b/siade/spec/services/provider_response_debugging_service_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe ProviderResponseDebuggingService do
+  subject(:service) { described_class.new(user, request) }
+
+  let(:user) { instance_double(JwtUser, token_id: whitelisted_token_id) }
+  let(:whitelisted_token_id) { 'f5d5cb02-185a-426f-b3f4-99a25ce6cdf4' }
+  let(:request) { instance_double(ActionDispatch::Request, headers:) }
+  let(:headers) { { described_class::HEADER_NAME => 'true' } }
+
+  before do
+    Siade.credentials[described_class::CREDENTIALS_KEY] = [whitelisted_token_id]
+  end
+
+  after do
+    Siade.credentials.delete(described_class::CREDENTIALS_KEY)
+  end
+
+  context 'when the header is present and the token is whitelisted' do
+    it { expect(service).to be_enable }
+  end
+
+  context 'when the header is missing' do
+    let(:headers) { {} }
+
+    it { expect(service).not_to be_enable }
+  end
+
+  context 'when the token is not whitelisted' do
+    let(:user) { instance_double(JwtUser, token_id: '00000000-0000-0000-0000-000000000000') }
+
+    it { expect(service).not_to be_enable }
+  end
+
+  context 'when there is no user' do
+    let(:user) { nil }
+
+    it { expect(service).not_to be_enable }
+  end
+
+  context 'when no token is whitelisted' do
+    before do
+      Siade.credentials.delete(described_class::CREDENTIALS_KEY)
+    end
+
+    it { expect(service).not_to be_enable }
+  end
+end

--- a/site/app/facade/api_request_facade.rb
+++ b/site/app/facade/api_request_facade.rb
@@ -48,7 +48,14 @@ class APIRequestFacade
       api: api_identifier
     ).call
 
-    result.merge(request_params: filtered_request_params(transformed_params))
+    payload = parse_payload(result[:body])
+    provider_response = extract_provider_response(payload)
+
+    result.merge(
+      body: provider_response ? without_provider_response(payload).to_json : result[:body],
+      request_params: filtered_request_params(transformed_params),
+      provider_response:
+    )
   end
 
   private
@@ -115,5 +122,32 @@ class APIRequestFacade
 
   def filtered_request_params(params)
     params.reject { |key, _| FIXED_PARAMS.include?(key.to_s) }
+  end
+
+  def parse_payload(body)
+    JSON.parse(body.to_s)
+  rescue JSON::ParserError
+    nil
+  end
+
+  def extract_provider_response(payload)
+    raw_response = payload&.dig('meta', 'provider_response')
+    return if raw_response.blank?
+
+    {
+      status: raw_response['status'],
+      headers: raw_response['headers'],
+      body: raw_response['body']
+    }
+  rescue TypeError
+    nil
+  end
+
+  def without_provider_response(payload)
+    meta = payload['meta'].except('provider_response')
+
+    return payload.except('meta') if meta.blank?
+
+    payload.merge('meta' => meta)
   end
 end

--- a/site/app/services/siade/manual_request.rb
+++ b/site/app/services/siade/manual_request.rb
@@ -30,6 +30,13 @@ class Siade::ManualRequest < Siade
 
   def domain = super(@api)
 
+  def headers
+    super.merge(
+      'X-Debug-Provider-Response' => 'true',
+      'Cache-Control' => 'no-cache'
+    )
+  end
+
   def authorization_token = AdminAPIToken.for(@api)
   def context = fetch_param('context') || 'Admin'
   def recipient = siret_dinum

--- a/site/app/views/admin/api_requests/_result.html.erb
+++ b/site/app/views/admin/api_requests/_result.html.erb
@@ -9,6 +9,22 @@
     </span>
   </h2>
   <pre class="fr-p-2w" style="background: #f5f5fe; overflow-x: auto; white-space: pre; max-height: 60vh;"><code><%= JSON.pretty_generate(JSON.parse(@result[:body])) rescue @result[:body] %></code></pre>
+
+  <% if @result[:provider_response] %>
+    <% provider_response = @result[:provider_response] %>
+    <h2 class="fr-text--lg fr-mt-4w">
+      Réponse du fournisseur de données
+      <span class="fr-badge fr-badge--<%= provider_response[:status] == 200 ? 'success' : 'error' %>">
+        <%= provider_response[:status] %>
+      </span>
+    </h2>
+
+    <h3 class="fr-text--md">En-têtes</h3>
+    <pre class="fr-p-2w fr-mb-4w" style="background: #f5f5fe; overflow-x: auto; white-space: pre; max-height: 30vh;"><code><%= JSON.pretty_generate(provider_response[:headers]) %></code></pre>
+
+    <h3 class="fr-text--md">Corps</h3>
+    <pre class="fr-p-2w" style="background: #f5f5fe; overflow-x: auto; white-space: pre; max-height: 60vh;"><code><%= JSON.pretty_generate(JSON.parse(provider_response[:body])) rescue provider_response[:body] %></code></pre>
+  <% end %>
 <% else %>
   <div class="fr-callout">
     <p class="fr-callout__text">

--- a/site/spec/facade/api_request_facade_spec.rb
+++ b/site/spec/facade/api_request_facade_spec.rb
@@ -180,5 +180,70 @@ RSpec.describe APIRequestFacade do
 
       expect(facade.execute_request('siren' => '130025265')).to be_nil
     end
+
+    context 'when siade exposes the provider response' do
+      let(:provider_body) { { 'etablissement' => 'brut' }.to_json }
+
+      before do
+        stub_request(:get, %r{#{siade_url}/v3/insee/sirene/unites_legales/130025265})
+          .to_return(
+            status: 200,
+            body: {
+              data: { siren: '130025265' },
+              meta: {
+                provider_response: {
+                  status: 404,
+                  headers: { 'content-type' => 'application/json' },
+                  body: provider_body
+                }
+              }
+            }.to_json
+          )
+      end
+
+      it 'extracts the provider response' do
+        result = facade.execute_request('siren' => '130025265')
+
+        expect(result[:provider_response]).to eq(
+          status: 404,
+          headers: { 'content-type' => 'application/json' },
+          body: provider_body
+        )
+      end
+
+      it 'removes the provider response from the displayed payload' do
+        result = facade.execute_request('siren' => '130025265')
+
+        expect(JSON.parse(result[:body])).to eq('data' => { 'siren' => '130025265' })
+      end
+    end
+
+    context 'when the provider body is not JSON' do
+      before do
+        stub_request(:get, %r{#{siade_url}/v3/insee/sirene/unites_legales/130025265})
+          .to_return(
+            status: 200,
+            body: {
+              data: { siren: '130025265' },
+              meta: { provider_response: { status: 500, headers: {}, body: '<html>Bad Gateway</html>' } }
+            }.to_json
+          )
+      end
+
+      it 'keeps the body as it is' do
+        result = facade.execute_request('siren' => '130025265')
+
+        expect(result[:provider_response][:body]).to eq('<html>Bad Gateway</html>')
+      end
+    end
+
+    context 'when siade does not expose the provider response' do
+      it 'returns no provider response' do
+        result = facade.execute_request('siren' => '130025265')
+
+        expect(result[:provider_response]).to be_nil
+        expect(JSON.parse(result[:body])).to eq('data' => { 'siren' => '130025265' })
+      end
+    end
   end
 end

--- a/site/spec/features/admin/api_requests_spec.rb
+++ b/site/spec/features/admin/api_requests_spec.rb
@@ -83,6 +83,53 @@ RSpec.describe 'Admin: API requests' do
       end
     end
 
+    describe 'displaying the provider response' do
+      let(:provider_body) { { 'message' => 'SIREN inconnu' }.to_json }
+      let(:response_body) do
+        {
+          errors: [{ detail: 'Non trouvé' }],
+          meta: {
+            provider_response: {
+              status: 404,
+              headers: { 'content-type' => 'application/json' },
+              body: provider_body
+            }
+          }
+        }.to_json
+      end
+
+      before do
+        stub_request(:get, %r{#{siade_entreprise_url}/v3/insee/sirene/unites_legales/130025265})
+          .to_return(status: 404, body: response_body)
+      end
+
+      it 'displays the raw provider status, headers and body' do
+        visit admin_api_requests_path(endpoint_uid: '/v3/insee/sirene/unites_legales/{siren}')
+
+        fill_in 'siren', with: '130025265'
+        click_on 'Envoyer la requête'
+
+        expect(page).to have_text('Réponse du fournisseur de données')
+        expect(page).to have_text('404')
+        expect(page).to have_text('content-type')
+        expect(page).to have_text('SIREN inconnu')
+        expect(page).to have_no_text('provider_response')
+      end
+
+      context 'when the provider body is not JSON' do
+        let(:provider_body) { '<html><body>Service indisponible</body></html>' }
+
+        it 'displays the raw body' do
+          visit admin_api_requests_path(endpoint_uid: '/v3/insee/sirene/unites_legales/{siren}')
+
+          fill_in 'siren', with: '130025265'
+          click_on 'Envoyer la requête'
+
+          expect(page).to have_text('<html><body>Service indisponible</body></html>')
+        end
+      end
+    end
+
     describe 'parameter labels' do
       it 'displays technical field name as label' do
         visit admin_api_requests_path(endpoint_uid: '/v3/insee/sirene/unites_legales/{siren}')

--- a/site/spec/services/siade/manual_request_spec.rb
+++ b/site/spec/services/siade/manual_request_spec.rb
@@ -114,6 +114,29 @@ RSpec.describe Siade::ManualRequest, type: :service do
       end
     end
 
+    context 'with a provider response exposed by siade' do
+      let(:endpoint_path) { '/v3/insee/sirene/unites_legales/{siren}' }
+      let(:params) { { 'siren' => '130025265' } }
+      let(:endpoint_url) { "#{siade_entreprise_url}/v3/insee/sirene/unites_legales/130025265" }
+      let(:response_body) { { data: { siren: '130025265' } }.to_json }
+
+      before do
+        stub_request(:get, endpoint_url)
+          .with(
+            query: siade_params,
+            headers: siade_headers.merge(
+              'X-Debug-Provider-Response' => 'true',
+              'Cache-Control' => 'no-cache'
+            )
+          )
+          .to_return(status: 200, body: response_body)
+      end
+
+      it 'asks for the raw provider response and bypasses siade cache' do
+        expect(subject).to eq({ body: response_body, status: 200 })
+      end
+    end
+
     context 'with blank context and object' do
       let(:endpoint_path) { '/v3/dss/quotient_familial/identite' }
       let(:params) { { 'context' => '', 'object' => '', 'nom' => 'Dupont' } }


### PR DESCRIPTION
Investigating a provider bug from the admin back-office means guessing
what the provider actually answered: the site only sees the payload we
build out of it. The requests debugger already captures that raw
response, but writes it to a log file on the backend, out of reach.

Siade now returns it in `meta.provider_response` when both conditions
hold: the token id sits in the `debug_provider_response_token_ids`
credential — meant for the tokens we own ourselves — and the call
carries the `X-Debug-Provider-Response` header. Without the credential
entry the header does nothing, and the header keeps the tokens we use
for other purposes from dragging provider payloads around. It stays out
of the public documentation.

Enriching the rendered JSON in an after_action rather than in the
serializers covers success and error payloads alike, on both APIs and
every version, without touching the two hundred serializers.

The body is exposed as it is rather than encoded: providers do not all
answer JSON, and deciding how to render XML, HTML or plain text belongs
to whoever reads it. Two kinds of responses cannot travel that way and
are described instead of being exposed. Binary bodies first, the
attestations returned as PDF: the provider content type cannot be
trusted to spot them — ACOSS announces `application/json` and answers
a base64 encoded PDF — so they are recognised on a null byte, looked
for in the body and, when the body is a long base64 blob, in what it
decodes to. Bodies over 64 KB then, truncated down to their beginning,
stating the size they had. What is left is scrubbed of the bytes that
are not valid UTF-8: a provider erroring out in latin-1 stays readable
once its accents are dropped, whereas a payload holding those bytes
could not be serialised back to JSON and would turn the whole call
into a 500.

On the site, manual requests ask for that response and display its
status, headers and body next to ours, pretty printed when it parses as
JSON and shown as it came otherwise. `meta.provider_response` is
stripped from the payload shown as the response, so that pane keeps
showing exactly what an API consumer would get. The requests also carry
`Cache-Control: no-cache`: served from siade's cache, a call reaches no
provider at all and would have nothing to show.

On the way, the provider response payload builder is extracted and the
requests debugger stops logging empty headers and statuses.

Nothing changes for API consumers: without an entry in the credential
the header does nothing.

Before merging, the credential has to be provisioned in very_ansible
with the ids of the tokens the back-office uses:

    Token.joins(:authorization_request)
      .where(authorization_requests: { external_id: %w[93423 93444] })
      .pluck(:id)

