### PR TITLE
Allow bypassing INSEE password rotation

### DIFF
--- a/siade/app/interactors/insee/make_request.rb
+++ b/siade/app/interactors/insee/make_request.rb
@@ -93,6 +93,7 @@ class INSEE::MakeRequest < MakeRequest::Get
   end
 
   def password_rotation_needed?
+    return false if INSEE::PasswordDerivation.bypassed?
     return false if context.token.blank?
     return false if INSEE::PasswordDerivation.current_period < INSEE::PasswordDerivation::DERIVATION_START
 

--- a/siade/app/services/insee/password_derivation.rb
+++ b/siade/app/services/insee/password_derivation.rb
@@ -3,6 +3,7 @@ require 'openssl'
 class INSEE::PasswordDerivation
   DERIVATION_START = '2026-09'.freeze
   BIMESTER_MONTHS = [1, 3, 5, 7, 9, 11].freeze
+  BYPASS_CREDENTIAL_KEY = :insee_apim_password_bypass
   PASSWORD_LENGTH = 16
   CHAR_GUARANTEES = {
     /[A-Z]/ => 'A',
@@ -11,11 +12,19 @@ class INSEE::PasswordDerivation
     /[^a-zA-Z0-9]/ => '#'
   }.freeze
 
+  def self.bypassed?
+    Siade.credentials.key?(BYPASS_CREDENTIAL_KEY)
+  end
+
   def self.current_password
+    return bypass_password if bypassed?
+
     password_for(current_period)
   end
 
   def self.previous_password
+    return bypass_password if bypassed?
+
     password_for(previous_period)
   end
 
@@ -33,6 +42,10 @@ class INSEE::PasswordDerivation
       idx = BIMESTER_MONTHS.index(month)
       format('%<year>d-%<month>02d', year: date.year, month: BIMESTER_MONTHS[idx - 1])
     end
+  end
+
+  def self.bypass_password
+    Siade.credentials[BYPASS_CREDENTIAL_KEY]
   end
 
   def self.password_for(period)
@@ -65,5 +78,5 @@ class INSEE::PasswordDerivation
     Siade.credentials[:insee_apim_password_derivation_key]
   end
 
-  private_class_method :password_for, :derive, :period_for, :format_password, :secret
+  private_class_method :bypass_password, :password_for, :derive, :period_for, :format_password, :secret
 end

--- a/siade/spec/interactors/insee/make_request_spec.rb
+++ b/siade/spec/interactors/insee/make_request_spec.rb
@@ -357,5 +357,31 @@ RSpec.describe INSEE::MakeRequest, type: :interactor do
         expect(WebMock).not_to have_requested(:post, renew_url)
       end
     end
+
+    context 'when the bypass credential is set' do
+      let(:token) { jwt_token_with_pwd_changed_time('2026-08-15T10:00:00Z') }
+
+      before do
+        Timecop.freeze(Date.new(2026, 9, 15))
+        Siade.credentials[INSEE::PasswordDerivation::BYPASS_CREDENTIAL_KEY] = 'ByPass#Password1'
+
+        stub_request(:get, /#{insee_sirene_url}/)
+          .to_return(status: 200, body: '{"uniteLegale":{}}')
+      end
+
+      after { Siade.credentials.delete(INSEE::PasswordDerivation::BYPASS_CREDENTIAL_KEY) }
+
+      it 'does not call the renewal API' do
+        make_request
+
+        expect(WebMock).not_to have_requested(:post, renew_url)
+      end
+
+      it 'does not take the rotation lock' do
+        make_request
+
+        expect(RedisService.new.get(INSEE::MakeRequest::ROTATION_LOCK_KEY)).to be_nil
+      end
+    end
   end
 end

--- a/siade/spec/services/insee/password_derivation_spec.rb
+++ b/siade/spec/services/insee/password_derivation_spec.rb
@@ -141,4 +141,35 @@ RSpec.describe INSEE::PasswordDerivation do
       expect(described_class.current_password).to match(/[^a-zA-Z0-9]/)
     end
   end
+
+  describe 'bypass credential' do
+    let(:bypass_password) { 'ByPass#Password1' }
+
+    before { Siade.credentials[described_class::BYPASS_CREDENTIAL_KEY] = bypass_password }
+
+    after do
+      Siade.credentials.delete(described_class::BYPASS_CREDENTIAL_KEY)
+      Timecop.return
+    end
+
+    it 'is bypassed' do
+      expect(described_class).to be_bypassed
+    end
+
+    it 'returns the bypass password whatever the period' do
+      Timecop.freeze(Date.new(2027, 1, 15))
+      expect(described_class.current_password).to eq(bypass_password)
+    end
+
+    it 'returns the bypass password as previous password too' do
+      Timecop.freeze(Date.new(2027, 1, 15))
+      expect(described_class.previous_password).to eq(bypass_password)
+    end
+  end
+
+  describe '.bypassed?' do
+    it 'is false when the credential is absent' do
+      expect(described_class).not_to be_bypassed
+    end
+  end
 end


### PR DESCRIPTION
The bimester rotation against INSEE's /renouvellement endpoint does not work reliably in production: renewals get rejected and the derived password then no longer matches the one actually registered on INSEE's side, which locks us out of the whole SIRENE API.

Add an escape hatch: when the `insee_apim_password_bypass` credential key exists, PasswordDerivation returns its value as both the current and the previous password, and MakeRequest skips rotation entirely — no /renouvellement call, no rotation lock. Setting a password by hand on the INSEE portal and dropping it in the credentials is then enough to keep the API running; removing the key restores the automatic rotation.

Presence is checked with `key?` rather than by reading the value, because the credentials hash has a default_proc in local and staging environments that fabricates a value for any missing key, which would otherwise enable the bypass everywhere.