### PR TITLE
Log error subcodes in access_logs

### DIFF
--- a/siade/app/controllers/api_controller.rb
+++ b/siade/app/controllers/api_controller.rb
@@ -1,6 +1,7 @@
 class APIController < ApplicationController
   include HandleTokens
   include CanLogRequestsInfoForDebugging
+  include LogsRenderedError
 
   rescue_from ActionController::ParameterMissing, with: :bad_request
   rescue_from MockedInteractor::EndpointNotYetImplemented, with: :not_implemented_error

--- a/siade/app/controllers/api_particulier/v2/base_controller.rb
+++ b/siade/app/controllers/api_particulier/v2/base_controller.rb
@@ -81,6 +81,8 @@ class APIParticulier::V2::BaseController < APIController
   end
 
   def format_error(error)
+    RenderedError.capture(error)
+
     send("format_#{error.kind}_error", error)
   rescue NoMethodError
     {
@@ -99,6 +101,8 @@ class APIParticulier::V2::BaseController < APIController
   end
 
   def format_unauthorized_error(error)
+    RenderedError.capture(error)
+
     {
       error: 'access_denied',
       reason: error.detail,

--- a/siade/app/controllers/concerns/logs_rendered_error.rb
+++ b/siade/app/controllers/concerns/logs_rendered_error.rb
@@ -1,0 +1,16 @@
+module LogsRenderedError
+  extend ActiveSupport::Concern
+
+  def append_info_to_payload(payload)
+    super
+
+    fields = RenderedError.log_fields
+
+    return if fields.blank?
+
+    payload[:parameters] ||= {}
+    payload[:parameters].merge!(fields)
+
+    LogStasher::CustomFields.add(:parameters)
+  end
+end

--- a/siade/app/controllers/mcp_controller.rb
+++ b/siade/app/controllers/mcp_controller.rb
@@ -1,5 +1,6 @@
 class MCPController < ActionController::API
   include HandleTokens
+  include LogsRenderedError
 
   skip_before_action :authorize_access_to_resource!, unless: :tool_calling?
 

--- a/siade/app/models/current.rb
+++ b/siade/app/models/current.rb
@@ -1,0 +1,3 @@
+class Current < ActiveSupport::CurrentAttributes
+  attribute :rendered_error
+end

--- a/siade/app/serializers/errors_serializer.rb
+++ b/siade/app/serializers/errors_serializer.rb
@@ -2,6 +2,8 @@ class ErrorsSerializer < ActiveModel::Serializer
   attribute :errors
 
   def errors
+    RenderedError.capture(object)
+
     object.map do |error_handler|
       public_send(format, error_handler)
     end

--- a/siade/app/services/rendered_error.rb
+++ b/siade/app/services/rendered_error.rb
@@ -1,0 +1,23 @@
+class RenderedError
+  def self.capture(errors)
+    Current.rendered_error ||= [*errors].first
+  end
+
+  def self.log_fields
+    code = error_code
+
+    return {} if code.blank?
+
+    {
+      error_code: code,
+      error_provider_code: code[0..1],
+      error_subcode: code[2..]
+    }
+  end
+
+  def self.error_code
+    Current.rendered_error&.code
+  rescue StandardError
+    nil
+  end
+end

--- a/siade/spec/acceptances/logstasher_custom_fields_spec.rb
+++ b/siade/spec/acceptances/logstasher_custom_fields_spec.rb
@@ -155,8 +155,10 @@ RSpec.describe 'logstasher custom fields', type: :controller do
 
       it 'does not add hashed params to logstasher parameters key' do
         expect(LogStasher).to receive(:build_logstash_event).with(
-          hash_excluding(
-            parameters: anything
+          hash_including(
+            parameters: hash_excluding(
+              hashed_params: anything
+            )
           ),
           anything
         )
@@ -266,8 +268,10 @@ RSpec.describe 'logstasher custom fields', type: :controller do
 
       it 'does not add france_connect_client to params' do
         expect(LogStasher).to receive(:build_logstash_event).with(
-          hash_not_including(
-            parameters: anything
+          hash_including(
+            parameters: hash_excluding(
+              france_connect_client: anything
+            )
           ),
           anything
         )
@@ -467,6 +471,194 @@ RSpec.describe 'logstasher custom fields', type: :controller do
         )
 
         make_call
+      end
+    end
+  end
+
+  describe 'rendered error codes' do
+    describe 'on api entreprise request' do
+      before do
+        routes.draw { get 'index' => 'api/v3_and_more/dummy#index' }
+      end
+
+      context 'when the error comes from the authentication' do
+        define_dummy_controller(APIEntreprise::V3AndMore::DummyController)
+
+        it 'adds the error code, provider code and subcode to logstasher parameters' do
+          expect(LogStasher).to receive(:build_logstash_event).with(
+            hash_including(
+              parameters: hash_including(
+                error_code: '00101',
+                error_provider_code: '00',
+                error_subcode: '101'
+              )
+            ),
+            anything
+          )
+
+          make_call
+        end
+      end
+
+      context 'when a provider error is rendered' do
+        controller(APIEntreprise::V3AndMore::DummyController) do
+          skip_before_action :authenticate_user!, :set_monitoring_context, :authorize_access_to_resource!, :verify_duplicate_params!
+          skip_after_action :clean_duplicate_param_tracking
+
+          def index
+            render json: ErrorsSerializer.new([ProviderUnknownError.new('CIBTP')]).as_json,
+              status: :bad_gateway
+          end
+        end
+
+        it 'adds the provider code and the subcode of the error' do
+          expect(LogStasher).to receive(:build_logstash_event).with(
+            hash_including(
+              parameters: hash_including(
+                error_code: '38999',
+                error_provider_code: '38',
+                error_subcode: '999'
+              )
+            ),
+            anything
+          )
+
+          make_call
+        end
+      end
+
+      context 'when several errors are rendered' do
+        controller(APIEntreprise::V3AndMore::DummyController) do
+          skip_before_action :authenticate_user!, :set_monitoring_context, :authorize_access_to_resource!, :verify_duplicate_params!
+          skip_after_action :clean_duplicate_param_tracking
+
+          def index
+            errors = [MissingMandatoryParamError.new(:context), MissingMandatoryParamError.new(:object)]
+
+            render json: ErrorsSerializer.new(errors).as_json,
+              status: :unprocessable_content
+          end
+        end
+
+        it 'keeps the first rendered error' do
+          expect(LogStasher).to receive(:build_logstash_event).with(
+            hash_including(
+              parameters: hash_including(
+                error_code: '00201'
+              )
+            ),
+            anything
+          )
+
+          make_call
+        end
+      end
+
+      context 'when no error is rendered' do
+        controller(APIEntreprise::V3AndMore::DummyController) do
+          skip_before_action :authenticate_user!, :set_monitoring_context, :authorize_access_to_resource!, :verify_duplicate_params!
+          skip_after_action :clean_duplicate_param_tracking
+
+          def index
+            head :ok
+          end
+        end
+
+        it 'does not add any error field to logstasher' do
+          expect(LogStasher).to receive(:build_logstash_event).with(
+            hash_excluding(
+              parameters: anything
+            ),
+            anything
+          )
+
+          make_call
+        end
+      end
+    end
+
+    describe 'on api particulier v2 request' do
+      subject(:make_call) do
+        get :index, params:
+      end
+
+      let(:params) { { foo: 'bar' } }
+      let(:hashed_params) { Digest::SHA512.hexdigest("#{Siade.credentials[:api_particulier_log_salt_key]}:#{params.to_json}") }
+
+      before do
+        routes.draw { get 'index' => 'api/v2/dummy#index' }
+      end
+
+      context 'when the error is rendered in the flat format' do
+        define_dummy_controller(APIParticulier::V2::DummyController)
+
+        it 'adds the error code without erasing the existing parameters' do
+          expect(LogStasher).to receive(:build_logstash_event).with(
+            hash_including(
+              parameters: hash_including(
+                hashed_params:,
+                error_code: '00101',
+                error_provider_code: '00',
+                error_subcode: '101'
+              )
+            ),
+            anything
+          )
+
+          make_call
+        end
+      end
+
+      context 'when a provider error is rendered in the flat format' do
+        controller(APIParticulier::V2::DummyController) do
+          skip_before_action :authenticate_user!, :set_monitoring_context, :authorize_access_to_resource!, :verify_duplicate_params!
+          skip_after_action :clean_duplicate_param_tracking
+
+          def index
+            render json: format_error(NotFoundError.new('CNAV')),
+              status: :not_found
+          end
+        end
+
+        it 'adds the provider code and the subcode of the error' do
+          expect(LogStasher).to receive(:build_logstash_event).with(
+            hash_including(
+              parameters: hash_including(
+                hashed_params:,
+                error_code: '37003',
+                error_provider_code: '37',
+                error_subcode: '003'
+              )
+            ),
+            anything
+          )
+
+          make_call
+        end
+      end
+
+      context 'when no error is rendered' do
+        controller(APIParticulier::V2::DummyController) do
+          skip_before_action :authenticate_user!, :set_monitoring_context, :authorize_access_to_resource!, :verify_duplicate_params!
+          skip_after_action :clean_duplicate_param_tracking
+
+          def index
+            head :ok
+          end
+        end
+
+        it 'does not add any error field to logstasher parameters' do
+          expect(LogStasher).to receive(:build_logstash_event).with(
+            hash_including(
+              parameters: hash_excluding(
+                error_code: anything
+              )
+            ),
+            anything
+          )
+
+          make_call
+        end
       end
     end
   end

--- a/siade/spec/services/rendered_error_spec.rb
+++ b/siade/spec/services/rendered_error_spec.rb
@@ -1,0 +1,74 @@
+RSpec.describe RenderedError, type: :service do
+  describe '.capture' do
+    subject(:captured) { Current.rendered_error }
+
+    context 'with a collection of errors' do
+      before do
+        described_class.capture([InvalidTokenError.new, BadRequestError.new])
+      end
+
+      it { is_expected.to be_a(InvalidTokenError) }
+    end
+
+    context 'with a single error' do
+      before do
+        described_class.capture(BadRequestError.new)
+      end
+
+      it { is_expected.to be_a(BadRequestError) }
+    end
+
+    context 'when an error has already been captured' do
+      before do
+        described_class.capture(InvalidTokenError.new)
+        described_class.capture(BadRequestError.new)
+      end
+
+      it { is_expected.to be_a(InvalidTokenError) }
+    end
+  end
+
+  describe '.log_fields' do
+    subject(:log_fields) { described_class.log_fields }
+
+    context 'without captured error' do
+      it { is_expected.to eq({}) }
+    end
+
+    context 'with a provider error' do
+      before do
+        described_class.capture(ProviderUnknownError.new('CIBTP'))
+      end
+
+      it do
+        expect(log_fields).to eq(
+          error_code: '38999',
+          error_provider_code: '38',
+          error_subcode: '999'
+        )
+      end
+    end
+
+    context 'with a fixed code error' do
+      before do
+        described_class.capture(InvalidTokenError.new)
+      end
+
+      it do
+        expect(log_fields).to eq(
+          error_code: '00101',
+          error_provider_code: '00',
+          error_subcode: '101'
+        )
+      end
+    end
+
+    context 'when the code cannot be computed' do
+      before do
+        described_class.capture(ProviderUnknownError.new('unknown provider'))
+      end
+
+      it { is_expected.to eq({}) }
+    end
+  end
+end

--- a/siade/spec/spec_helper.rb
+++ b/siade/spec/spec_helper.rb
@@ -112,6 +112,10 @@ RSpec.configure do |config|
     Rails.cache.clear
   end
 
+  config.before do
+    ActiveSupport::CurrentAttributes.clear_all
+  end
+
   config.include ResponsesHelper, type: :controller
   config.include ResponsesHelper, type: :request
   config.include CommonErrorsMessagesHelpers


### PR DESCRIPTION
https://linear.app/pole-api/issue/API-6961

access_logs only stores the HTTP status, so behind a 502 there is no way to tell a 999 (unidentified provider response, i.e. a bug we do not know about) from an 001 (identified outage). For API Particulier it is worse: params are hashed and the v2 flat format does not even return the code to the client, so the information exists nowhere.

The error a request ends on is captured at render time — `ErrorsSerializer` for both formats, plus API Particulier v2's hand-rolled `format_error` / `format_unauthorized_error`. That is the only hook every error goes through: errors coming from an organizer, but also the ones rendered before any action runs, where no organizer exists at all. It is carried to the LogStasher hooks by a new `Current` (`ActiveSupport::CurrentAttributes`), reset by the executor at the end of each request.

`append_info_to_payload` then merges `error_code`, `error_provider_code` and `error_subcode` into the `parameters` field, next to the `hashed_params` and `france_connect_client` metadata `LogStasherFieldsBuilder` already puts there. It is mapped to the `access_logs.params` jsonb column by the existing fluentd configuration, so no migration and no infra change are needed, and the three keys stay flat to remain queryable like `params->>'siren'`.

The commit bodies detail the two LogStasher timing traps this had to work around (the fields builder runs before the action; `request_context` is copied over the payload afterwards, hence the in-place merge), and why the code extraction swallows its own exceptions.