### PR TITLE
Exclude provider rate-limit errors from CNAV ping ratio

### DIFF
--- a/siade/app/ping_drivers/abstract_ping_driver.rb
+++ b/siade/app/ping_drivers/abstract_ping_driver.rb
@@ -36,12 +36,16 @@ class AbstractPingDriver < ApplicationPingDriver
   end
 
   def error_ratio_too_high?
-    total, errors = AccessLogPingView
-      .where(route: routes)
-      .pick(Arel.sql("COUNT(*), COUNT(*) FILTER (WHERE status IN (#{error_statuses.map { |s| "'#{s}'" }.join(', ')}))"))
+    total, errors = counts
 
     return false if total.nil? || total.zero?
 
     errors.to_f / total >= ERROR_RATIO_THRESHOLD
+  end
+
+  def counts
+    AccessLogPingView
+      .where(route: routes)
+      .pick(Arel.sql("COUNT(*), COUNT(*) FILTER (WHERE status IN (#{error_statuses.map { |s| "'#{s}'" }.join(', ')}))"))
   end
 end

--- a/siade/app/ping_drivers/cnav_ping_driver.rb
+++ b/siade/app/ping_drivers/cnav_ping_driver.rb
@@ -1,4 +1,7 @@
 class CNAVPingDriver < AbstractPingDriver
+  RATE_LIMIT_ERROR_RATIO_THRESHOLD = 0.25
+  RATE_LIMIT_SUBCODE = '008'.freeze
+
   private
 
   attr_reader :provider
@@ -10,5 +13,44 @@ class CNAVPingDriver < AbstractPingDriver
   def build_context(driver_params)
     @routes = driver_params.fetch(:routes)
     @provider = driver_params.fetch(:provider)
+  end
+
+  def error_ratio_too_high?
+    return false if no_errors?
+
+    return true if rate_limit_threshold_crossed?
+
+    error_limit_threshold_crossed?
+  end
+
+  def no_errors?
+    total.nil? || total.zero? || errors.zero?
+  end
+
+  def rate_limit_threshold_crossed?
+    rate_limited_errors.to_f / total >= RATE_LIMIT_ERROR_RATIO_THRESHOLD
+  end
+
+  def error_limit_threshold_crossed?
+    [errors - rate_limited_errors, 0].max.to_f / total >= ERROR_RATIO_THRESHOLD
+  end
+
+  def total
+    counts[0]
+  end
+
+  def errors
+    counts[1]
+  end
+
+  def counts
+    @counts ||= super || [0, 0]
+  end
+
+  def rate_limited_errors
+    @rate_limited_errors ||= AccessLog
+      .where(route: routes, status: error_statuses, timestamp: 10.minutes.ago..)
+      .where("params ->> 'error_subcode' = ?", RATE_LIMIT_SUBCODE)
+      .count
   end
 end

--- a/siade/app/ping_drivers/cnav_ping_driver.rb
+++ b/siade/app/ping_drivers/cnav_ping_driver.rb
@@ -24,33 +24,48 @@ class CNAVPingDriver < AbstractPingDriver
   end
 
   def no_errors?
-    total.nil? || total.zero? || errors.zero?
+    errors.zero?
   end
 
   def rate_limit_threshold_crossed?
-    rate_limited_errors.to_f / total >= RATE_LIMIT_ERROR_RATIO_THRESHOLD
+    rate_limited_errors.to_f / snapshot_total >= RATE_LIMIT_ERROR_RATIO_THRESHOLD
   end
 
   def error_limit_threshold_crossed?
-    [errors - rate_limited_errors, 0].max.to_f / total >= ERROR_RATIO_THRESHOLD
-  end
-
-  def total
-    counts[0]
+    non_rate_limited_errors.to_f / snapshot_total >= ERROR_RATIO_THRESHOLD
   end
 
   def errors
-    counts[1]
+    view_counts[1]
   end
 
-  def counts
-    @counts ||= super || [0, 0]
+  def view_counts
+    @view_counts ||= counts || [0, 0]
+  end
+
+  def snapshot_total
+    rate_limit_snapshot[0]
   end
 
   def rate_limited_errors
-    @rate_limited_errors ||= AccessLog
-      .where(route: routes, status: error_statuses, timestamp: 10.minutes.ago..)
-      .where("params ->> 'error_subcode' = ?", RATE_LIMIT_SUBCODE)
-      .count
+    rate_limit_snapshot[1]
+  end
+
+  def non_rate_limited_errors
+    rate_limit_snapshot[2]
+  end
+
+  def rate_limit_snapshot
+    @rate_limit_snapshot ||= AccessLog
+      .where(route: routes, timestamp: 10.minutes.ago..)
+      .pick(Arel.sql(<<~SQL.squish)) || [0, 0, 0]
+        COUNT(*),
+        COUNT(*) FILTER (WHERE status IN (#{quoted_error_statuses}) AND COALESCE(params ->> 'error_subcode', '') = '#{RATE_LIMIT_SUBCODE}'),
+        COUNT(*) FILTER (WHERE status IN (#{quoted_error_statuses}) AND COALESCE(params ->> 'error_subcode', '') != '#{RATE_LIMIT_SUBCODE}')
+      SQL
+  end
+
+  def quoted_error_statuses
+    error_statuses.map { |s| "'#{s}'" }.join(', ')
   end
 end

--- a/siade/db/structure.sql
+++ b/siade/db/structure.sql
@@ -103,7 +103,8 @@ CREATE TABLE public.access_logs (
   route character varying,
   status character varying,
   path character varying,
-  cached boolean
+  cached boolean,
+  params jsonb
 );
 
 CREATE MATERIALIZED VIEW public.admin_apientreprise_test_access_logs_last_10_minutes AS

--- a/siade/spec/ping_drivers/cnav_ping_driver_spec.rb
+++ b/siade/spec/ping_drivers/cnav_ping_driver_spec.rb
@@ -84,5 +84,69 @@ RSpec.describe CNAVPingDriver, type: :ping_driver do
 
       it { is_expected.to eq(:ok) }
     end
+
+    context 'when rate-limit responses (subcode 008) are below the 25% rate-limit threshold' do
+      before do
+        8.times { AccessLog.create!(route: routes.first, status: '200', timestamp: 1.minute.ago) }
+        2.times do
+          AccessLog.create!(
+            route: routes.first, status: '502', timestamp: 1.minute.ago,
+            params: { error_subcode: '008' }
+          )
+        end
+        AccessLogPingView.refresh!
+      end
+
+      it 'returns :ok despite a raw ratio above the normal 10% threshold' do
+        expect(subject).to eq(:ok)
+      end
+    end
+
+    context 'when rate-limit responses (subcode 008) are at the 25% rate-limit threshold' do
+      before do
+        9.times { AccessLog.create!(route: routes.first, status: '200', timestamp: 1.minute.ago) }
+        3.times do
+          AccessLog.create!(
+            route: routes.first, status: '502', timestamp: 1.minute.ago,
+            params: { error_subcode: '008' }
+          )
+        end
+        AccessLogPingView.refresh!
+      end
+
+      it { is_expected.to eq(:bad_gateway) }
+    end
+
+    context 'when non-rate-limited errors are at the normal 10% threshold despite rate-limit noise below 25%' do
+      before do
+        15.times { AccessLog.create!(route: routes.first, status: '200', timestamp: 1.minute.ago) }
+        3.times do
+          AccessLog.create!(
+            route: routes.first, status: '502', timestamp: 1.minute.ago,
+            params: { error_subcode: '008' }
+          )
+        end
+        2.times { AccessLog.create!(route: routes.first, status: '502', timestamp: 1.minute.ago) }
+        AccessLogPingView.refresh!
+      end
+
+      it 'returns :bad_gateway due to the non-rate-limited errors alone' do
+        expect(subject).to eq(:bad_gateway)
+      end
+    end
+
+    context 'when both rate-limited and non-rate-limited errors stay under their own threshold' do
+      before do
+        18.times { AccessLog.create!(route: routes.first, status: '200', timestamp: 1.minute.ago) }
+        AccessLog.create!(
+          route: routes.first, status: '502', timestamp: 1.minute.ago,
+          params: { error_subcode: '008' }
+        )
+        AccessLog.create!(route: routes.first, status: '502', timestamp: 1.minute.ago)
+        AccessLogPingView.refresh!
+      end
+
+      it { is_expected.to eq(:ok) }
+    end
   end
 end


### PR DESCRIPTION
## Summary

- The CNAF/MSA quotient familial ping (QFv2) was flagging `bad_gateway` for hours while the provider was actually up: a client hammering `quotient_familial_with_civility` past the provider's rate limit produced a wave of identified `502` responses (`error_subcode 008`), pushing the combined error ratio over the normal 10% threshold and keeping it there as the client kept retrying.
- `CNAVPingDriver` now checks two independent thresholds instead of one: non-rate-limited `502/503/504` responses still trip at the normal 10%, while rate-limit responses (`error_subcode 008`) alone need to reach 25% before they flag the route down. Either one crossing its threshold is enough to report `bad_gateway`.
- The rate-limit subcode is read from the raw `access_logs` table (the `AccessLogPingView` materialized view only exposes `timestamp/route/status`), but only when the cheap view query already shows at least one error — the common healthy-route case is unaffected.
- `db/structure.sql` gains the `params jsonb` column on `access_logs` to match production (already populated there via fluentd) so specs can exercise this.

## Test plan

- [x] `bundle exec rspec spec/ping_drivers/cnav_ping_driver_spec.rb` — 11 examples, 0 failures
- [x] `bundle exec rspec spec/ping_drivers/ spec/requests/ping_routes_spec.rb spec/requests/api_particulier/pings_spec.rb` — 105 examples, 0 failures
- [x] `bundle exec rubocop app/ping_drivers/cnav_ping_driver.rb spec/ping_drivers/cnav_ping_driver_spec.rb` — no offenses

https://claude.ai/code/session_01URU8CughNTrgXwtQYWWjxY