### PR TITLE
Read the provider response off the organizer context

### DIFF
--- a/siade/app/controllers/concerns/can_expose_provider_response.rb
+++ b/siade/app/controllers/concerns/can_expose_provider_response.rb
@@ -24,10 +24,6 @@ module CanExposeProviderResponse
     nil
   end
 
-  def provider_raw_response
-    @organizer&.context&.response
-  end
-
   def json_response?
     response.media_type.to_s.include?('json')
   end

--- a/siade/app/controllers/concerns/can_log_requests_info_for_debugging.rb
+++ b/siade/app/controllers/concerns/can_log_requests_info_for_debugging.rb
@@ -18,17 +18,13 @@ module CanLogRequestsInfoForDebugging
   end
 
   def provider_payload
-    return {} unless provider_response?
+    return {} if provider_raw_response.blank?
 
-    ProviderRawResponse.new(provider_response).as_debugging_log
+    ProviderRawResponse.new(provider_raw_response).as_debugging_log
   end
 
-  def provider_response?
-    organizer&.context&.response
-  end
-
-  def provider_response
-    organizer.context.response
+  def provider_raw_response
+    organizer&.response || organizer&.retriever&.response
   end
 
   def requests_debugging_enabled?

--- a/siade/spec/controllers/api_controller_can_expose_provider_response_spec.rb
+++ b/siade/spec/controllers/api_controller_can_expose_provider_response_spec.rb
@@ -17,13 +17,11 @@ RSpec.describe APIController, 'expose provider response' do
     end
 
     def binary_body
-      @organizer = OpenStruct.new(
-        context: OpenStruct.new(
-          response: OpenStruct.new(
-            headers: { 'Content-Type' => 'application/pdf' },
-            body: "%PDF-1.4\xC3\x28".dup.force_encoding(Encoding::ASCII_8BIT),
-            status: 200
-          )
+      @organizer = Interactor::Context.build(
+        response: OpenStruct.new(
+          headers: { 'Content-Type' => 'application/pdf' },
+          body: "%PDF-1.4\xC3\x28".dup.force_encoding(Encoding::ASCII_8BIT),
+          status: 200
         )
       )
 
@@ -35,13 +33,11 @@ RSpec.describe APIController, 'expose provider response' do
     end
 
     def organizer
-      @organizer ||= OpenStruct.new(
-        context: OpenStruct.new(
-          response: OpenStruct.new(
-            headers: { 'Content-Type' => 'application/json' },
-            body: { 'message' => 'I like providers\' tea' }.to_json,
-            status: 418
-          )
+      @organizer ||= Interactor::Context.build(
+        response: OpenStruct.new(
+          headers: { 'Content-Type' => 'application/json' },
+          body: { 'message' => 'I like providers\' tea' }.to_json,
+          status: 418
         )
       )
     end

--- a/siade/spec/controllers/api_controller_can_log_requests_info_for_debugging_spec.rb
+++ b/siade/spec/controllers/api_controller_can_log_requests_info_for_debugging_spec.rb
@@ -13,13 +13,11 @@ RSpec.describe APIController, 'log requests info for debugging' do
     end
 
     def organizer
-      @organizer ||= OpenStruct.new(
-        context: OpenStruct.new(
-          response: OpenStruct.new(
-            headers: { 'Content-Type' => 'application/json' },
-            body: { 'message' => 'I like providers\' tea' }.to_json,
-            status: 418
-          )
+      @organizer ||= Interactor::Context.build(
+        response: OpenStruct.new(
+          headers: { 'Content-Type' => 'application/json' },
+          body: { 'message' => 'I like providers\' tea' }.to_json,
+          status: 418
         )
       )
     end
@@ -76,6 +74,78 @@ RSpec.describe APIController, 'log requests info for debugging' do
     end
   end
 
+  context 'when the organizer went through the cache retriever' do
+    controller(described_class) do
+      def show
+        render json: { message: 'I like tea' },
+          status: 418
+      end
+
+      def operation_id
+        'whatever'
+      end
+
+      def organizer
+        @organizer ||= Interactor::Context.build(
+          retriever: Interactor::Context.build(
+            response: OpenStruct.new(
+              headers: { 'Content-Type' => 'application/json' },
+              body: { 'message' => 'I like providers\' tea' }.to_json,
+              status: 418
+            )
+          )
+        )
+      end
+    end
+
+    before do
+      allow(requests_debugging_service).to receive(:enable?).and_return(true)
+    end
+
+    it 'logs the provider response held by the wrapped retriever' do
+      expect(RequestsDebuggerLogger.instance).to receive(:log).with(
+        hash_including(
+          provider: {
+            header: { 'Content-Type' => 'application/json' },
+            body: 'eyJtZXNzYWdlIjoiSSBsaWtlIHByb3ZpZGVycycgdGVhIn0=',
+            status: 418
+          }
+        )
+      )
+
+      subject
+    end
+  end
+
+  context 'when the response was served from the cache' do
+    controller(described_class) do
+      def show
+        render json: { message: 'I like tea' },
+          status: 418
+      end
+
+      def operation_id
+        'whatever'
+      end
+
+      def organizer
+        @organizer ||= Interactor::Context.build(from_cache: true)
+      end
+    end
+
+    before do
+      allow(requests_debugging_service).to receive(:enable?).and_return(true)
+    end
+
+    it 'logs an empty provider payload' do
+      expect(RequestsDebuggerLogger.instance).to receive(:log).with(
+        hash_including(provider: {})
+      )
+
+      subject
+    end
+  end
+
   context 'when request debugging is disabled' do
     before do
       allow(requests_debugging_service).to receive(:enable?).and_return(false)
@@ -104,13 +174,11 @@ RSpec.describe APIController, 'log requests info for debugging' do
       end
 
       def organizer
-        @organizer ||= OpenStruct.new(
-          context: OpenStruct.new(
-            response: OpenStruct.new(
-              headers: { 'Content-Type' => 'application/json' },
-              body: { 'message' => 'I like providers\' tea' }.to_json,
-              status: 418
-            )
+        @organizer ||= Interactor::Context.build(
+          response: OpenStruct.new(
+            headers: { 'Content-Type' => 'application/json' },
+            body: { 'message' => 'I like providers\' tea' }.to_json,
+            status: 418
           )
         )
       end

--- a/siade/spec/requests/provider_response_exposure_spec.rb
+++ b/siade/spec/requests/provider_response_exposure_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe 'Provider response exposure', api: :entreprise do
+  subject(:payload) do
+    get "/v3/insee/sirene/unites_legales/#{siren}",
+      params: { context: 'Admin', recipient: '13002526500013', object: 'Debug requête' },
+      headers: request_headers
+
+    response_json
+  end
+
+  let(:siren) { sirens_insee_v3[:active_GE] }
+  let(:request_headers) do
+    {
+      'Authorization' => "Bearer #{yes_jwt}",
+      ProviderResponseDebuggingService::HEADER_NAME => 'true',
+      'Cache-Control' => 'no-cache'
+    }
+  end
+
+  before do
+    Siade.credentials[ProviderResponseDebuggingService::CREDENTIALS_KEY] = [yes_jwt_user.token_id]
+  end
+
+  after do
+    Siade.credentials.delete(ProviderResponseDebuggingService::CREDENTIALS_KEY)
+  end
+
+  it 'exposes the raw INSEE response next to the serialized payload', vcr: { cassette_name: 'insee/siren/active_GE_with_token' } do
+    provider_response = payload.dig(:meta, :provider_response)
+
+    expect(response).to have_http_status(:ok)
+    expect(payload.dig(:data, :siren)).to eq(siren)
+    expect(provider_response[:status]).to eq(200)
+    expect(JSON.parse(provider_response[:body]).dig('uniteLegale', 'siren')).to eq(siren)
+  end
+
+  context 'without the header' do
+    let(:request_headers) { { 'Authorization' => "Bearer #{yes_jwt}" } }
+
+    it 'keeps the payload untouched', vcr: { cassette_name: 'insee/siren/active_GE_with_token' } do
+      expect(payload[:meta]).not_to have_key(:provider_response)
+    end
+  end
+end


### PR DESCRIPTION
Read the provider response off the organizer context

`organizer` in API controllers holds what `RetrieverOrganizer.call`
returns: an `Interactor::Context`, not the organizer itself. Both the
requests debugger and the provider response exposure looked for the raw
provider response under `organizer.context.response`, and since a
context is an OpenStruct, the missing `context` accessor answered nil
instead of raising. The debugger has therefore always logged an empty
provider payload, and `meta.provider_response` never showed up in the
back-office manual requests, whatever the credential and header.

The raw response lives at `organizer.response`, or one level deeper at
`organizer.retriever.response` for the endpoints going through
`CacheResourceRetriever` when the provider was actually called. Both
concerns now share a single accessor covering the two shapes.

The concern specs hid the bug by stubbing the organizer with the shape
the code expected rather than the one it gets; they now build genuine
`Interactor::Context`s. A request spec on the INSEE endpoint checks the
whole chain, from the header down to the raw INSEE body in `meta`.

