### PR TITLE
Serve a disallow-all robots.txt outside production

### DIFF
--- a/siade/public/robots.txt
+++ b/siade/public/robots.txt
@@ -1,5 +1,0 @@
-# See http://www.robotstxt.org/wc/norobots.html for documentation on how to use the robots.txt file
-#
-# To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /

--- a/site/app/lib/robots_txt.rb
+++ b/site/app/lib/robots_txt.rb
@@ -1,0 +1,22 @@
+class RobotsTxt
+  PRODUCTION_TEMPLATE_PATH = 'config/seo/robots.txt'.freeze
+  NON_PRODUCTION_TEMPLATE_PATH = 'config/seo/robots_non_production.txt'.freeze
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(_env)
+    [200, { 'Content-Type' => 'text/plain' }, [body]]
+  end
+
+  private
+
+  attr_reader :app
+
+  def body
+    return Rails.root.join(NON_PRODUCTION_TEMPLATE_PATH).read unless Rails.env.production?
+
+    format(Rails.root.join(PRODUCTION_TEMPLATE_PATH).read, app:)
+  end
+end

--- a/site/config/routes/api_entreprise.rb
+++ b/site/config/routes/api_entreprise.rb
@@ -79,7 +79,7 @@ constraints(APIEntrepriseDomainConstraint.new) do
 
     get '/open-api.yml', to: 'open_api#show', as: :openapi_definition
     get '/open-api-without-deprecated-paths.yml', to: ->(env) { [200, {}, [APIEntreprise::OpenAPIDefinition.instance.open_api_without_deprecated_paths_definition_content]] }, as: :openapi_without_deprecated_definition
-    get '/robots.txt', to: ->(env) { [200, {}, [File.read('config/seo/robots.txt') % { app: 'entreprise' }]] }
+    get '/robots.txt', to: RobotsTxt.new('entreprise')
 
     get '/infolettre', to: 'pages#newsletter', as: :newsletter
     get '/mentions-legales', to: 'pages#mentions', as: :mentions

--- a/site/config/routes/api_particulier.rb
+++ b/site/config/routes/api_particulier.rb
@@ -11,7 +11,7 @@ constraints(APIParticulierDomainConstraint.new) do
   scope module: :api_particulier do
     get '/auth/:provider/callback', to: 'sessions#create_from_oauth', constraints: { provider: /proconnect_api_entreprise|proconnect_api_particulier/ }
     get '/auth/failure', to: 'sessions#failure'
-    get '/robots.txt', to: ->(env) { [200, {}, [File.read('config/seo/robots.txt') % { app: 'particulier' }]] }
+    get '/robots.txt', to: RobotsTxt.new('particulier')
     get '/status/apis', to: 'pages#current_status', as: :api_particulier_current_status
   end
 

--- a/site/config/seo/robots_non_production.txt
+++ b/site/config/seo/robots_non_production.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/site/spec/requests/robots_txt_spec.rb
+++ b/site/spec/requests/robots_txt_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /robots.txt' do
+  context 'when on API Entreprise' do
+    before { host! 'entreprise.api.localtest.me' }
+
+    it 'forbids every crawler outside production' do
+      get '/robots.txt'
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to eq("User-agent: *\nDisallow: /\n")
+    end
+
+    it 'exposes the sitemap in production' do
+      allow(Rails.env).to receive(:production?).and_return(true)
+
+      get '/robots.txt'
+
+      expect(response.body).to include('Sitemap: http://entreprise.api.gouv.fr/sitemaps/api-entreprise/sitemap.xml.gz')
+      expect(response.body).to include('Disallow: /compte/')
+    end
+  end
+
+  context 'when on API Particulier' do
+    before { host! 'particulier.api.localtest.me' }
+
+    it 'forbids every crawler outside production' do
+      get '/robots.txt'
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to eq("User-agent: *\nDisallow: /\n")
+    end
+
+    it 'exposes the sitemap in production' do
+      allow(Rails.env).to receive(:production?).and_return(true)
+
+      get '/robots.txt'
+
+      expect(response.body).to include('Sitemap: http://particulier.api.gouv.fr/sitemaps/api-particulier/sitemap.xml.gz')
+    end
+  end
+end


### PR DESCRIPTION
The sandbox and staging instances of the site answer on public hostnames and
were serving the very same robots.txt as production, sitemap included, so
crawlers were free to index them. The layouts already emit a noindex meta tag
outside production; the robots.txt now follows the same rule and returns a
plain `Disallow: /` everywhere but production, keeping the sitemap and the
fine-grained rules for the production hosts only. On the way, the two
duplicated route lambdas move to a `RobotsTxt` rack endpoint, which also sets
the `text/plain` content type that was missing.

Separately, the API backend loses its `public/robots.txt`: it was the untouched
Rails scaffolding, every directive commented out, saying nothing a missing file
would not already say.