### PR TITLE
Stop sending an empty genre to the CNAV

### DIFF
--- a/siade/app/interactors/cnav/make_request.rb
+++ b/siade/app/interactors/cnav/make_request.rb
@@ -65,7 +65,7 @@ class CNAV::MakeRequest < MakeRequest::Get
       codePaysNaissance: context.params[:code_cog_insee_pays_naissance],
       villeNaissance: context.params[:nom_commune_naissance],
       depNaissance: context.params[:code_cog_insee_departement_naissance],
-      genre: context.params[:sexe_etat_civil]&.upcase
+      genre: context.params[:sexe_etat_civil].presence&.upcase
     }.compact
   end
 

--- a/siade/spec/interactors/cnav/make_request_spec.rb
+++ b/siade/spec/interactors/cnav/make_request_spec.rb
@@ -144,15 +144,31 @@ RSpec.describe CNAV::MakeRequest, type: :make_request do
     end
 
     context 'when sexe_etat_civil is blank (non-regression test)' do
-      let(:params) { super().merge(sexe_etat_civil: nil) }
-
       let!(:stubbed_request) do
-        stub_request(:get, Siade.credentials[:cnav_complementaire_sante_solidaire_url])
-          .with(query: hash_excluding(:genre))
-          .to_return(status: 200, body: read_payload_file('cnav/complementaire_sante_solidaire/make_request_valid.json'))
+        stub_request(:get, Siade.credentials[:cnav_complementaire_sante_solidaire_url]).with(
+          query: {
+            codeLieuNaissance: '17300',
+            codePaysNaissance: '99100',
+            dateNaissance: '1980-06-12',
+            listePrenoms: 'JEAN-PASCAL',
+            nomNaissance: 'CHAMPION'
+          }
+        ).to_return(
+          status: 200,
+          body: read_payload_file('cnav/complementaire_sante_solidaire/make_request_valid.json')
+        )
       end
 
-      it { is_expected.to be_a_success }
+      [nil, '', ' '].each do |blank_sexe_etat_civil|
+        context "with #{blank_sexe_etat_civil.inspect}" do
+          let(:params) { super().merge(sexe_etat_civil: blank_sexe_etat_civil) }
+
+          it 'omits the genre param instead of sending it empty' do
+            expect(make_call).to be_a_success
+            expect(stubbed_request).to have_been_requested
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
CNAV::ValidateSexeEtatCivil deliberately accepts a blank
sexe_etat_civil since API-4484: the provider declared the field
optional, so an unprovided gender must simply not be forwarded.

CNAV::MakeRequest only honoured that for nil. An empty string went
through untouched and produced `genre=` in the outbound query string,
which the API-SECU rejects with a 400 — surfaced to our users as a
35561 rejected_civility. Commit 0e8d26f2b3 claimed `.compact` would
drop the entry "when no gender is provided", but `.compact` only
removes nil, never a blank string.

Use `.presence` so that "" and " " are treated like nil, matching the
`.blank?` the validator relies on.

The existing non-regression test only covered nil, and its
`hash_excluding(:genre)` matcher was vacuous: WebMock normalises query
keys to strings, so the symbol key was never present and the
expectation held whatever we sent. Stub the full expected query
instead, and cover nil, "" and " ".

