### PR TITLE
Document the API-SECU chain behind API Particulier

### DIFF
--- a/docs/cnav-api-secu.md
+++ b/docs/cnav-api-secu.md
@@ -6,7 +6,8 @@ document ne parle pas d'implémentation ; pour le code, partir de
 `siade/app/organizers/cnav/`.
 
 Les points marqués **À confirmer** n'ont pas été validés par le
-fournisseur de données.
+fournisseur de données. Les autres l'ont été, notamment lors du point
+CNAV du 10 septembre 2026.
 
 ## Les acteurs
 
@@ -14,12 +15,22 @@ fournisseur de données.
 
 Guichet unique de la Sécurité sociale, exploité par la CNAV (Caisse
 nationale d'assurance vieillesse). C'est le seul interlocuteur d'API
-Particulier pour les prestations sociales et le quotient familial : on ne parle jamais
-directement à une caisse.
+Particulier pour les prestations sociales et le quotient familial : on
+ne parle jamais directement à une caisse.
 
 API-SECU ne détient aucune donnée métier. Il reçoit une identité, la
-vérifie, la transforme en NIR (Numéro d'inscription au répertoire), trouve la caisse compétente, lui pose la question et relaie sa
-réponse. Nos routes le nomment `dss` (`/v3/dss/...`).
+contrôle, la fait transformer en NIR (numéro d'inscription au
+répertoire), trouve la caisse compétente, lui pose la question et
+relaie sa réponse. Il adapte et enrichit les appels au passage
+(en-têtes, contrôles de saisie) mais n'applique aucune règle métier :
+c'est un passe-plat. Nos routes le nomment `dss` (`/v3/dss/...`).
+
+Les contrôles de saisie sont faits par API-SECU lui-même, avant toute
+identification. Le sexe en est un : absent ou vide, l'appel est refusé
+avec un 400, quelle que soit la qualité du reste de l'identité. C'est
+pour cette raison que le paramètre redevient obligatoire sur nos
+endpoints, après avoir été rendu optionnel en avril 2026 : en pratique
+il ne l'a jamais été.
 
 ### SNGI
 
@@ -33,19 +44,20 @@ Sans cette conversion, aucune caisse ne peut être interrogée.
 
 C'est ce qui explique le poids inégal des paramètres d'identification :
 le nom de naissance, l'année de naissance et le lieu de naissance
-suffisent souvent à trouver la personne si elle n'a pas d'homonyme, et leur absence fait chuter le
-taux d'identification.
+suffisent souvent à trouver la personne si elle n'a pas d'homonyme, et
+leur absence fait chuter le taux d'identification.
 
 ### RNCPS
 
 Répertoire national commun de la protection sociale, exploité par la
 CNAV. À partir du NIR, il indique le régime et la caisse de rattachement
-de la personne.
+de la personne. Une même personne peut avoir plusieurs rattachements,
+potentiellement sur plusieurs caisses.
 
-Les caisses y remontent aussi en temps réel les droits ouverts pour les prestations. Le RNCPS
-est donc à la fois l'annuaire de rattachement pour tous les endpoints et
-la source de données des endpoints de statut de prestation (statut RSA,
-statut AAH, prime d'activité, etc.).
+Les caisses y remontent aussi en temps réel les droits ouverts pour les
+prestations. Le RNCPS est donc à la fois l'annuaire de rattachement
+pour tous les endpoints et la source de données des endpoints de statut
+de prestation (statut RSA, statut AAH, prime d'activité, etc.).
 
 ### CNAF et MSA
 
@@ -53,6 +65,8 @@ Les caisses qui possèdent réellement les dossiers allocataires :
 
 - CNAF : régime général, réseau des CAF ;
 - MSA : régime agricole.
+
+La CNAM (Assurance maladie) doit rejoindre la chaîne prochainement.
 
 C'est chez elles que vivent le quotient familial, la composition
 familiale, l'adresse et la participation familiale EAJE. Ces
@@ -65,9 +79,10 @@ Les deux caisses ne fonctionnent pas au même rythme :
 
 - la MSA recalcule en temps réel à chaque changement de situation ;
 - la CAF met à jour une fois par mois, après le premier week-end du
-  mois ;
-- seule la CAF sert un historique du quotient familial, limité aux 24
-  derniers mois.
+  mois. Un appel sur le mois en cours avant cette bascule ne trouve
+  rien : c'est une cause connue de 404 en début de mois ;
+- seule la CAF sert un historique du quotient familial, limité à
+  environ 23 mois.
 
 ## Le parcours d'une demande
 
@@ -75,19 +90,30 @@ Les deux caisses ne fonctionnent pas au même rythme :
    l'usager, ou via FranceConnect qui fournit cette identité.
 2. API Particulier contrôle la forme des paramètres et transmet à
    API-SECU.
-3. **SNGI** : conversion de l'identité en NIR. Aucune correspondance :
+3. **API-SECU** contrôle la saisie (format du nom, sexe présent, lieu
+   de naissance connu). Un refus ici est un 400 avec un code d'erreur
+   du guichet.
+4. **SNGI** : conversion de l'identité en NIR. Aucune correspondance :
    l'appel s'arrête sur « identité non reconnue par le fournisseur ».
    L'usager est invité à vérifier ses informations.
-4. **RNCPS** : à partir du NIR, recherche du régime et de la caisse de
+5. **RNCPS** : à partir du NIR, recherche du régime et de la caisse de
    rattachement. Aucun rattachement : « allocataire non référencé auprès
    des caisses éligibles ».
-5. Lecture de la donnée, selon l'endpoint :
+6. Lecture de la donnée, selon l'endpoint :
    - statut de prestation : dans le RNCPS lui-même ;
    - quotient familial et participation familiale EAJE : auprès de la
      CAF ou de la MSA, selon le rattachement.
-6. API-SECU relaie la réponse en indiquant la caisse qui a répondu.
+7. API-SECU relaie la réponse en indiquant la caisse qui a répondu.
    API Particulier la restitue, en nommant CAF ou MSA sur le quotient
    familial.
+
+### Savoir qui a répondu
+
+API-SECU renseigne dans sa réponse un en-tête avec le code de la caisse
+interrogée. En-tête absent ou vide : l'appel a été bloqué avant
+d'atteindre une caisse, au contrôle de saisie ou à l'identification
+SNGI. La correspondance code / caisse est dans
+`siade/app/organizers/cnav/retriever_organizer.rb`.
 
 ## Les refus d'API-SECU
 
@@ -98,12 +124,31 @@ pour l'appelant.
 |---|---|---|
 | Contrôle de saisie du guichet | format du nom, commune de naissance inconnue, sexe absent, département inconnu | corriger les paramètres |
 | Identification (SNGI, RNCPS) | personne introuvable, aucun rattachement | vérifier l'identité, ou fermer le dossier |
-| Caisse (CAF, MSA) | dossier absent, calcul du quotient impossible, période hors historique | rien sur l'identité ; changer la période ou réessayer plus tard |
+| Caisse (CAF, MSA) | dossier absent, période hors historique, mauvais routage | rien sur l'identité ; changer la période ou réessayer plus tard |
 
-Cas particulier du quotient familial : la CAF ne sert que 24 mois
-d'historique. Une période plus ancienne est refusée par la caisse et
-restituée comme « période refusée par le fournisseur de données », pas
-comme une erreur d'identité.
+Sur le quotient familial, deux refus de la caisse ne sont pas des
+erreurs d'identité et sont restitués comme tels :
+
+- **Période trop ancienne** : la CAF ne sert qu'environ 23 mois
+  d'historique. Restitué comme « période refusée par le fournisseur de
+  données ». Un appelant qui balaie mois par mois sans s'arrêter au
+  premier refus le produit en masse.
+- **Mauvais routage** : la personne a plusieurs rattachements, parfois
+  sur plusieurs caisses, et API-SECU interroge une caisse qui n'a rien
+  pour elle. Anomalie en cours d'investigation côté MSA, restituée
+  comme erreur interne du fournisseur.
+
+Le détail des codes du guichet et leur restitution côté API
+Particulier est dans `siade/app/interactors/cnav/`.
+
+## Ce qu'API-SECU ne fait pas
+
+API-SECU n'applique aucun filtre métier. Le filtrage par âge des
+enfants sur la participation familiale EAJE (moins de 7 ans pour les
+crèches) est appliqué par API Particulier, pas par le guichet ni par
+les caisses. L'évolution envisagée pour les garderies scolaires est un
+paramètre d'intervalle d'âge porté par l'habilitation ; la CNAF et la
+MSA doivent confirmer qu'elles peuvent le prendre en charge.
 
 ## Endpoints concernés
 
@@ -116,7 +161,7 @@ deux modalités d'appel, `/identite` (identité pivot) et
 | Prestation | Route v3 |
 |---|---|
 | Quotient familial et composition familiale | `/v3/dss/quotient_familial/{identite,france_connect}` |
-| Participation familiale EAJE (prestation de service unique) | `/v3/dss/participation_familiale_eaje/{identite,france_connect}`|
+| Participation familiale EAJE (prestation de service unique) | `/v3/dss/participation_familiale_eaje/{identite,france_connect}` |
 
 ### Données RNCPS
 
@@ -135,8 +180,11 @@ fiches publiques la présentent comme issue du RNCPS, et l'historique du
 projet la traite comme le cas où le RNCPS répond directement en tant
 que régime. La C2S étant une prestation de l'Assurance maladie et non
 des caisses d'allocations familiales, cette origine reste à valider
-avec la CNAV.
+avec la CNAV. Une API distincte d'éligibilité à la C2S, fondée sur les
+ressources, figure par ailleurs dans la feuille de route CNAV.
 
 **À confirmer** : le RNCPS comme source directe des statuts de
-prestation. Les fiches publiques l'affirment ; la CNAV ne l'a pas
-formellement confirmé.
+prestation. Les fiches publiques l'affirment. La CNAV a précisé que le
+RNCPS détermine les affiliations et que les prestations restent
+stockées chez chaque caisse ; reste à établir si les statuts sont lus
+dans le répertoire ou chez la caisse au travers de celui-ci.

--- a/docs/cnav-api-secu.md
+++ b/docs/cnav-api-secu.md
@@ -1,0 +1,139 @@
+# API-SECU : les prestations sociales sur API Particulier
+
+Description fonctionnelle de la chaîne qui relie API Particulier aux
+caisses de la Sécurité sociale (CNAV, SNGI, RNCPS, CNAF, MSA). Ce
+document ne parle pas d'implémentation ; pour le code, partir de
+`siade/app/organizers/cnav/`.
+
+Les points marqués **À confirmer** n'ont pas été validés par le
+fournisseur de données.
+
+## Les acteurs
+
+### API-SECU
+
+Guichet unique de la Sécurité sociale, exploité par la CNAV (Caisse
+nationale d'assurance vieillesse). C'est le seul interlocuteur d'API
+Particulier pour les prestations sociales : on ne parle jamais
+directement à une caisse.
+
+API-SECU ne détient aucune donnée métier. Il reçoit une identité, la
+vérifie, trouve la caisse compétente, lui pose la question et relaie sa
+réponse. Nos routes le nomment `dss` (`/v3/dss/...`).
+
+### SNGI
+
+Système national de gestion des identifiants. Référentiel des identités
+de la Sécurité sociale, exploité par la CNAV.
+
+Les caisses ne connaissent pas les identités civiles, uniquement des
+NIR. Le SNGI est le seul système capable de passer d'une identité pivot
+(nom de naissance, prénoms, date et lieu de naissance, sexe) à un NIR.
+Sans cette conversion, aucune caisse ne peut être interrogée.
+
+C'est ce qui explique le poids inégal des paramètres d'identification :
+le nom de naissance, l'année de naissance et le lieu de naissance
+suffisent souvent à trouver la personne, et leur absence fait chuter le
+taux d'identification.
+
+### RNCPS
+
+Répertoire national commun de la protection sociale, exploité par la
+CNAV. À partir du NIR, il indique le régime et la caisse de rattachement
+de la personne.
+
+Les caisses y remontent aussi en temps réel les droits ouverts. Le RNCPS
+est donc à la fois l'annuaire de rattachement pour tous les endpoints et
+la source de données des endpoints de statut de prestation (statut RSA,
+statut AAH, prime d'activité, etc.).
+
+### CNAF et MSA
+
+Les caisses qui possèdent réellement les dossiers allocataires :
+
+- CNAF : régime général, réseau des CAF ;
+- MSA : régime agricole.
+
+C'est chez elles que vivent le quotient familial, la composition
+familiale et l'adresse. Le RNCPS ne porte que les droits, pas ces
+données de dossier.
+
+Les deux caisses ne fonctionnent pas au même rythme :
+
+- la MSA recalcule en temps réel à chaque changement de situation ;
+- la CAF met à jour une fois par mois, après le premier week-end du
+  mois ;
+- seule la CAF sert un historique du quotient familial, limité aux 24
+  derniers mois.
+
+## Le parcours d'une demande
+
+1. L'administration appelle API Particulier avec l'identité pivot de
+   l'usager, ou via FranceConnect qui fournit cette identité.
+2. API Particulier contrôle la forme des paramètres et transmet à
+   API-SECU.
+3. **SNGI** : conversion de l'identité en NIR. Aucune correspondance :
+   l'appel s'arrête sur « identité non reconnue par le fournisseur ».
+   L'usager est invité à vérifier ses informations.
+4. **RNCPS** : à partir du NIR, recherche du régime et de la caisse de
+   rattachement. Aucun rattachement : « allocataire non référencé auprès
+   des caisses éligibles ».
+5. Lecture de la donnée, selon l'endpoint :
+   - statut de prestation : dans le RNCPS lui-même ;
+   - quotient familial : auprès de la CAF ou de la MSA, selon le
+     rattachement.
+6. API-SECU relaie la réponse en indiquant la caisse qui a répondu.
+   API Particulier la restitue, en nommant CAF ou MSA sur le quotient
+   familial.
+
+## Les refus d'API-SECU
+
+Un refus peut venir de trois niveaux, avec des conséquences différentes
+pour l'appelant.
+
+| Origine | Exemple | Ce que l'appelant peut faire |
+|---|---|---|
+| Contrôle de saisie du guichet | format du nom, commune de naissance inconnue, sexe absent, département inconnu | corriger les paramètres |
+| Identification (SNGI, RNCPS) | personne introuvable, aucun rattachement | vérifier l'identité, ou fermer le dossier |
+| Caisse (CAF, MSA) | dossier absent, calcul du quotient impossible, période hors historique | rien sur l'identité ; changer la période ou réessayer plus tard |
+
+Cas particulier du quotient familial : la CAF ne sert que 24 mois
+d'historique. Une période plus ancienne est refusée par la caisse et
+restituée comme « période refusée par le fournisseur de données », pas
+comme une erreur d'identité.
+
+## Endpoints concernés
+
+Tous les endpoints ci-dessous passent par API-SECU. Chacun existe en
+deux modalités d'appel, `/identite` (identité pivot) et
+`/france_connect`.
+
+### Données CAF / MSA
+
+| Prestation | Route v3 |
+|---|---|
+| Quotient familial et composition familiale | `/v3/dss/quotient_familial/{identite,france_connect}` |
+
+### Données RNCPS
+
+| Prestation | Route v3 |
+|---|---|
+| Revenu de solidarité active | `/v3/dss/revenu_solidarite_active/{identite,france_connect}` |
+| Prime d'activité | `/v3/dss/prime_activite/{identite,france_connect}` |
+| Allocation aux adultes handicapés | `/v3/dss/allocation_adulte_handicape/{identite,france_connect}` |
+| Allocation de soutien familial | `/v3/dss/allocation_soutien_familial/{identite,france_connect}` |
+| Allocation de rentrée scolaire | `/v3/dss/allocation_rentree_scolaire/{identite,france_connect}` |
+| Allocation d'éducation de l'enfant handicapé | `/v3/dss/allocation_enfant_handicape/{identite,france_connect}` |
+| Participation familiale EAJE (prestation de service unique) | `/v3/dss/participation_familiale_eaje/{identite,france_connect}` |
+| Complémentaire santé solidaire | `/v3/dss/complementaire_sante_solidaire/{identite,france_connect}` |
+
+**À confirmer** : la source de la complémentaire santé solidaire. Les
+fiches publiques la présentent comme issue du RNCPS, et l'historique du
+projet la traite comme le cas où le RNCPS répond directement en tant
+que régime. La C2S étant une prestation de l'Assurance maladie et non
+des caisses d'allocations familiales, cette origine reste à valider
+avec la CNAV.
+
+**À confirmer** : le RNCPS comme source directe des statuts de
+prestation. Les fiches publiques l'affirment ; la CNAV ne l'a pas
+formellement confirmé.

--- a/docs/cnav-api-secu.md
+++ b/docs/cnav-api-secu.md
@@ -55,8 +55,11 @@ Les caisses qui possèdent réellement les dossiers allocataires :
 - MSA : régime agricole.
 
 C'est chez elles que vivent le quotient familial, la composition
-familiale et l'adresse. Le RNCPS ne porte que les droits, pas ces
-données de dossier.
+familiale, l'adresse et la participation familiale EAJE. Ces
+informations ne remontent pas au RNCPS : le répertoire sait qu'une
+personne a un droit ouvert à une prestation, il ne connaît pas le
+contenu de son dossier. Pour les obtenir, API-SECU doit interroger la
+caisse elle-même.
 
 Les deux caisses ne fonctionnent pas au même rythme :
 
@@ -80,8 +83,8 @@ Les deux caisses ne fonctionnent pas au même rythme :
    des caisses éligibles ».
 5. Lecture de la donnée, selon l'endpoint :
    - statut de prestation : dans le RNCPS lui-même ;
-   - quotient familial : auprès de la CAF ou de la MSA, selon le
-     rattachement.
+   - quotient familial et participation familiale EAJE : auprès de la
+     CAF ou de la MSA, selon le rattachement.
 6. API-SECU relaie la réponse en indiquant la caisse qui a répondu.
    API Particulier la restitue, en nommant CAF ou MSA sur le quotient
    familial.

--- a/docs/cnav-api-secu.md
+++ b/docs/cnav-api-secu.md
@@ -21,16 +21,15 @@ ne parle jamais directement à une caisse.
 API-SECU ne détient aucune donnée métier. Il reçoit une identité, la
 contrôle, la fait transformer en NIR (numéro d'inscription au
 répertoire), trouve la caisse compétente, lui pose la question et
-relaie sa réponse. Il adapte et enrichit les appels au passage
-(en-têtes, contrôles de saisie) mais n'applique aucune règle métier :
-c'est un passe-plat. Nos routes le nomment `dss` (`/v3/dss/...`).
+relaie sa réponse. Nos routes le nomment `dss` (`/v3/dss/...`).
 
-Les contrôles de saisie sont faits par API-SECU lui-même, avant toute
-identification. Le sexe en est un : absent ou vide, l'appel est refusé
-avec un 400, quelle que soit la qualité du reste de l'identité. C'est
-pour cette raison que le paramètre redevient obligatoire sur nos
-endpoints, après avoir été rendu optionnel en avril 2026 : en pratique
-il ne l'a jamais été.
+API-SECU applique ses propres règles métier sur les paramètres avant de
+passer la main au SNGI pour l'identification. Ces règles ne sont pas
+celles de l'identification : le sexe, par exemple, est aujourd'hui
+obligatoire pour API-SECU alors qu'il ne pèse presque rien dans le
+matching du SNGI. Un paramètre peut donc être refusé par le guichet
+sans que cela dise quoi que ce soit sur les chances d'identifier la
+personne.
 
 ### SNGI
 
@@ -143,12 +142,13 @@ Particulier est dans `siade/app/interactors/cnav/`.
 
 ## Ce qu'API-SECU ne fait pas
 
-API-SECU n'applique aucun filtre métier. Le filtrage par âge des
-enfants sur la participation familiale EAJE (moins de 7 ans pour les
-crèches) est appliqué par API Particulier, pas par le guichet ni par
-les caisses. L'évolution envisagée pour les garderies scolaires est un
-paramètre d'intervalle d'âge porté par l'habilitation ; la CNAF et la
-MSA doivent confirmer qu'elles peuvent le prendre en charge.
+API-SECU ne filtre pas les données renvoyées par les caisses : c'est un
+passe-plat. Le filtrage par âge des enfants sur la participation
+familiale EAJE (moins de 7 ans pour les crèches) est appliqué par API
+Particulier, pas par le guichet ni par les caisses. L'évolution
+envisagée pour les garderies scolaires est un paramètre d'intervalle
+d'âge porté par l'habilitation ; la CNAF et la MSA doivent confirmer
+qu'elles peuvent le prendre en charge.
 
 ## Endpoints concernés
 

--- a/docs/cnav-api-secu.md
+++ b/docs/cnav-api-secu.md
@@ -14,11 +14,11 @@ fournisseur de données.
 
 Guichet unique de la Sécurité sociale, exploité par la CNAV (Caisse
 nationale d'assurance vieillesse). C'est le seul interlocuteur d'API
-Particulier pour les prestations sociales : on ne parle jamais
+Particulier pour les prestations sociales et le quotient familial : on ne parle jamais
 directement à une caisse.
 
 API-SECU ne détient aucune donnée métier. Il reçoit une identité, la
-vérifie, trouve la caisse compétente, lui pose la question et relaie sa
+vérifie, la transforme en NIR (Numéro d'inscription au répertoire), trouve la caisse compétente, lui pose la question et relaie sa
 réponse. Nos routes le nomment `dss` (`/v3/dss/...`).
 
 ### SNGI
@@ -33,7 +33,7 @@ Sans cette conversion, aucune caisse ne peut être interrogée.
 
 C'est ce qui explique le poids inégal des paramètres d'identification :
 le nom de naissance, l'année de naissance et le lieu de naissance
-suffisent souvent à trouver la personne, et leur absence fait chuter le
+suffisent souvent à trouver la personne si elle n'a pas d'homonyme, et leur absence fait chuter le
 taux d'identification.
 
 ### RNCPS
@@ -42,7 +42,7 @@ Répertoire national commun de la protection sociale, exploité par la
 CNAV. À partir du NIR, il indique le régime et la caisse de rattachement
 de la personne.
 
-Les caisses y remontent aussi en temps réel les droits ouverts. Le RNCPS
+Les caisses y remontent aussi en temps réel les droits ouverts pour les prestations. Le RNCPS
 est donc à la fois l'annuaire de rattachement pour tous les endpoints et
 la source de données des endpoints de statut de prestation (statut RSA,
 statut AAH, prime d'activité, etc.).
@@ -113,6 +113,7 @@ deux modalités d'appel, `/identite` (identité pivot) et
 | Prestation | Route v3 |
 |---|---|
 | Quotient familial et composition familiale | `/v3/dss/quotient_familial/{identite,france_connect}` |
+| Participation familiale EAJE (prestation de service unique) | `/v3/dss/participation_familiale_eaje/{identite,france_connect}`|
 
 ### Données RNCPS
 
@@ -124,7 +125,6 @@ deux modalités d'appel, `/identite` (identité pivot) et
 | Allocation de soutien familial | `/v3/dss/allocation_soutien_familial/{identite,france_connect}` |
 | Allocation de rentrée scolaire | `/v3/dss/allocation_rentree_scolaire/{identite,france_connect}` |
 | Allocation d'éducation de l'enfant handicapé | `/v3/dss/allocation_enfant_handicape/{identite,france_connect}` |
-| Participation familiale EAJE (prestation de service unique) | `/v3/dss/participation_familiale_eaje/{identite,france_connect}` |
 | Complémentaire santé solidaire | `/v3/dss/complementaire_sante_solidaire/{identite,france_connect}` |
 
 **À confirmer** : la source de la complémentaire santé solidaire. Les

--- a/docs/cnav-api-secu.md
+++ b/docs/cnav-api-secu.md
@@ -5,9 +5,9 @@ caisses de la Sécurité sociale (CNAV, SNGI, RNCPS, CNAF, MSA). Ce
 document ne parle pas d'implémentation ; pour le code, partir de
 `siade/app/organizers/cnav/`.
 
-Les points marqués **À confirmer** n'ont pas été validés par le
-fournisseur de données. Les autres l'ont été, notamment lors du point
-CNAV du 10 septembre 2026.
+Les points ci-dessous ont été validés avec le fournisseur de données,
+notamment lors du point CNAV du 10 septembre 2026, ou recoupés avec
+les tickets Linear et l'historique du projet.
 
 ## Les acteurs
 
@@ -53,10 +53,17 @@ CNAV. À partir du NIR, il indique le régime et la caisse de rattachement
 de la personne. Une même personne peut avoir plusieurs rattachements,
 potentiellement sur plusieurs caisses.
 
-Les caisses y remontent aussi en temps réel les droits ouverts pour les
-prestations. Le RNCPS est donc à la fois l'annuaire de rattachement
-pour tous les endpoints et la source de données des endpoints de statut
-de prestation (statut RSA, statut AAH, prime d'activité, etc.).
+Les caisses y remontent aussi les droits ouverts pour les prestations,
+mais les prestations elles-mêmes restent stockées chez chaque caisse.
+Pour les statuts de prestation (statut RSA, statut AAH, prime
+d'activité, etc.), le RNCPS sert donc d'annuaire : API-SECU y lit les
+rattachements puis interroge la ou les caisses concernées, qui
+répondent avec leurs prestations.
+
+La complémentaire santé solidaire est l'exception : le RNCPS répond
+lui-même, avec les droits que la CNAM (Assurance maladie) et la MSA
+lui remontent, la CNAM n'étant pas encore branchée en direct sur
+API-SECU.
 
 ### CNAF et MSA
 
@@ -99,7 +106,9 @@ Les deux caisses ne fonctionnent pas au même rythme :
    rattachement. Aucun rattachement : « allocataire non référencé auprès
    des caisses éligibles ».
 6. Lecture de la donnée, selon l'endpoint :
-   - statut de prestation : dans le RNCPS lui-même ;
+   - statut de prestation : auprès de la ou des caisses de
+     rattachement, sauf la complémentaire santé solidaire lue dans le
+     RNCPS lui-même ;
    - quotient familial et participation familiale EAJE : auprès de la
      CAF ou de la MSA, selon le rattachement.
 7. API-SECU relaie la réponse en indiquant la caisse qui a répondu.
@@ -124,6 +133,14 @@ pour l'appelant.
 | Contrôle de saisie du guichet | format du nom, commune de naissance inconnue, sexe absent, département inconnu | corriger les paramètres |
 | Identification (SNGI, RNCPS) | personne introuvable, aucun rattachement | vérifier l'identité, ou fermer le dossier |
 | Caisse (CAF, MSA) | dossier absent, période hors historique, mauvais routage | rien sur l'identité ; changer la période ou réessayer plus tard |
+
+Sur les statuts de prestation, une caisse qui ne répond pas dans la
+chaîne produit une erreur RNCPS « dossier absent » alors que la
+personne est bénéficiaire. Le fournisseur en a confirmé la cause en
+2026 sans donner de délai de correction ; le quotient familial et
+l'EAJE ne sont pas concernés. Par ailleurs un droit ouvert peut mettre
+jusqu'à 30 jours à apparaître dans l'API, délai avéré sur la
+complémentaire santé solidaire et suspecté sur les autres statuts.
 
 Sur le quotient familial, deux refus de la caisse ne sont pas des
 erreurs d'identité et sont restitués comme tels :
@@ -163,7 +180,7 @@ deux modalités d'appel, `/identite` (identité pivot) et
 | Quotient familial et composition familiale | `/v3/dss/quotient_familial/{identite,france_connect}` |
 | Participation familiale EAJE (prestation de service unique) | `/v3/dss/participation_familiale_eaje/{identite,france_connect}` |
 
-### Données RNCPS
+### Statuts de prestation, données CAF / MSA via le RNCPS
 
 | Prestation | Route v3 |
 |---|---|
@@ -173,18 +190,18 @@ deux modalités d'appel, `/identite` (identité pivot) et
 | Allocation de soutien familial | `/v3/dss/allocation_soutien_familial/{identite,france_connect}` |
 | Allocation de rentrée scolaire | `/v3/dss/allocation_rentree_scolaire/{identite,france_connect}` |
 | Allocation d'éducation de l'enfant handicapé | `/v3/dss/allocation_enfant_handicape/{identite,france_connect}` |
+
+Les fiches publiques de ces endpoints disent les données « issues du
+RNCPS ». C'est un raccourci : le RNCPS donne le rattachement, la
+prestation vient de la caisse.
+
+### Statut de prestation, données RNCPS
+
+| Prestation | Route v3 |
+|---|---|
 | Complémentaire santé solidaire | `/v3/dss/complementaire_sante_solidaire/{identite,france_connect}` |
 
-**À confirmer** : la source de la complémentaire santé solidaire. Les
-fiches publiques la présentent comme issue du RNCPS, et l'historique du
-projet la traite comme le cas où le RNCPS répond directement en tant
-que régime. La C2S étant une prestation de l'Assurance maladie et non
-des caisses d'allocations familiales, cette origine reste à valider
-avec la CNAV. Une API distincte d'éligibilité à la C2S, fondée sur les
-ressources, figure par ailleurs dans la feuille de route CNAV.
-
-**À confirmer** : le RNCPS comme source directe des statuts de
-prestation. Les fiches publiques l'affirment. La CNAV a précisé que le
-RNCPS détermine les affiliations et que les prestations restent
-stockées chez chaque caisse ; reste à établir si les statuts sont lus
-dans le répertoire ou chez la caisse au travers de celui-ci.
+Le RNCPS répond directement, alimenté par la CNAM pour le régime
+général et la MSA pour le régime agricole. Une API distincte
+d'éligibilité à la C2S, fondée sur les ressources, figure par ailleurs
+dans la feuille de route CNAV.


### PR DESCRIPTION
Nine API Particulier endpoints go through the same Sécurité sociale
gateway, and the roles of the systems behind it (CNAV, SNGI, RNCPS,
CNAF, MSA) were only recorded in scattered commit messages and in the
public endpoint fiches. Working on the CNAV error mapping (API-7373)
required reassembling that picture from scratch.

Write it down once, functionally: who holds what, why the identity has
to become a NIR before any caisse can be asked, where each endpoint
reads its data, and how the three levels of refusal (gateway input
control, identification, caisse) differ for the caller.

Two points are flagged as unconfirmed by the provider: the source of
the complémentaire santé solidaire, and the RNCPS as the direct source
of the prestation statuses.
