### PR TITLE
Fix the Sentry events pagination cursor

### DIFF
--- a/bin/sentry/sentry_client.rb
+++ b/bin/sentry/sentry_client.rb
@@ -39,7 +39,7 @@ class SentryClient
   def events(issue_id, page: 0, full: false)
     response = @connection.get(
       "/api/0/issues/#{issue_id}/events/",
-      { full: full, cursor: "0:0:#{page * 100}" }
+      { full: full, cursor: "0:#{page * 100}:0" }
     )
     response.body
   end


### PR DESCRIPTION
The Sentry cursor format is `<value>:<offset>:<is_prev>`, and the client sent the offset in the third field. Every page therefore came back as the first one: `bin/sentry/events -p N` and `bin/sentry/export -p N` returned N copies of the same 100 events, which went unnoticed because the rows were only counted, not deduplicated.