### PR TITLE
Present the ANTS-issued certificate to the SIV

### DIFF
--- a/siade/app/interactors/ants/extrait_immatriculation_vehicule/make_request.rb
+++ b/siade/app/interactors/ants/extrait_immatriculation_vehicule/make_request.rb
@@ -1,10 +1,23 @@
 class ANTS::ExtraitImmatriculationVehicule::MakeRequest < MakeRequest::Post
-  include UseWildcardSSLCertificate
-
   private
 
   def http_options
-    http_wildcard_ssl_options
+    {
+      use_ssl: true,
+      verify_mode: OpenSSL::SSL::VERIFY_PEER,
+      cert:,
+      key:
+    }
+  end
+
+  def cert
+    raw_cert = File.read(Siade.credentials[:ants_siv_client_certificate_path])
+    OpenSSL::X509::Certificate.new(raw_cert)
+  end
+
+  def key
+    raw_key = File.read(Siade.credentials[:ants_siv_client_certificate_key_path])
+    OpenSSL::PKey::RSA.new(raw_key)
   end
 
   def extra_headers(request)

--- a/siade/spec/spec_helper.rb
+++ b/siade/spec/spec_helper.rb
@@ -61,6 +61,8 @@ RSpec.configure do |config|
     Siade.credentials[:france_connect_v2_rsa_public] = rsa_key.public_key.to_pem
     Siade.credentials[:ssl_wildcard_certif_crt_path] = Rails.root.join('spec/fixtures/ssl/certificat.crt').to_s
     Siade.credentials[:ssl_wildcard_certif_key_path] = Rails.root.join('spec/fixtures/ssl/certificat.key').to_s
+    Siade.credentials[:ants_siv_client_certificate_path] = Rails.root.join('spec/fixtures/ssl/certificat.crt').to_s
+    Siade.credentials[:ants_siv_client_certificate_key_path] = Rails.root.join('spec/fixtures/ssl/certificat.key').to_s
     Siade.credentials[:men_scolarites_client_id] = 'api-particuliers-tests'
   end
 


### PR DESCRIPTION
ANTS now issues our client certificate from its own CA, under an RGS* qualified TLS Client profile with an RSA 3072 key, while Banque de France and ProBTP stay on the Certigna one.

This is a temporary fix to mitigate the current expired mTLS certificate