### PR TITLE
Fix invalid links and stale fields in the Sirene endpoint docs

### DIFF
--- a/commons/endpoints/_swagger_shared/insee.yml
+++ b/commons/endpoints/_swagger_shared/insee.yml
@@ -572,22 +572,32 @@ insee:
         "La distribution spéciale reprend les éléments particuliers qui accompagnent une adresse de distribution spéciale, la modalité la plus connue étant les adresses en 'CEDEX'.
         \n
         \n
+        L'Insee ne gère plus cette variable : elle est désormais toujours à 'null'.
+        \n
+        \n
         Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement"
     code_cedex: &insee_adresse_etablissement_code_cedex_property
       title: "Code cedex"
       type: "string"
       nullable: true
-      description: "Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
+      description: "L'Insee ne gère plus cette variable : elle est désormais toujours à 'null'.
+        \n
+        \n
+        Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
         \n
         \n
         Sur le sigle CEDEX lui-même : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle"
-      example: "75590"
     libelle_cedex: &insee_adresse_etablissement_libelle_cedex_property
       title: "Libellé du code cedex"
       type: "string"
       nullable: true
-      example: "PARIS CEDEX 12"
-      description: "Ce champ indique le libellé correspondant au code cedex de l'établissement. Si le code cedex est à 'null', ce champ est également à 'null'."
+      description: "Ce champ indique le libellé correspondant au code cedex de l'établissement. Si le code cedex est à 'null', ce champ est également à 'null'.
+        \n
+        \n
+        L'Insee ne gère plus cette variable : elle est désormais toujours à 'null'.
+        \n
+        \n
+        Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#libellecedexetablissement"
     libelle_commune:
       title: "Nom de la commune pour une adresse en France"
       description: "Cette valeur est à 'null' pour les établissements à l'étranger."
@@ -659,15 +669,17 @@ insee:
         l5: &adresse_etablissement_acheminement_postal_l5_property
           title: "Ligne 5"
           type: "string"
-          description: "Distribution spéciale comme décrit dans la clé `distribution_speciale`"
+          description: "Distribution spéciale comme décrit dans la clé `distribution_speciale`, que l'Insee ne gère plus : cette ligne est désormais toujours vide."
           nullable: true
-          example: "CS 72809"
         l6: &adresse_etablissement_acheminement_postal_l6_property
           title: "Ligne 6"
           type: "string"
-          description: "Si le code cedex est existant : code cedex accompagné de son libellé ; sinon, si le pays est en France : code postal accompagné de son libellé, sinon : libellé de la commune de l'établissement situé à l'étranger"
+          description: "Si le pays est en France : code postal accompagné du libellé de la commune, sinon : libellé de la commune de l'établissement situé à l'étranger.
+          \n
+          \n
+          Le code cedex, qui primait sur le code postal, ne sort plus de cette ligne : l'Insee ne gère plus cette variable."
           nullable: true
-          example: "75256 PARIX CEDEX 12"
+          example: "75012 PARIS"
         l7: &adresse_etablissement_acheminement_postal_l7_property
           title: "Ligne 7"
           type: "string"
@@ -712,12 +724,17 @@ insee:
       description: "La distribution spéciale reprend les éléments particuliers qui accompagnent une adresse de distribution   spéciale, la modalité la plus connue étant les adresses en 'CEDEX'.
         \n
         \n
+        L'Insee ne gère plus cette variable : elle est désormais toujours à 'null'.
+        \n
+        \n
         Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement
         \n
         Si la personne morale est en diffusion partielle, la valeur est remplacée par \"[ND]\"."
     code_cedex:
       <<: *insee_adresse_etablissement_code_cedex_property
-      description: "Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
+      description: "L'Insee ne gère plus cette variable : elle est désormais toujours à 'null'.
+      \n
+      Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
       \n
       Sur le sigle CEDEX lui-même : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle
       \n
@@ -725,6 +742,10 @@ insee:
     libelle_cedex:
       <<: *insee_adresse_etablissement_libelle_cedex_property
       description: "Ce champ indique le libellé correspondant au code cedex de l'établissement. Si le code cedex est à 'null', ce champ est également à 'null'.
+      \n
+      L'Insee ne gère plus cette variable : elle est désormais toujours à 'null'.
+      \n
+      Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#libellecedexetablissement
       \n
       Si la personne morale est en diffusion partielle, la valeur est remplacée par \"[ND]\"."
     acheminement_postal:
@@ -752,12 +773,14 @@ insee:
           Si la personne morale est en diffusion partielle, la valeur est remplacée par \"[ND]\"."
         l5:
           <<: *adresse_etablissement_acheminement_postal_l5_property
-          description: "Distribution spéciale comme décrit dans la clé `distribution_speciale`
+          description: "Distribution spéciale comme décrit dans la clé `distribution_speciale`, que l'Insee ne gère plus : cette ligne est désormais toujours vide.
           \n
           Si la personne morale est en diffusion partielle, la valeur est remplacée par \"[ND]\"."
         l6:
           <<: *adresse_etablissement_acheminement_postal_l6_property
-          description: "Si le code cedex est existant : code cedex accompagné de son libellé ; sinon, si le pays est en France : code postal accompagné de son libellé, sinon : libellé de la commune de l'établissement situé à l'étranger
+          description: "Si le pays est en France : code postal accompagné du libellé de la commune, sinon : libellé de la commune de l'établissement situé à l'étranger.
+          \n
+          Le code cedex, qui primait sur le code postal, ne sort plus de cette ligne : l'Insee ne gère plus cette variable.
           \n
           Si la personne morale est en diffusion partielle, la valeur est remplacée par \"[ND]\"."
         l7:

--- a/commons/endpoints/_swagger_shared/insee.yml
+++ b/commons/endpoints/_swagger_shared/insee.yml
@@ -231,7 +231,7 @@ insee:
         \n
         - non-diffusible (obsolète) : 'false', dans ce cas, les informations obtenues ne doivent en aucun cas être accessibles au grand public. Ce cas n'étant plus censé exister, préférer l'API en open data qui masque automatiquement les données protégées.
         \n
-        Plus d'informations sur les conditions de diffusion : https://sirene.fr/static-resources/htm/v_sommaire.htm#26"
+        Plus d'informations sur les conditions de diffusion : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=8279ad8c-c12d-4a2c-b9ad-8cc12dea2c39"
     forme_juridique:
       type: "object"
       additionalProperties: false
@@ -360,7 +360,7 @@ insee:
             - 53 : 10 000 salariés et plus
             \n
             \n
-            Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#trancheeffectifsunitelegale.
+            Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#trancheeffectifsunitelegale.
             \n
             \n
             L'effectif exact de l'entreprise, mensuel et annuel, est disponible au travers de l'API Effectifs - URSSAF Caisse nationale. Si votre jeton contient ce droit d'accès, nous vous recommandons d'utiliser cette API. Ces données étant protégées, leur cadre d'utilisation est différent de la tranche effectif fournie par l'Insee, qui elle est une donnée publique."
@@ -431,7 +431,7 @@ insee:
         En dehors de ces cas, l'état administratif de l'unité légale est toujours « actif ».
         \n
         \n
-        Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#etatadministratifunitelegale"
+        Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#etatadministratifunitelegale"
     economie_sociale_et_solidaire:
       title: "Unité légale de l'économie sociale et solidaire (ESS)"
       description:
@@ -456,7 +456,7 @@ insee:
         Ces conditions cumulatives sont explicitées à l'[Article 1 de la loi n° 2014-856 du 31 juillet 2014](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000029314926){:target='_blank'}.
         \n
         \n
-        Plus d'informations dans la documentation INSEE de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#economiesocialesolidaireunitelegale"
+        Plus d'informations dans la documentation INSEE de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#economiesocialesolidaireunitelegale"
       type: "boolean"
       example: true
       nullable: true
@@ -476,7 +476,7 @@ insee:
         Pour les unités purgées, la date de création n'est jamais à 'null'. Si elle est non renseignée, elle sera au 01/01/1900.
         \n
         \n
-        Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#datecreationunitelegale"
+        Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#datecreationunitelegale"
   shared_insee_unite_legale_attributes_diffusible: &shared_insee_unite_legale_attributes_diffusible
     <<: *shared_insee_unite_legale_attributes
     personne_morale_attributs: *personne_morale_attributes_diffusible
@@ -492,7 +492,7 @@ insee:
         \n
         - partiellement-diffusible : 'true'. Dans ce cas, les informations protégées suite au droit d'opposition sont masquées par la chaîne de caractère '[ND]' ;
         \n
-        Plus d'informations sur les conditions de diffusion : https://sirene.fr/static-resources/htm/v_sommaire.htm#26"
+        Plus d'informations sur les conditions de diffusion : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=8279ad8c-c12d-4a2c-b9ad-8cc12dea2c39"
 
   date_cessation_property: &date_cessation_property
     title: "Date de cessation de l'unité légale"
@@ -516,7 +516,7 @@ insee:
       example: "22"
     indice_repetition_voie: &insee_adresse_etablissement_indice_repetition_voie_property
       title: "Indice de répétition du numéro dans la voie"
-      description: "Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#indicerepetitionetablissement"
+      description: "Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#indicerepetitionetablissement"
       type: "string"
       nullable: true
       enum:
@@ -534,7 +534,7 @@ insee:
         l'information n'existe pas.
         \n
         \n
-        Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#typevoieetablissement"
+        Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#typevoieetablissement"
       type: "string"
       nullable: true
       enum: <%= YAML.load_file(Rails.root.join('config/data/insee/types_de_voie.yml')).values.map(&:upcase).concat([nil]).to_json %>
@@ -572,12 +572,15 @@ insee:
         "La distribution spéciale reprend les éléments particuliers qui accompagnent une adresse de distribution spéciale, la modalité la plus connue étant les adresses en 'CEDEX'.
         \n
         \n
-        Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#distributionspecialeetablissement"
+        Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement"
     code_cedex: &insee_adresse_etablissement_code_cedex_property
       title: "Code cedex"
       type: "string"
       nullable: true
-      description: "Plus d'informations : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle"
+      description: "Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
+        \n
+        \n
+        Sur le sigle CEDEX lui-même : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle"
       example: "75590"
     libelle_cedex: &insee_adresse_etablissement_libelle_cedex_property
       title: "Libellé du code cedex"
@@ -684,7 +687,7 @@ insee:
       description: "Si la personne morale est en diffusion partielle, la valeur est remplacée par \"[ND]\"."
     indice_repetition_voie:
       <<: *insee_adresse_etablissement_indice_repetition_voie_property
-      description: "Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#indicerepetitionetablissement
+      description: "Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#indicerepetitionetablissement
       \n
       Si la personne morale est en diffusion partielle, la valeur est remplacée par \"[ND]\"."
     type_voie:
@@ -695,7 +698,7 @@ insee:
         l'information n'existe pas.
         \n
         \n
-        Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#typevoieetablissement
+        Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#typevoieetablissement
         \n
         Si la personne morale est en diffusion partielle, la valeur est remplacée par \"[ND]\"."
     libelle_voie:
@@ -709,12 +712,14 @@ insee:
       description: "La distribution spéciale reprend les éléments particuliers qui accompagnent une adresse de distribution   spéciale, la modalité la plus connue étant les adresses en 'CEDEX'.
         \n
         \n
-        Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#distributionspecialeetablissement
+        Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement
         \n
         Si la personne morale est en diffusion partielle, la valeur est remplacée par \"[ND]\"."
     code_cedex:
       <<: *insee_adresse_etablissement_code_cedex_property
-      description: "Plus d'informations : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle
+      description: "Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
+      \n
+      Sur le sigle CEDEX lui-même : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle
       \n
       Si la personne morale est en diffusion partielle, la valeur est remplacée par \"[ND]\"."
     libelle_cedex:
@@ -789,7 +794,7 @@ insee:
         - fermé. Cet état découle de la prise en compte d'une déclaration de fermeture. Un établissement fermé peut être rouvert.
         \n
         \n
-        Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#etatadministratifetablissement"
+        Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#etatadministratifetablissement"
     date_fermeture:
       title: "Date de fermeture de l'établissement"
       type: "integer"
@@ -881,7 +886,7 @@ insee:
             - 53 : 10 000 salariés et plus
             \n
             \n
-            Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#trancheeffectifsetablissement.
+            Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#trancheeffectifsetablissement.
             \n
             \n
             L'effectif mensuel exact de l'établissement est disponible au travers de l'[API Effectifs - URSSAF Caisse nationale](TODO). Si votre jeton contient ce droit d'accès, nous vous recommandons d'utiliser cette API. Ces données étant protégées, leur cadre d'utilisation est différent de la tranche effectif fournie par l'Insee, qui elle est une donnée publique."
@@ -945,7 +950,7 @@ insee:
       description: "L'enseigne est l'appellation désignant l'emplacement ou le local dans lequel est exercée l'activité. Un établissement peut posséder une enseigne, plusieurs enseignes ou aucune.
         \n
         \n
-        Cette variable est la concaténation séparée par des virgules des 3 champs \"renvoyés\" par l'Insee. Plus d'informations ici: https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#enseigne1etablissement-enseigne2etablissement-enseigne3etablissement"
+        Cette variable est la concaténation séparée par des virgules des 3 champs \"renvoyés\" par l'Insee. Plus d'informations ici: https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#enseigne1etablissement-enseigne2etablissement-enseigne3etablissement"
       example: "Coiff Land, CoiffureLand"
     unite_legale:
       type: "object"
@@ -976,7 +981,7 @@ insee:
       description: "L'enseigne est l'appellation désignant l'emplacement ou le local dans lequel est exercée l'activité. Un établissement peut posséder une enseigne, plusieurs enseignes ou aucune.
         \n
         \n
-        Cette variable est la concaténation séparée par des virgules des 3 champs \"renvoyés\" par l'Insee. Plus d'informations ici: https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#enseigne1etablissement-enseigne2etablissement-enseigne3etablissement
+        Cette variable est la concaténation séparée par des virgules des 3 champs \"renvoyés\" par l'Insee. Plus d'informations ici: https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#enseigne1etablissement-enseigne2etablissement-enseigne3etablissement
         \n
         Si la personne morale est en diffusion partielle, l'enseigne n'est pas renvoyée, et la valeur est remplacée par \"[ND]\"."
     diffusable_commercialement:

--- a/commons/endpoints/_swagger_shared/insee.yml
+++ b/commons/endpoints/_swagger_shared/insee.yml
@@ -1075,11 +1075,11 @@ insee:
     links:
       siege_social:
         type: "string"
-        example: "https://entreprises.api.gouv.fr/api/v3/insee/etablissements/30613890001294"
+        example: "https://entreprise.api.gouv.fr/api/v3/insee/etablissements/30613890001294"
         description: "Lien vers la ressource 'Données de référence d'un établissement' correspondant au siège social de cette unité légale."
       siege_social_adresse:
         type: "string"
-        example: "https://entreprises.api.gouv.fr/api/v3/insee/etablissements/30613890001294/adresse"
+        example: "https://entreprise.api.gouv.fr/api/v3/insee/etablissements/30613890001294/adresse"
         description: "Lien vers la ressource 'Adresse d'un établissement' correspondant au siège social de cette unité légale."
     meta:
       date_derniere_mise_a_jour: *insee_date_derniere_mise_a_jour

--- a/commons/endpoints/_swagger_shared/mi.yml
+++ b/commons/endpoints/_swagger_shared/mi.yml
@@ -611,7 +611,7 @@ Pour en savoir plus sur le CEC : https://www.associations.gouv.fr/le-compte-d-en
               - 53 : 10 000 salariés et plus
               \n
               \n
-              Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#trancheeffectifsunitelegale."
+              Plus d'informations dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#trancheeffectifsunitelegale."
             enum:
             - "NN"
             - "00"

--- a/commons/swagger/openapi-entreprise.yaml
+++ b/commons/swagger/openapi-entreprise.yaml
@@ -20540,24 +20540,27 @@ paths:
                         description: "La distribution spéciale reprend les éléments
                           particuliers qui accompagnent une adresse de distribution
                           spéciale, la modalité la plus connue étant les adresses
-                          en 'CEDEX'. \n \n Plus d'informations dans la documentation
-                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement"
+                          en 'CEDEX'. \n \n L'Insee ne gère plus cette variable :
+                          elle est désormais toujours à 'null'. \n \n Plus d'informations
+                          dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement"
                       code_cedex:
                         title: Code cedex
                         type: string
                         nullable: true
-                        description: "Plus d'informations dans la documentation Insee
-                          de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
+                        description: "L'Insee ne gère plus cette variable : elle est
+                          désormais toujours à 'null'. \n \n Plus d'informations dans
+                          la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
                           \n \n Sur le sigle CEDEX lui-même : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle"
-                        example: '75590'
                       libelle_cedex:
                         title: Libellé du code cedex
                         type: string
                         nullable: true
-                        example: PARIS CEDEX 12
-                        description: Ce champ indique le libellé correspondant au
+                        description: "Ce champ indique le libellé correspondant au
                           code cedex de l'établissement. Si le code cedex est à 'null',
-                          ce champ est également à 'null'.
+                          ce champ est également à 'null'. \n \n L'Insee ne gère plus
+                          cette variable : elle est désormais toujours à 'null'. \n
+                          \n Plus d'informations dans la documentation Insee de l'API
+                          Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#libellecedexetablissement"
                       libelle_commune:
                         title: Nom de la commune pour une adresse en France
                         description: Cette valeur est à 'null' pour les établissements
@@ -20640,20 +20643,20 @@ paths:
                           l5:
                             title: Ligne 5
                             type: string
-                            description: Distribution spéciale comme décrit dans la
-                              clé `distribution_speciale`
+                            description: 'Distribution spéciale comme décrit dans
+                              la clé `distribution_speciale`, que l''Insee ne gère
+                              plus : cette ligne est désormais toujours vide.'
                             nullable: true
-                            example: CS 72809
                           l6:
                             title: Ligne 6
                             type: string
-                            description: 'Si le code cedex est existant : code cedex
-                              accompagné de son libellé ; sinon, si le pays est en
-                              France : code postal accompagné de son libellé, sinon
-                              : libellé de la commune de l''établissement situé à
-                              l''étranger'
+                            description: "Si le pays est en France : code postal accompagné
+                              du libellé de la commune, sinon : libellé de la commune
+                              de l'établissement situé à l'étranger. \n \n Le code
+                              cedex, qui primait sur le code postal, ne sort plus
+                              de cette ligne : l'Insee ne gère plus cette variable."
                             nullable: true
-                            example: 75256 PARIX CEDEX 12
+                            example: 75012 PARIS
                           l7:
                             title: Ligne 7
                             type: string
@@ -21273,30 +21276,33 @@ paths:
                         description: "La distribution spéciale reprend les éléments
                           particuliers qui accompagnent une adresse de distribution
                           \  spéciale, la modalité la plus connue étant les adresses
-                          en 'CEDEX'. \n \n Plus d'informations dans la documentation
-                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement
+                          en 'CEDEX'. \n \n L'Insee ne gère plus cette variable :
+                          elle est désormais toujours à 'null'. \n \n Plus d'informations
+                          dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement
                           \n Si la personne morale est en diffusion partielle, la
                           valeur est remplacée par \"[ND]\"."
                       code_cedex:
                         title: Code cedex
                         type: string
                         nullable: true
-                        description: "Plus d'informations dans la documentation Insee
-                          de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
+                        description: "L'Insee ne gère plus cette variable : elle est
+                          désormais toujours à 'null'. \n Plus d'informations dans
+                          la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
                           \n Sur le sigle CEDEX lui-même : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle
                           \n Si la personne morale est en diffusion partielle, la
                           valeur est remplacée par \"[ND]\"."
-                        example: '75590'
                       libelle_cedex:
                         title: Libellé du code cedex
                         type: string
                         nullable: true
-                        example: PARIS CEDEX 12
                         description: "Ce champ indique le libellé correspondant au
                           code cedex de l'établissement. Si le code cedex est à 'null',
-                          ce champ est également à 'null'. \n Si la personne morale
-                          est en diffusion partielle, la valeur est remplacée par
-                          \"[ND]\"."
+                          ce champ est également à 'null'. \n L'Insee ne gère plus
+                          cette variable : elle est désormais toujours à 'null'. \n
+                          Plus d'informations dans la documentation Insee de l'API
+                          Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#libellecedexetablissement
+                          \n Si la personne morale est en diffusion partielle, la
+                          valeur est remplacée par \"[ND]\"."
                       libelle_commune:
                         title: Nom de la commune pour une adresse en France
                         description: Cette valeur est à 'null' pour les établissements
@@ -21388,22 +21394,23 @@ paths:
                             title: Ligne 5
                             type: string
                             description: "Distribution spéciale comme décrit dans
-                              la clé `distribution_speciale` \n Si la personne morale
-                              est en diffusion partielle, la valeur est remplacée
-                              par \"[ND]\"."
+                              la clé `distribution_speciale`, que l'Insee ne gère
+                              plus : cette ligne est désormais toujours vide. \n Si
+                              la personne morale est en diffusion partielle, la valeur
+                              est remplacée par \"[ND]\"."
                             nullable: true
-                            example: CS 72809
                           l6:
                             title: Ligne 6
                             type: string
-                            description: "Si le code cedex est existant : code cedex
-                              accompagné de son libellé ; sinon, si le pays est en
-                              France : code postal accompagné de son libellé, sinon
-                              : libellé de la commune de l'établissement situé à l'étranger
-                              \n Si la personne morale est en diffusion partielle,
-                              la valeur est remplacée par \"[ND]\"."
+                            description: "Si le pays est en France : code postal accompagné
+                              du libellé de la commune, sinon : libellé de la commune
+                              de l'établissement situé à l'étranger. \n Le code cedex,
+                              qui primait sur le code postal, ne sort plus de cette
+                              ligne : l'Insee ne gère plus cette variable. \n Si la
+                              personne morale est en diffusion partielle, la valeur
+                              est remplacée par \"[ND]\"."
                             nullable: true
-                            example: 75256 PARIX CEDEX 12
+                            example: 75012 PARIS
                           l7:
                             title: Ligne 7
                             type: string
@@ -22703,24 +22710,27 @@ paths:
                             description: "La distribution spéciale reprend les éléments
                               particuliers qui accompagnent une adresse de distribution
                               spéciale, la modalité la plus connue étant les adresses
-                              en 'CEDEX'. \n \n Plus d'informations dans la documentation
-                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement"
+                              en 'CEDEX'. \n \n L'Insee ne gère plus cette variable
+                              : elle est désormais toujours à 'null'. \n \n Plus d'informations
+                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement"
                           code_cedex:
                             title: Code cedex
                             type: string
                             nullable: true
-                            description: "Plus d'informations dans la documentation
-                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
+                            description: "L'Insee ne gère plus cette variable : elle
+                              est désormais toujours à 'null'. \n \n Plus d'informations
+                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
                               \n \n Sur le sigle CEDEX lui-même : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle"
-                            example: '75590'
                           libelle_cedex:
                             title: Libellé du code cedex
                             type: string
                             nullable: true
-                            example: PARIS CEDEX 12
-                            description: Ce champ indique le libellé correspondant
+                            description: "Ce champ indique le libellé correspondant
                               au code cedex de l'établissement. Si le code cedex est
-                              à 'null', ce champ est également à 'null'.
+                              à 'null', ce champ est également à 'null'. \n \n L'Insee
+                              ne gère plus cette variable : elle est désormais toujours
+                              à 'null'. \n \n Plus d'informations dans la documentation
+                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#libellecedexetablissement"
                           libelle_commune:
                             title: Nom de la commune pour une adresse en France
                             description: Cette valeur est à 'null' pour les établissements
@@ -22807,20 +22817,21 @@ paths:
                               l5:
                                 title: Ligne 5
                                 type: string
-                                description: Distribution spéciale comme décrit dans
-                                  la clé `distribution_speciale`
+                                description: 'Distribution spéciale comme décrit dans
+                                  la clé `distribution_speciale`, que l''Insee ne
+                                  gère plus : cette ligne est désormais toujours vide.'
                                 nullable: true
-                                example: CS 72809
                               l6:
                                 title: Ligne 6
                                 type: string
-                                description: 'Si le code cedex est existant : code
-                                  cedex accompagné de son libellé ; sinon, si le pays
-                                  est en France : code postal accompagné de son libellé,
-                                  sinon : libellé de la commune de l''établissement
-                                  situé à l''étranger'
+                                description: "Si le pays est en France : code postal
+                                  accompagné du libellé de la commune, sinon : libellé
+                                  de la commune de l'établissement situé à l'étranger.
+                                  \n \n Le code cedex, qui primait sur le code postal,
+                                  ne sort plus de cette ligne : l'Insee ne gère plus
+                                  cette variable."
                                 nullable: true
-                                example: 75256 PARIX CEDEX 12
+                                example: 75012 PARIS
                               l7:
                                 title: Ligne 7
                                 type: string
@@ -24193,24 +24204,27 @@ paths:
                             description: "La distribution spéciale reprend les éléments
                               particuliers qui accompagnent une adresse de distribution
                               spéciale, la modalité la plus connue étant les adresses
-                              en 'CEDEX'. \n \n Plus d'informations dans la documentation
-                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement"
+                              en 'CEDEX'. \n \n L'Insee ne gère plus cette variable
+                              : elle est désormais toujours à 'null'. \n \n Plus d'informations
+                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement"
                           code_cedex:
                             title: Code cedex
                             type: string
                             nullable: true
-                            description: "Plus d'informations dans la documentation
-                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
+                            description: "L'Insee ne gère plus cette variable : elle
+                              est désormais toujours à 'null'. \n \n Plus d'informations
+                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
                               \n \n Sur le sigle CEDEX lui-même : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle"
-                            example: '75590'
                           libelle_cedex:
                             title: Libellé du code cedex
                             type: string
                             nullable: true
-                            example: PARIS CEDEX 12
-                            description: Ce champ indique le libellé correspondant
+                            description: "Ce champ indique le libellé correspondant
                               au code cedex de l'établissement. Si le code cedex est
-                              à 'null', ce champ est également à 'null'.
+                              à 'null', ce champ est également à 'null'. \n \n L'Insee
+                              ne gère plus cette variable : elle est désormais toujours
+                              à 'null'. \n \n Plus d'informations dans la documentation
+                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#libellecedexetablissement"
                           libelle_commune:
                             title: Nom de la commune pour une adresse en France
                             description: Cette valeur est à 'null' pour les établissements
@@ -24297,20 +24311,21 @@ paths:
                               l5:
                                 title: Ligne 5
                                 type: string
-                                description: Distribution spéciale comme décrit dans
-                                  la clé `distribution_speciale`
+                                description: 'Distribution spéciale comme décrit dans
+                                  la clé `distribution_speciale`, que l''Insee ne
+                                  gère plus : cette ligne est désormais toujours vide.'
                                 nullable: true
-                                example: CS 72809
                               l6:
                                 title: Ligne 6
                                 type: string
-                                description: 'Si le code cedex est existant : code
-                                  cedex accompagné de son libellé ; sinon, si le pays
-                                  est en France : code postal accompagné de son libellé,
-                                  sinon : libellé de la commune de l''établissement
-                                  situé à l''étranger'
+                                description: "Si le pays est en France : code postal
+                                  accompagné du libellé de la commune, sinon : libellé
+                                  de la commune de l'établissement situé à l'étranger.
+                                  \n \n Le code cedex, qui primait sur le code postal,
+                                  ne sort plus de cette ligne : l'Insee ne gère plus
+                                  cette variable."
                                 nullable: true
-                                example: 75256 PARIX CEDEX 12
+                                example: 75012 PARIS
                               l7:
                                 title: Ligne 7
                                 type: string
@@ -25714,30 +25729,33 @@ paths:
                             description: "La distribution spéciale reprend les éléments
                               particuliers qui accompagnent une adresse de distribution
                               \  spéciale, la modalité la plus connue étant les adresses
-                              en 'CEDEX'. \n \n Plus d'informations dans la documentation
-                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement
+                              en 'CEDEX'. \n \n L'Insee ne gère plus cette variable
+                              : elle est désormais toujours à 'null'. \n \n Plus d'informations
+                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement
                               \n Si la personne morale est en diffusion partielle,
                               la valeur est remplacée par \"[ND]\"."
                           code_cedex:
                             title: Code cedex
                             type: string
                             nullable: true
-                            description: "Plus d'informations dans la documentation
-                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
+                            description: "L'Insee ne gère plus cette variable : elle
+                              est désormais toujours à 'null'. \n Plus d'informations
+                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
                               \n Sur le sigle CEDEX lui-même : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle
                               \n Si la personne morale est en diffusion partielle,
                               la valeur est remplacée par \"[ND]\"."
-                            example: '75590'
                           libelle_cedex:
                             title: Libellé du code cedex
                             type: string
                             nullable: true
-                            example: PARIS CEDEX 12
                             description: "Ce champ indique le libellé correspondant
                               au code cedex de l'établissement. Si le code cedex est
-                              à 'null', ce champ est également à 'null'. \n Si la
-                              personne morale est en diffusion partielle, la valeur
-                              est remplacée par \"[ND]\"."
+                              à 'null', ce champ est également à 'null'. \n L'Insee
+                              ne gère plus cette variable : elle est désormais toujours
+                              à 'null'. \n Plus d'informations dans la documentation
+                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#libellecedexetablissement
+                              \n Si la personne morale est en diffusion partielle,
+                              la valeur est remplacée par \"[ND]\"."
                           libelle_commune:
                             title: Nom de la commune pour une adresse en France
                             description: Cette valeur est à 'null' pour les établissements
@@ -25831,23 +25849,24 @@ paths:
                                 title: Ligne 5
                                 type: string
                                 description: "Distribution spéciale comme décrit dans
-                                  la clé `distribution_speciale` \n Si la personne
-                                  morale est en diffusion partielle, la valeur est
-                                  remplacée par \"[ND]\"."
+                                  la clé `distribution_speciale`, que l'Insee ne gère
+                                  plus : cette ligne est désormais toujours vide.
+                                  \n Si la personne morale est en diffusion partielle,
+                                  la valeur est remplacée par \"[ND]\"."
                                 nullable: true
-                                example: CS 72809
                               l6:
                                 title: Ligne 6
                                 type: string
-                                description: "Si le code cedex est existant : code
-                                  cedex accompagné de son libellé ; sinon, si le pays
-                                  est en France : code postal accompagné de son libellé,
-                                  sinon : libellé de la commune de l'établissement
-                                  situé à l'étranger \n Si la personne morale est
-                                  en diffusion partielle, la valeur est remplacée
-                                  par \"[ND]\"."
+                                description: "Si le pays est en France : code postal
+                                  accompagné du libellé de la commune, sinon : libellé
+                                  de la commune de l'établissement situé à l'étranger.
+                                  \n Le code cedex, qui primait sur le code postal,
+                                  ne sort plus de cette ligne : l'Insee ne gère plus
+                                  cette variable. \n Si la personne morale est en
+                                  diffusion partielle, la valeur est remplacée par
+                                  \"[ND]\"."
                                 nullable: true
-                                example: 75256 PARIX CEDEX 12
+                                example: 75012 PARIS
                               l7:
                                 title: Ligne 7
                                 type: string
@@ -27246,30 +27265,33 @@ paths:
                             description: "La distribution spéciale reprend les éléments
                               particuliers qui accompagnent une adresse de distribution
                               \  spéciale, la modalité la plus connue étant les adresses
-                              en 'CEDEX'. \n \n Plus d'informations dans la documentation
-                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement
+                              en 'CEDEX'. \n \n L'Insee ne gère plus cette variable
+                              : elle est désormais toujours à 'null'. \n \n Plus d'informations
+                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement
                               \n Si la personne morale est en diffusion partielle,
                               la valeur est remplacée par \"[ND]\"."
                           code_cedex:
                             title: Code cedex
                             type: string
                             nullable: true
-                            description: "Plus d'informations dans la documentation
-                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
+                            description: "L'Insee ne gère plus cette variable : elle
+                              est désormais toujours à 'null'. \n Plus d'informations
+                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
                               \n Sur le sigle CEDEX lui-même : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle
                               \n Si la personne morale est en diffusion partielle,
                               la valeur est remplacée par \"[ND]\"."
-                            example: '75590'
                           libelle_cedex:
                             title: Libellé du code cedex
                             type: string
                             nullable: true
-                            example: PARIS CEDEX 12
                             description: "Ce champ indique le libellé correspondant
                               au code cedex de l'établissement. Si le code cedex est
-                              à 'null', ce champ est également à 'null'. \n Si la
-                              personne morale est en diffusion partielle, la valeur
-                              est remplacée par \"[ND]\"."
+                              à 'null', ce champ est également à 'null'. \n L'Insee
+                              ne gère plus cette variable : elle est désormais toujours
+                              à 'null'. \n Plus d'informations dans la documentation
+                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#libellecedexetablissement
+                              \n Si la personne morale est en diffusion partielle,
+                              la valeur est remplacée par \"[ND]\"."
                           libelle_commune:
                             title: Nom de la commune pour une adresse en France
                             description: Cette valeur est à 'null' pour les établissements
@@ -27363,23 +27385,24 @@ paths:
                                 title: Ligne 5
                                 type: string
                                 description: "Distribution spéciale comme décrit dans
-                                  la clé `distribution_speciale` \n Si la personne
-                                  morale est en diffusion partielle, la valeur est
-                                  remplacée par \"[ND]\"."
+                                  la clé `distribution_speciale`, que l'Insee ne gère
+                                  plus : cette ligne est désormais toujours vide.
+                                  \n Si la personne morale est en diffusion partielle,
+                                  la valeur est remplacée par \"[ND]\"."
                                 nullable: true
-                                example: CS 72809
                               l6:
                                 title: Ligne 6
                                 type: string
-                                description: "Si le code cedex est existant : code
-                                  cedex accompagné de son libellé ; sinon, si le pays
-                                  est en France : code postal accompagné de son libellé,
-                                  sinon : libellé de la commune de l'établissement
-                                  situé à l'étranger \n Si la personne morale est
-                                  en diffusion partielle, la valeur est remplacée
-                                  par \"[ND]\"."
+                                description: "Si le pays est en France : code postal
+                                  accompagné du libellé de la commune, sinon : libellé
+                                  de la commune de l'établissement situé à l'étranger.
+                                  \n Le code cedex, qui primait sur le code postal,
+                                  ne sort plus de cette ligne : l'Insee ne gère plus
+                                  cette variable. \n Si la personne morale est en
+                                  diffusion partielle, la valeur est remplacée par
+                                  \"[ND]\"."
                                 nullable: true
-                                example: 75256 PARIX CEDEX 12
+                                example: 75012 PARIS
                               l7:
                                 title: Ligne 7
                                 type: string
@@ -28775,30 +28798,33 @@ paths:
                             description: "La distribution spéciale reprend les éléments
                               particuliers qui accompagnent une adresse de distribution
                               \  spéciale, la modalité la plus connue étant les adresses
-                              en 'CEDEX'. \n \n Plus d'informations dans la documentation
-                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement
+                              en 'CEDEX'. \n \n L'Insee ne gère plus cette variable
+                              : elle est désormais toujours à 'null'. \n \n Plus d'informations
+                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement
                               \n Si la personne morale est en diffusion partielle,
                               la valeur est remplacée par \"[ND]\"."
                           code_cedex:
                             title: Code cedex
                             type: string
                             nullable: true
-                            description: "Plus d'informations dans la documentation
-                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
+                            description: "L'Insee ne gère plus cette variable : elle
+                              est désormais toujours à 'null'. \n Plus d'informations
+                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
                               \n Sur le sigle CEDEX lui-même : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle
                               \n Si la personne morale est en diffusion partielle,
                               la valeur est remplacée par \"[ND]\"."
-                            example: '75590'
                           libelle_cedex:
                             title: Libellé du code cedex
                             type: string
                             nullable: true
-                            example: PARIS CEDEX 12
                             description: "Ce champ indique le libellé correspondant
                               au code cedex de l'établissement. Si le code cedex est
-                              à 'null', ce champ est également à 'null'. \n Si la
-                              personne morale est en diffusion partielle, la valeur
-                              est remplacée par \"[ND]\"."
+                              à 'null', ce champ est également à 'null'. \n L'Insee
+                              ne gère plus cette variable : elle est désormais toujours
+                              à 'null'. \n Plus d'informations dans la documentation
+                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#libellecedexetablissement
+                              \n Si la personne morale est en diffusion partielle,
+                              la valeur est remplacée par \"[ND]\"."
                           libelle_commune:
                             title: Nom de la commune pour une adresse en France
                             description: Cette valeur est à 'null' pour les établissements
@@ -28892,23 +28918,24 @@ paths:
                                 title: Ligne 5
                                 type: string
                                 description: "Distribution spéciale comme décrit dans
-                                  la clé `distribution_speciale` \n Si la personne
-                                  morale est en diffusion partielle, la valeur est
-                                  remplacée par \"[ND]\"."
+                                  la clé `distribution_speciale`, que l'Insee ne gère
+                                  plus : cette ligne est désormais toujours vide.
+                                  \n Si la personne morale est en diffusion partielle,
+                                  la valeur est remplacée par \"[ND]\"."
                                 nullable: true
-                                example: CS 72809
                               l6:
                                 title: Ligne 6
                                 type: string
-                                description: "Si le code cedex est existant : code
-                                  cedex accompagné de son libellé ; sinon, si le pays
-                                  est en France : code postal accompagné de son libellé,
-                                  sinon : libellé de la commune de l'établissement
-                                  situé à l'étranger \n Si la personne morale est
-                                  en diffusion partielle, la valeur est remplacée
-                                  par \"[ND]\"."
+                                description: "Si le pays est en France : code postal
+                                  accompagné du libellé de la commune, sinon : libellé
+                                  de la commune de l'établissement situé à l'étranger.
+                                  \n Le code cedex, qui primait sur le code postal,
+                                  ne sort plus de cette ligne : l'Insee ne gère plus
+                                  cette variable. \n Si la personne morale est en
+                                  diffusion partielle, la valeur est remplacée par
+                                  \"[ND]\"."
                                 nullable: true
-                                example: 75256 PARIX CEDEX 12
+                                example: 75012 PARIS
                               l7:
                                 title: Ligne 7
                                 type: string
@@ -30305,30 +30332,33 @@ paths:
                             description: "La distribution spéciale reprend les éléments
                               particuliers qui accompagnent une adresse de distribution
                               \  spéciale, la modalité la plus connue étant les adresses
-                              en 'CEDEX'. \n \n Plus d'informations dans la documentation
-                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement
+                              en 'CEDEX'. \n \n L'Insee ne gère plus cette variable
+                              : elle est désormais toujours à 'null'. \n \n Plus d'informations
+                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement
                               \n Si la personne morale est en diffusion partielle,
                               la valeur est remplacée par \"[ND]\"."
                           code_cedex:
                             title: Code cedex
                             type: string
                             nullable: true
-                            description: "Plus d'informations dans la documentation
-                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
+                            description: "L'Insee ne gère plus cette variable : elle
+                              est désormais toujours à 'null'. \n Plus d'informations
+                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
                               \n Sur le sigle CEDEX lui-même : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle
                               \n Si la personne morale est en diffusion partielle,
                               la valeur est remplacée par \"[ND]\"."
-                            example: '75590'
                           libelle_cedex:
                             title: Libellé du code cedex
                             type: string
                             nullable: true
-                            example: PARIS CEDEX 12
                             description: "Ce champ indique le libellé correspondant
                               au code cedex de l'établissement. Si le code cedex est
-                              à 'null', ce champ est également à 'null'. \n Si la
-                              personne morale est en diffusion partielle, la valeur
-                              est remplacée par \"[ND]\"."
+                              à 'null', ce champ est également à 'null'. \n L'Insee
+                              ne gère plus cette variable : elle est désormais toujours
+                              à 'null'. \n Plus d'informations dans la documentation
+                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#libellecedexetablissement
+                              \n Si la personne morale est en diffusion partielle,
+                              la valeur est remplacée par \"[ND]\"."
                           libelle_commune:
                             title: Nom de la commune pour une adresse en France
                             description: Cette valeur est à 'null' pour les établissements
@@ -30422,23 +30452,24 @@ paths:
                                 title: Ligne 5
                                 type: string
                                 description: "Distribution spéciale comme décrit dans
-                                  la clé `distribution_speciale` \n Si la personne
-                                  morale est en diffusion partielle, la valeur est
-                                  remplacée par \"[ND]\"."
+                                  la clé `distribution_speciale`, que l'Insee ne gère
+                                  plus : cette ligne est désormais toujours vide.
+                                  \n Si la personne morale est en diffusion partielle,
+                                  la valeur est remplacée par \"[ND]\"."
                                 nullable: true
-                                example: CS 72809
                               l6:
                                 title: Ligne 6
                                 type: string
-                                description: "Si le code cedex est existant : code
-                                  cedex accompagné de son libellé ; sinon, si le pays
-                                  est en France : code postal accompagné de son libellé,
-                                  sinon : libellé de la commune de l'établissement
-                                  situé à l'étranger \n Si la personne morale est
-                                  en diffusion partielle, la valeur est remplacée
-                                  par \"[ND]\"."
+                                description: "Si le pays est en France : code postal
+                                  accompagné du libellé de la commune, sinon : libellé
+                                  de la commune de l'établissement situé à l'étranger.
+                                  \n Le code cedex, qui primait sur le code postal,
+                                  ne sort plus de cette ligne : l'Insee ne gère plus
+                                  cette variable. \n Si la personne morale est en
+                                  diffusion partielle, la valeur est remplacée par
+                                  \"[ND]\"."
                                 nullable: true
-                                example: 75256 PARIX CEDEX 12
+                                example: 75012 PARIS
                               l7:
                                 title: Ligne 7
                                 type: string
@@ -31803,24 +31834,27 @@ paths:
                             description: "La distribution spéciale reprend les éléments
                               particuliers qui accompagnent une adresse de distribution
                               spéciale, la modalité la plus connue étant les adresses
-                              en 'CEDEX'. \n \n Plus d'informations dans la documentation
-                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement"
+                              en 'CEDEX'. \n \n L'Insee ne gère plus cette variable
+                              : elle est désormais toujours à 'null'. \n \n Plus d'informations
+                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement"
                           code_cedex:
                             title: Code cedex
                             type: string
                             nullable: true
-                            description: "Plus d'informations dans la documentation
-                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
+                            description: "L'Insee ne gère plus cette variable : elle
+                              est désormais toujours à 'null'. \n \n Plus d'informations
+                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
                               \n \n Sur le sigle CEDEX lui-même : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle"
-                            example: '75590'
                           libelle_cedex:
                             title: Libellé du code cedex
                             type: string
                             nullable: true
-                            example: PARIS CEDEX 12
-                            description: Ce champ indique le libellé correspondant
+                            description: "Ce champ indique le libellé correspondant
                               au code cedex de l'établissement. Si le code cedex est
-                              à 'null', ce champ est également à 'null'.
+                              à 'null', ce champ est également à 'null'. \n \n L'Insee
+                              ne gère plus cette variable : elle est désormais toujours
+                              à 'null'. \n \n Plus d'informations dans la documentation
+                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#libellecedexetablissement"
                           libelle_commune:
                             title: Nom de la commune pour une adresse en France
                             description: Cette valeur est à 'null' pour les établissements
@@ -31907,20 +31941,21 @@ paths:
                               l5:
                                 title: Ligne 5
                                 type: string
-                                description: Distribution spéciale comme décrit dans
-                                  la clé `distribution_speciale`
+                                description: 'Distribution spéciale comme décrit dans
+                                  la clé `distribution_speciale`, que l''Insee ne
+                                  gère plus : cette ligne est désormais toujours vide.'
                                 nullable: true
-                                example: CS 72809
                               l6:
                                 title: Ligne 6
                                 type: string
-                                description: 'Si le code cedex est existant : code
-                                  cedex accompagné de son libellé ; sinon, si le pays
-                                  est en France : code postal accompagné de son libellé,
-                                  sinon : libellé de la commune de l''établissement
-                                  situé à l''étranger'
+                                description: "Si le pays est en France : code postal
+                                  accompagné du libellé de la commune, sinon : libellé
+                                  de la commune de l'établissement situé à l'étranger.
+                                  \n \n Le code cedex, qui primait sur le code postal,
+                                  ne sort plus de cette ligne : l'Insee ne gère plus
+                                  cette variable."
                                 nullable: true
-                                example: 75256 PARIX CEDEX 12
+                                example: 75012 PARIS
                               l7:
                                 title: Ligne 7
                                 type: string
@@ -33286,24 +33321,27 @@ paths:
                             description: "La distribution spéciale reprend les éléments
                               particuliers qui accompagnent une adresse de distribution
                               spéciale, la modalité la plus connue étant les adresses
-                              en 'CEDEX'. \n \n Plus d'informations dans la documentation
-                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement"
+                              en 'CEDEX'. \n \n L'Insee ne gère plus cette variable
+                              : elle est désormais toujours à 'null'. \n \n Plus d'informations
+                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement"
                           code_cedex:
                             title: Code cedex
                             type: string
                             nullable: true
-                            description: "Plus d'informations dans la documentation
-                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
+                            description: "L'Insee ne gère plus cette variable : elle
+                              est désormais toujours à 'null'. \n \n Plus d'informations
+                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
                               \n \n Sur le sigle CEDEX lui-même : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle"
-                            example: '75590'
                           libelle_cedex:
                             title: Libellé du code cedex
                             type: string
                             nullable: true
-                            example: PARIS CEDEX 12
-                            description: Ce champ indique le libellé correspondant
+                            description: "Ce champ indique le libellé correspondant
                               au code cedex de l'établissement. Si le code cedex est
-                              à 'null', ce champ est également à 'null'.
+                              à 'null', ce champ est également à 'null'. \n \n L'Insee
+                              ne gère plus cette variable : elle est désormais toujours
+                              à 'null'. \n \n Plus d'informations dans la documentation
+                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#libellecedexetablissement"
                           libelle_commune:
                             title: Nom de la commune pour une adresse en France
                             description: Cette valeur est à 'null' pour les établissements
@@ -33390,20 +33428,21 @@ paths:
                               l5:
                                 title: Ligne 5
                                 type: string
-                                description: Distribution spéciale comme décrit dans
-                                  la clé `distribution_speciale`
+                                description: 'Distribution spéciale comme décrit dans
+                                  la clé `distribution_speciale`, que l''Insee ne
+                                  gère plus : cette ligne est désormais toujours vide.'
                                 nullable: true
-                                example: CS 72809
                               l6:
                                 title: Ligne 6
                                 type: string
-                                description: 'Si le code cedex est existant : code
-                                  cedex accompagné de son libellé ; sinon, si le pays
-                                  est en France : code postal accompagné de son libellé,
-                                  sinon : libellé de la commune de l''établissement
-                                  situé à l''étranger'
+                                description: "Si le pays est en France : code postal
+                                  accompagné du libellé de la commune, sinon : libellé
+                                  de la commune de l'établissement situé à l'étranger.
+                                  \n \n Le code cedex, qui primait sur le code postal,
+                                  ne sort plus de cette ligne : l'Insee ne gère plus
+                                  cette variable."
                                 nullable: true
-                                example: 75256 PARIX CEDEX 12
+                                example: 75012 PARIS
                               l7:
                                 title: Ligne 7
                                 type: string

--- a/commons/swagger/openapi-entreprise.yaml
+++ b/commons/swagger/openapi-entreprise.yaml
@@ -10701,7 +10701,7 @@ paths:
                                   : 2 000 à 4 999 salariés \n - 52 : 5 000 à 9 999
                                   salariés \n - 53 : 10 000 salariés et plus \n \n
                                   Plus d'informations dans la documentation Insee
-                                  de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#trancheeffectifsunitelegale."
+                                  de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#trancheeffectifsunitelegale."
                                 enum:
                                 - NN
                                 - '00'
@@ -10926,7 +10926,7 @@ paths:
                                     \n - 51 : 2 000 à 4 999 salariés \n - 52 : 5 000
                                     à 9 999 salariés \n - 53 : 10 000 salariés et
                                     plus \n \n Plus d'informations dans la documentation
-                                    Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#trancheeffectifsunitelegale."
+                                    Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#trancheeffectifsunitelegale."
                                   enum:
                                   - NN
                                   - '00'
@@ -12591,7 +12591,7 @@ paths:
                                   : 2 000 à 4 999 salariés \n - 52 : 5 000 à 9 999
                                   salariés \n - 53 : 10 000 salariés et plus \n \n
                                   Plus d'informations dans la documentation Insee
-                                  de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#trancheeffectifsunitelegale."
+                                  de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#trancheeffectifsunitelegale."
                                 enum:
                                 - NN
                                 - '00'
@@ -12814,7 +12814,7 @@ paths:
                                     \n - 51 : 2 000 à 4 999 salariés \n - 52 : 5 000
                                     à 9 999 salariés \n - 53 : 10 000 salariés et
                                     plus \n \n Plus d'informations dans la documentation
-                                    Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#trancheeffectifsunitelegale."
+                                    Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#trancheeffectifsunitelegale."
                                   enum:
                                   - NN
                                   - '00'
@@ -20440,7 +20440,7 @@ paths:
                       indice_repetition_voie:
                         title: Indice de répétition du numéro dans la voie
                         description: 'Plus d''informations dans la documentation Insee
-                          de l''API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#indicerepetitionetablissement'
+                          de l''API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#indicerepetitionetablissement'
                         type: string
                         nullable: true
                         enum:
@@ -20456,7 +20456,7 @@ paths:
                           en abrégé et en majuscules. L'information n'est pas toujours
                           renseignée. Pour certaines petites communes, l'information
                           n'existe pas. \n \n Plus d'informations dans la documentation
-                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#typevoieetablissement"
+                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#typevoieetablissement"
                         type: string
                         nullable: true
                         enum:
@@ -20541,12 +20541,14 @@ paths:
                           particuliers qui accompagnent une adresse de distribution
                           spéciale, la modalité la plus connue étant les adresses
                           en 'CEDEX'. \n \n Plus d'informations dans la documentation
-                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#distributionspecialeetablissement"
+                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement"
                       code_cedex:
                         title: Code cedex
                         type: string
                         nullable: true
-                        description: 'Plus d''informations : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle'
+                        description: "Plus d'informations dans la documentation Insee
+                          de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
+                          \n \n Sur le sigle CEDEX lui-même : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle"
                         example: '75590'
                       libelle_cedex:
                         title: Libellé du code cedex
@@ -21160,7 +21162,7 @@ paths:
                       indice_repetition_voie:
                         title: Indice de répétition du numéro dans la voie
                         description: "Plus d'informations dans la documentation Insee
-                          de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#indicerepetitionetablissement
+                          de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#indicerepetitionetablissement
                           \n Si la personne morale est en diffusion partielle, la
                           valeur est remplacée par \"[ND]\"."
                         type: string
@@ -21178,7 +21180,7 @@ paths:
                           en abrégé et en majuscules. L'information n'est pas toujours
                           renseignée. Pour certaines petites communes, l'information
                           n'existe pas. \n \n Plus d'informations dans la documentation
-                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#typevoieetablissement
+                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#typevoieetablissement
                           \n Si la personne morale est en diffusion partielle, la
                           valeur est remplacée par \"[ND]\"."
                         type: string
@@ -21272,14 +21274,16 @@ paths:
                           particuliers qui accompagnent une adresse de distribution
                           \  spéciale, la modalité la plus connue étant les adresses
                           en 'CEDEX'. \n \n Plus d'informations dans la documentation
-                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#distributionspecialeetablissement
+                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement
                           \n Si la personne morale est en diffusion partielle, la
                           valeur est remplacée par \"[ND]\"."
                       code_cedex:
                         title: Code cedex
                         type: string
                         nullable: true
-                        description: "Plus d'informations : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle
+                        description: "Plus d'informations dans la documentation Insee
+                          de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
+                          \n Sur le sigle CEDEX lui-même : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle
                           \n Si la personne morale est en diffusion partielle, la
                           valeur est remplacée par \"[ND]\"."
                         example: '75590'
@@ -21946,7 +21950,7 @@ paths:
                           est à l'état 'actif'\n\n - fermé. Cet état découle de la
                           prise en compte d'une déclaration de fermeture. Un établissement
                           fermé peut être rouvert. \n \n Plus d'informations dans
-                          la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#etatadministratifetablissement"
+                          la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#etatadministratifetablissement"
                       date_fermeture:
                         title: Date de fermeture de l'établissement
                         type: integer
@@ -22033,7 +22037,7 @@ paths:
                               \n - 42 : 1 000 à 1 999 salariés \n - 51 : 2 000 à 4
                               999 salariés \n - 52 : 5 000 à 9 999 salariés \n - 53
                               : 10 000 salariés et plus \n \n Plus d'informations
-                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#trancheeffectifsetablissement.
+                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#trancheeffectifsetablissement.
                               \n \n L'effectif mensuel exact de l'établissement est
                               disponible au travers de l'[API Effectifs - URSSAF Caisse
                               nationale](TODO). Si votre jeton contient ce droit d'accès,
@@ -22119,7 +22123,7 @@ paths:
                           en aucun cas être accessibles au grand public. Ce cas n'étant
                           plus censé exister, préférer l'API en open data qui masque
                           automatiquement les données protégées. \n Plus d'informations
-                          sur les conditions de diffusion : https://sirene.fr/static-resources/htm/v_sommaire.htm#26"
+                          sur les conditions de diffusion : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=8279ad8c-c12d-4a2c-b9ad-8cc12dea2c39"
                       enseigne:
                         title: Enseigne de l'établissement
                         type: string
@@ -22129,7 +22133,7 @@ paths:
                           peut posséder une enseigne, plusieurs enseignes ou aucune.
                           \n \n Cette variable est la concaténation séparée par des
                           virgules des 3 champs \"renvoyés\" par l'Insee. Plus d'informations
-                          ici: https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#enseigne1etablissement-enseigne2etablissement-enseigne3etablissement"
+                          ici: https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#enseigne1etablissement-enseigne2etablissement-enseigne3etablissement"
                         example: Coiff Land, CoiffureLand
                       unite_legale:
                         type: object
@@ -22326,7 +22330,7 @@ paths:
                               Ce cas n'étant plus censé exister, préférer l'API en
                               open data qui masque automatiquement les données protégées.
                               \n Plus d'informations sur les conditions de diffusion
-                              : https://sirene.fr/static-resources/htm/v_sommaire.htm#26"
+                              : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=8279ad8c-c12d-4a2c-b9ad-8cc12dea2c39"
                           forme_juridique:
                             type: object
                             additionalProperties: false
@@ -22454,7 +22458,7 @@ paths:
                                   : 2 000 à 4 999 salariés \n - 52 : 5 000 à 9 999
                                   salariés \n - 53 : 10 000 salariés et plus \n \n
                                   Plus d'informations dans la documentation Insee
-                                  de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#trancheeffectifsunitelegale.
+                                  de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#trancheeffectifsunitelegale.
                                   \n \n L'effectif exact de l'entreprise, mensuel
                                   et annuel, est disponible au travers de l'API Effectifs
                                   - URSSAF Caisse nationale. Si votre jeton contient
@@ -22528,7 +22532,7 @@ paths:
                               dépose une cessation d'activité. \n \n En dehors de
                               ces cas, l'état administratif de l'unité légale est
                               toujours « actif ». \n \n Plus d'informations dans la
-                              documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#etatadministratifunitelegale"
+                              documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#etatadministratifunitelegale"
                           economie_sociale_et_solidaire:
                             title: Unité légale de l'économie sociale et solidaire
                               (ESS)
@@ -22546,7 +22550,7 @@ paths:
                               Ces conditions cumulatives sont explicitées à l'[Article
                               1 de la loi n° 2014-856 du 31 juillet 2014](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000029314926){:target='_blank'}.
                               \n \n Plus d'informations dans la documentation INSEE
-                              de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#economiesocialesolidaireunitelegale"
+                              de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#economiesocialesolidaireunitelegale"
                             type: boolean
                             example: true
                             nullable: true
@@ -22568,7 +22572,7 @@ paths:
                               la date de création n'est jamais à 'null'. Si elle est
                               non renseignée, elle sera au 01/01/1900. \n \n Plus
                               d'informations dans la documentation Insee de l'API
-                              Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#datecreationunitelegale"
+                              Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#datecreationunitelegale"
                         required:
                         - siren
                         - rna
@@ -22597,7 +22601,7 @@ paths:
                           indice_repetition_voie:
                             title: Indice de répétition du numéro dans la voie
                             description: 'Plus d''informations dans la documentation
-                              Insee de l''API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#indicerepetitionetablissement'
+                              Insee de l''API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#indicerepetitionetablissement'
                             type: string
                             nullable: true
                             enum:
@@ -22613,7 +22617,7 @@ paths:
                               en abrégé et en majuscules. L'information n'est pas
                               toujours renseignée. Pour certaines petites communes,
                               l'information n'existe pas. \n \n Plus d'informations
-                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#typevoieetablissement"
+                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#typevoieetablissement"
                             type: string
                             nullable: true
                             enum:
@@ -22700,12 +22704,14 @@ paths:
                               particuliers qui accompagnent une adresse de distribution
                               spéciale, la modalité la plus connue étant les adresses
                               en 'CEDEX'. \n \n Plus d'informations dans la documentation
-                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#distributionspecialeetablissement"
+                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement"
                           code_cedex:
                             title: Code cedex
                             type: string
                             nullable: true
-                            description: 'Plus d''informations : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle'
+                            description: "Plus d'informations dans la documentation
+                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
+                              \n \n Sur le sigle CEDEX lui-même : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle"
                             example: '75590'
                           libelle_cedex:
                             title: Libellé du code cedex
@@ -22860,7 +22866,7 @@ paths:
                           nulle. \n Pour les unités purgées, la date de création n'est
                           jamais à 'null'. Si elle est non renseignée, elle sera au
                           01/01/1900. \n \n Plus d'informations dans la documentation
-                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#datecreationunitelegale"
+                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#datecreationunitelegale"
                     required:
                     - siret
                     - siege_social
@@ -23405,7 +23411,7 @@ paths:
                           est à l'état 'actif'\n\n - fermé. Cet état découle de la
                           prise en compte d'une déclaration de fermeture. Un établissement
                           fermé peut être rouvert. \n \n Plus d'informations dans
-                          la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#etatadministratifetablissement"
+                          la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#etatadministratifetablissement"
                       date_fermeture:
                         title: Date de fermeture de l'établissement
                         type: integer
@@ -23492,7 +23498,7 @@ paths:
                               \n - 42 : 1 000 à 1 999 salariés \n - 51 : 2 000 à 4
                               999 salariés \n - 52 : 5 000 à 9 999 salariés \n - 53
                               : 10 000 salariés et plus \n \n Plus d'informations
-                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#trancheeffectifsetablissement.
+                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#trancheeffectifsetablissement.
                               \n \n L'effectif mensuel exact de l'établissement est
                               disponible au travers de l'[API Effectifs - URSSAF Caisse
                               nationale](TODO). Si votre jeton contient ce droit d'accès,
@@ -23578,7 +23584,7 @@ paths:
                           en aucun cas être accessibles au grand public. Ce cas n'étant
                           plus censé exister, préférer l'API en open data qui masque
                           automatiquement les données protégées. \n Plus d'informations
-                          sur les conditions de diffusion : https://sirene.fr/static-resources/htm/v_sommaire.htm#26"
+                          sur les conditions de diffusion : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=8279ad8c-c12d-4a2c-b9ad-8cc12dea2c39"
                       enseigne:
                         title: Enseigne de l'établissement
                         type: string
@@ -23588,7 +23594,7 @@ paths:
                           peut posséder une enseigne, plusieurs enseignes ou aucune.
                           \n \n Cette variable est la concaténation séparée par des
                           virgules des 3 champs \"renvoyés\" par l'Insee. Plus d'informations
-                          ici: https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#enseigne1etablissement-enseigne2etablissement-enseigne3etablissement"
+                          ici: https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#enseigne1etablissement-enseigne2etablissement-enseigne3etablissement"
                         example: Coiff Land, CoiffureLand
                       unite_legale:
                         type: object
@@ -23785,7 +23791,7 @@ paths:
                               Ce cas n'étant plus censé exister, préférer l'API en
                               open data qui masque automatiquement les données protégées.
                               \n Plus d'informations sur les conditions de diffusion
-                              : https://sirene.fr/static-resources/htm/v_sommaire.htm#26"
+                              : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=8279ad8c-c12d-4a2c-b9ad-8cc12dea2c39"
                           forme_juridique:
                             type: object
                             additionalProperties: false
@@ -23913,7 +23919,7 @@ paths:
                                   : 2 000 à 4 999 salariés \n - 52 : 5 000 à 9 999
                                   salariés \n - 53 : 10 000 salariés et plus \n \n
                                   Plus d'informations dans la documentation Insee
-                                  de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#trancheeffectifsunitelegale.
+                                  de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#trancheeffectifsunitelegale.
                                   \n \n L'effectif exact de l'entreprise, mensuel
                                   et annuel, est disponible au travers de l'API Effectifs
                                   - URSSAF Caisse nationale. Si votre jeton contient
@@ -23987,7 +23993,7 @@ paths:
                               dépose une cessation d'activité. \n \n En dehors de
                               ces cas, l'état administratif de l'unité légale est
                               toujours « actif ». \n \n Plus d'informations dans la
-                              documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#etatadministratifunitelegale"
+                              documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#etatadministratifunitelegale"
                           economie_sociale_et_solidaire:
                             title: Unité légale de l'économie sociale et solidaire
                               (ESS)
@@ -24005,7 +24011,7 @@ paths:
                               Ces conditions cumulatives sont explicitées à l'[Article
                               1 de la loi n° 2014-856 du 31 juillet 2014](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000029314926){:target='_blank'}.
                               \n \n Plus d'informations dans la documentation INSEE
-                              de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#economiesocialesolidaireunitelegale"
+                              de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#economiesocialesolidaireunitelegale"
                             type: boolean
                             example: true
                             nullable: true
@@ -24027,7 +24033,7 @@ paths:
                               la date de création n'est jamais à 'null'. Si elle est
                               non renseignée, elle sera au 01/01/1900. \n \n Plus
                               d'informations dans la documentation Insee de l'API
-                              Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#datecreationunitelegale"
+                              Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#datecreationunitelegale"
                           activite_principale_naf_rev2:
                             title: Attributs de l'activité principale en nomenclature
                               NAFRev2
@@ -24085,7 +24091,7 @@ paths:
                           indice_repetition_voie:
                             title: Indice de répétition du numéro dans la voie
                             description: 'Plus d''informations dans la documentation
-                              Insee de l''API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#indicerepetitionetablissement'
+                              Insee de l''API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#indicerepetitionetablissement'
                             type: string
                             nullable: true
                             enum:
@@ -24101,7 +24107,7 @@ paths:
                               en abrégé et en majuscules. L'information n'est pas
                               toujours renseignée. Pour certaines petites communes,
                               l'information n'existe pas. \n \n Plus d'informations
-                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#typevoieetablissement"
+                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#typevoieetablissement"
                             type: string
                             nullable: true
                             enum:
@@ -24188,12 +24194,14 @@ paths:
                               particuliers qui accompagnent une adresse de distribution
                               spéciale, la modalité la plus connue étant les adresses
                               en 'CEDEX'. \n \n Plus d'informations dans la documentation
-                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#distributionspecialeetablissement"
+                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement"
                           code_cedex:
                             title: Code cedex
                             type: string
                             nullable: true
-                            description: 'Plus d''informations : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle'
+                            description: "Plus d'informations dans la documentation
+                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
+                              \n \n Sur le sigle CEDEX lui-même : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle"
                             example: '75590'
                           libelle_cedex:
                             title: Libellé du code cedex
@@ -24348,7 +24356,7 @@ paths:
                           nulle. \n Pour les unités purgées, la date de création n'est
                           jamais à 'null'. Si elle est non renseignée, elle sera au
                           01/01/1900. \n \n Plus d'informations dans la documentation
-                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#datecreationunitelegale"
+                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#datecreationunitelegale"
                       activite_principale_naf_rev2:
                         title: Attributs de l'activité principale en nomenclature
                           NAFRev2
@@ -24921,7 +24929,7 @@ paths:
                           est à l'état 'actif'\n\n - fermé. Cet état découle de la
                           prise en compte d'une déclaration de fermeture. Un établissement
                           fermé peut être rouvert. \n \n Plus d'informations dans
-                          la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#etatadministratifetablissement"
+                          la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#etatadministratifetablissement"
                       date_fermeture:
                         title: Date de fermeture de l'établissement
                         type: integer
@@ -25008,7 +25016,7 @@ paths:
                               \n - 42 : 1 000 à 1 999 salariés \n - 51 : 2 000 à 4
                               999 salariés \n - 52 : 5 000 à 9 999 salariés \n - 53
                               : 10 000 salariés et plus \n \n Plus d'informations
-                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#trancheeffectifsetablissement.
+                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#trancheeffectifsetablissement.
                               \n \n L'effectif mensuel exact de l'établissement est
                               disponible au travers de l'[API Effectifs - URSSAF Caisse
                               nationale](TODO). Si votre jeton contient ce droit d'accès,
@@ -25094,7 +25102,7 @@ paths:
                           en aucun cas être accessibles au grand public. Ce cas n'étant
                           plus censé exister, préférer l'API en open data qui masque
                           automatiquement les données protégées. \n Plus d'informations
-                          sur les conditions de diffusion : https://sirene.fr/static-resources/htm/v_sommaire.htm#26"
+                          sur les conditions de diffusion : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=8279ad8c-c12d-4a2c-b9ad-8cc12dea2c39"
                       enseigne:
                         title: Enseigne de l'établissement
                         type: string
@@ -25104,7 +25112,7 @@ paths:
                           peut posséder une enseigne, plusieurs enseignes ou aucune.
                           \n \n Cette variable est la concaténation séparée par des
                           virgules des 3 champs \"renvoyés\" par l'Insee. Plus d'informations
-                          ici: https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#enseigne1etablissement-enseigne2etablissement-enseigne3etablissement
+                          ici: https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#enseigne1etablissement-enseigne2etablissement-enseigne3etablissement
                           \n Si la personne morale est en diffusion partielle, l'enseigne
                           n'est pas renvoyée, et la valeur est remplacée par \"[ND]\"."
                         example: Coiff Land, CoiffureLand
@@ -25321,7 +25329,7 @@ paths:
                               : 'true'. Dans ce cas, les informations protégées suite
                               au droit d'opposition sont masquées par la chaîne de
                               caractère '[ND]' ; \n Plus d'informations sur les conditions
-                              de diffusion : https://sirene.fr/static-resources/htm/v_sommaire.htm#26"
+                              de diffusion : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=8279ad8c-c12d-4a2c-b9ad-8cc12dea2c39"
                           forme_juridique:
                             type: object
                             additionalProperties: false
@@ -25449,7 +25457,7 @@ paths:
                                   : 2 000 à 4 999 salariés \n - 52 : 5 000 à 9 999
                                   salariés \n - 53 : 10 000 salariés et plus \n \n
                                   Plus d'informations dans la documentation Insee
-                                  de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#trancheeffectifsunitelegale.
+                                  de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#trancheeffectifsunitelegale.
                                   \n \n L'effectif exact de l'entreprise, mensuel
                                   et annuel, est disponible au travers de l'API Effectifs
                                   - URSSAF Caisse nationale. Si votre jeton contient
@@ -25523,7 +25531,7 @@ paths:
                               dépose une cessation d'activité. \n \n En dehors de
                               ces cas, l'état administratif de l'unité légale est
                               toujours « actif ». \n \n Plus d'informations dans la
-                              documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#etatadministratifunitelegale"
+                              documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#etatadministratifunitelegale"
                           economie_sociale_et_solidaire:
                             title: Unité légale de l'économie sociale et solidaire
                               (ESS)
@@ -25541,7 +25549,7 @@ paths:
                               Ces conditions cumulatives sont explicitées à l'[Article
                               1 de la loi n° 2014-856 du 31 juillet 2014](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000029314926){:target='_blank'}.
                               \n \n Plus d'informations dans la documentation INSEE
-                              de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#economiesocialesolidaireunitelegale"
+                              de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#economiesocialesolidaireunitelegale"
                             type: boolean
                             example: true
                             nullable: true
@@ -25563,7 +25571,7 @@ paths:
                               la date de création n'est jamais à 'null'. Si elle est
                               non renseignée, elle sera au 01/01/1900. \n \n Plus
                               d'informations dans la documentation Insee de l'API
-                              Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#datecreationunitelegale"
+                              Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#datecreationunitelegale"
                         required:
                         - siren
                         - rna
@@ -25594,7 +25602,7 @@ paths:
                           indice_repetition_voie:
                             title: Indice de répétition du numéro dans la voie
                             description: "Plus d'informations dans la documentation
-                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#indicerepetitionetablissement
+                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#indicerepetitionetablissement
                               \n Si la personne morale est en diffusion partielle,
                               la valeur est remplacée par \"[ND]\"."
                             type: string
@@ -25612,7 +25620,7 @@ paths:
                               en abrégé et en majuscules. L'information n'est pas
                               toujours renseignée. Pour certaines petites communes,
                               l'information n'existe pas. \n \n Plus d'informations
-                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#typevoieetablissement
+                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#typevoieetablissement
                               \n Si la personne morale est en diffusion partielle,
                               la valeur est remplacée par \"[ND]\"."
                             type: string
@@ -25707,14 +25715,16 @@ paths:
                               particuliers qui accompagnent une adresse de distribution
                               \  spéciale, la modalité la plus connue étant les adresses
                               en 'CEDEX'. \n \n Plus d'informations dans la documentation
-                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#distributionspecialeetablissement
+                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement
                               \n Si la personne morale est en diffusion partielle,
                               la valeur est remplacée par \"[ND]\"."
                           code_cedex:
                             title: Code cedex
                             type: string
                             nullable: true
-                            description: "Plus d'informations : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle
+                            description: "Plus d'informations dans la documentation
+                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
+                              \n Sur le sigle CEDEX lui-même : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle
                               \n Si la personne morale est en diffusion partielle,
                               la valeur est remplacée par \"[ND]\"."
                             example: '75590'
@@ -25883,7 +25893,7 @@ paths:
                           nulle. \n Pour les unités purgées, la date de création n'est
                           jamais à 'null'. Si elle est non renseignée, elle sera au
                           01/01/1900. \n \n Plus d'informations dans la documentation
-                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#datecreationunitelegale"
+                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#datecreationunitelegale"
                     required:
                     - siret
                     - siege_social
@@ -26422,7 +26432,7 @@ paths:
                           est à l'état 'actif'\n\n - fermé. Cet état découle de la
                           prise en compte d'une déclaration de fermeture. Un établissement
                           fermé peut être rouvert. \n \n Plus d'informations dans
-                          la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#etatadministratifetablissement"
+                          la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#etatadministratifetablissement"
                       date_fermeture:
                         title: Date de fermeture de l'établissement
                         type: integer
@@ -26509,7 +26519,7 @@ paths:
                               \n - 42 : 1 000 à 1 999 salariés \n - 51 : 2 000 à 4
                               999 salariés \n - 52 : 5 000 à 9 999 salariés \n - 53
                               : 10 000 salariés et plus \n \n Plus d'informations
-                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#trancheeffectifsetablissement.
+                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#trancheeffectifsetablissement.
                               \n \n L'effectif mensuel exact de l'établissement est
                               disponible au travers de l'[API Effectifs - URSSAF Caisse
                               nationale](TODO). Si votre jeton contient ce droit d'accès,
@@ -26595,7 +26605,7 @@ paths:
                           en aucun cas être accessibles au grand public. Ce cas n'étant
                           plus censé exister, préférer l'API en open data qui masque
                           automatiquement les données protégées. \n Plus d'informations
-                          sur les conditions de diffusion : https://sirene.fr/static-resources/htm/v_sommaire.htm#26"
+                          sur les conditions de diffusion : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=8279ad8c-c12d-4a2c-b9ad-8cc12dea2c39"
                       enseigne:
                         title: Enseigne de l'établissement
                         type: string
@@ -26605,7 +26615,7 @@ paths:
                           peut posséder une enseigne, plusieurs enseignes ou aucune.
                           \n \n Cette variable est la concaténation séparée par des
                           virgules des 3 champs \"renvoyés\" par l'Insee. Plus d'informations
-                          ici: https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#enseigne1etablissement-enseigne2etablissement-enseigne3etablissement
+                          ici: https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#enseigne1etablissement-enseigne2etablissement-enseigne3etablissement
                           \n Si la personne morale est en diffusion partielle, l'enseigne
                           n'est pas renvoyée, et la valeur est remplacée par \"[ND]\"."
                         example: Coiff Land, CoiffureLand
@@ -26822,7 +26832,7 @@ paths:
                               : 'true'. Dans ce cas, les informations protégées suite
                               au droit d'opposition sont masquées par la chaîne de
                               caractère '[ND]' ; \n Plus d'informations sur les conditions
-                              de diffusion : https://sirene.fr/static-resources/htm/v_sommaire.htm#26"
+                              de diffusion : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=8279ad8c-c12d-4a2c-b9ad-8cc12dea2c39"
                           forme_juridique:
                             type: object
                             additionalProperties: false
@@ -26950,7 +26960,7 @@ paths:
                                   : 2 000 à 4 999 salariés \n - 52 : 5 000 à 9 999
                                   salariés \n - 53 : 10 000 salariés et plus \n \n
                                   Plus d'informations dans la documentation Insee
-                                  de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#trancheeffectifsunitelegale.
+                                  de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#trancheeffectifsunitelegale.
                                   \n \n L'effectif exact de l'entreprise, mensuel
                                   et annuel, est disponible au travers de l'API Effectifs
                                   - URSSAF Caisse nationale. Si votre jeton contient
@@ -27024,7 +27034,7 @@ paths:
                               dépose une cessation d'activité. \n \n En dehors de
                               ces cas, l'état administratif de l'unité légale est
                               toujours « actif ». \n \n Plus d'informations dans la
-                              documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#etatadministratifunitelegale"
+                              documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#etatadministratifunitelegale"
                           economie_sociale_et_solidaire:
                             title: Unité légale de l'économie sociale et solidaire
                               (ESS)
@@ -27042,7 +27052,7 @@ paths:
                               Ces conditions cumulatives sont explicitées à l'[Article
                               1 de la loi n° 2014-856 du 31 juillet 2014](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000029314926){:target='_blank'}.
                               \n \n Plus d'informations dans la documentation INSEE
-                              de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#economiesocialesolidaireunitelegale"
+                              de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#economiesocialesolidaireunitelegale"
                             type: boolean
                             example: true
                             nullable: true
@@ -27064,7 +27074,7 @@ paths:
                               la date de création n'est jamais à 'null'. Si elle est
                               non renseignée, elle sera au 01/01/1900. \n \n Plus
                               d'informations dans la documentation Insee de l'API
-                              Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#datecreationunitelegale"
+                              Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#datecreationunitelegale"
                           activite_principale_naf_rev2:
                             title: Attributs de l'activité principale en nomenclature
                               NAFRev2
@@ -27124,7 +27134,7 @@ paths:
                           indice_repetition_voie:
                             title: Indice de répétition du numéro dans la voie
                             description: "Plus d'informations dans la documentation
-                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#indicerepetitionetablissement
+                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#indicerepetitionetablissement
                               \n Si la personne morale est en diffusion partielle,
                               la valeur est remplacée par \"[ND]\"."
                             type: string
@@ -27142,7 +27152,7 @@ paths:
                               en abrégé et en majuscules. L'information n'est pas
                               toujours renseignée. Pour certaines petites communes,
                               l'information n'existe pas. \n \n Plus d'informations
-                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#typevoieetablissement
+                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#typevoieetablissement
                               \n Si la personne morale est en diffusion partielle,
                               la valeur est remplacée par \"[ND]\"."
                             type: string
@@ -27237,14 +27247,16 @@ paths:
                               particuliers qui accompagnent une adresse de distribution
                               \  spéciale, la modalité la plus connue étant les adresses
                               en 'CEDEX'. \n \n Plus d'informations dans la documentation
-                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#distributionspecialeetablissement
+                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement
                               \n Si la personne morale est en diffusion partielle,
                               la valeur est remplacée par \"[ND]\"."
                           code_cedex:
                             title: Code cedex
                             type: string
                             nullable: true
-                            description: "Plus d'informations : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle
+                            description: "Plus d'informations dans la documentation
+                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
+                              \n Sur le sigle CEDEX lui-même : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle
                               \n Si la personne morale est en diffusion partielle,
                               la valeur est remplacée par \"[ND]\"."
                             example: '75590'
@@ -27413,7 +27425,7 @@ paths:
                           nulle. \n Pour les unités purgées, la date de création n'est
                           jamais à 'null'. Si elle est non renseignée, elle sera au
                           01/01/1900. \n \n Plus d'informations dans la documentation
-                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#datecreationunitelegale"
+                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#datecreationunitelegale"
                       activite_principale_naf_rev2:
                         title: Attributs de l'activité principale en nomenclature
                           NAFRev2
@@ -27978,7 +27990,7 @@ paths:
                           est à l'état 'actif'\n\n - fermé. Cet état découle de la
                           prise en compte d'une déclaration de fermeture. Un établissement
                           fermé peut être rouvert. \n \n Plus d'informations dans
-                          la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#etatadministratifetablissement"
+                          la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#etatadministratifetablissement"
                       date_fermeture:
                         title: Date de fermeture de l'établissement
                         type: integer
@@ -28065,7 +28077,7 @@ paths:
                               \n - 42 : 1 000 à 1 999 salariés \n - 51 : 2 000 à 4
                               999 salariés \n - 52 : 5 000 à 9 999 salariés \n - 53
                               : 10 000 salariés et plus \n \n Plus d'informations
-                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#trancheeffectifsetablissement.
+                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#trancheeffectifsetablissement.
                               \n \n L'effectif mensuel exact de l'établissement est
                               disponible au travers de l'[API Effectifs - URSSAF Caisse
                               nationale](TODO). Si votre jeton contient ce droit d'accès,
@@ -28151,7 +28163,7 @@ paths:
                           en aucun cas être accessibles au grand public. Ce cas n'étant
                           plus censé exister, préférer l'API en open data qui masque
                           automatiquement les données protégées. \n Plus d'informations
-                          sur les conditions de diffusion : https://sirene.fr/static-resources/htm/v_sommaire.htm#26"
+                          sur les conditions de diffusion : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=8279ad8c-c12d-4a2c-b9ad-8cc12dea2c39"
                       enseigne:
                         title: Enseigne de l'établissement
                         type: string
@@ -28161,7 +28173,7 @@ paths:
                           peut posséder une enseigne, plusieurs enseignes ou aucune.
                           \n \n Cette variable est la concaténation séparée par des
                           virgules des 3 champs \"renvoyés\" par l'Insee. Plus d'informations
-                          ici: https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#enseigne1etablissement-enseigne2etablissement-enseigne3etablissement
+                          ici: https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#enseigne1etablissement-enseigne2etablissement-enseigne3etablissement
                           \n Si la personne morale est en diffusion partielle, l'enseigne
                           n'est pas renvoyée, et la valeur est remplacée par \"[ND]\"."
                         example: Coiff Land, CoiffureLand
@@ -28378,7 +28390,7 @@ paths:
                               : 'true'. Dans ce cas, les informations protégées suite
                               au droit d'opposition sont masquées par la chaîne de
                               caractère '[ND]' ; \n Plus d'informations sur les conditions
-                              de diffusion : https://sirene.fr/static-resources/htm/v_sommaire.htm#26"
+                              de diffusion : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=8279ad8c-c12d-4a2c-b9ad-8cc12dea2c39"
                           forme_juridique:
                             type: object
                             additionalProperties: false
@@ -28506,7 +28518,7 @@ paths:
                                   : 2 000 à 4 999 salariés \n - 52 : 5 000 à 9 999
                                   salariés \n - 53 : 10 000 salariés et plus \n \n
                                   Plus d'informations dans la documentation Insee
-                                  de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#trancheeffectifsunitelegale.
+                                  de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#trancheeffectifsunitelegale.
                                   \n \n L'effectif exact de l'entreprise, mensuel
                                   et annuel, est disponible au travers de l'API Effectifs
                                   - URSSAF Caisse nationale. Si votre jeton contient
@@ -28580,7 +28592,7 @@ paths:
                               dépose une cessation d'activité. \n \n En dehors de
                               ces cas, l'état administratif de l'unité légale est
                               toujours « actif ». \n \n Plus d'informations dans la
-                              documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#etatadministratifunitelegale"
+                              documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#etatadministratifunitelegale"
                           economie_sociale_et_solidaire:
                             title: Unité légale de l'économie sociale et solidaire
                               (ESS)
@@ -28598,7 +28610,7 @@ paths:
                               Ces conditions cumulatives sont explicitées à l'[Article
                               1 de la loi n° 2014-856 du 31 juillet 2014](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000029314926){:target='_blank'}.
                               \n \n Plus d'informations dans la documentation INSEE
-                              de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#economiesocialesolidaireunitelegale"
+                              de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#economiesocialesolidaireunitelegale"
                             type: boolean
                             example: true
                             nullable: true
@@ -28620,7 +28632,7 @@ paths:
                               la date de création n'est jamais à 'null'. Si elle est
                               non renseignée, elle sera au 01/01/1900. \n \n Plus
                               d'informations dans la documentation Insee de l'API
-                              Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#datecreationunitelegale"
+                              Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#datecreationunitelegale"
                         required:
                         - siren
                         - rna
@@ -28651,7 +28663,7 @@ paths:
                           indice_repetition_voie:
                             title: Indice de répétition du numéro dans la voie
                             description: "Plus d'informations dans la documentation
-                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#indicerepetitionetablissement
+                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#indicerepetitionetablissement
                               \n Si la personne morale est en diffusion partielle,
                               la valeur est remplacée par \"[ND]\"."
                             type: string
@@ -28669,7 +28681,7 @@ paths:
                               en abrégé et en majuscules. L'information n'est pas
                               toujours renseignée. Pour certaines petites communes,
                               l'information n'existe pas. \n \n Plus d'informations
-                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#typevoieetablissement
+                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#typevoieetablissement
                               \n Si la personne morale est en diffusion partielle,
                               la valeur est remplacée par \"[ND]\"."
                             type: string
@@ -28764,14 +28776,16 @@ paths:
                               particuliers qui accompagnent une adresse de distribution
                               \  spéciale, la modalité la plus connue étant les adresses
                               en 'CEDEX'. \n \n Plus d'informations dans la documentation
-                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#distributionspecialeetablissement
+                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement
                               \n Si la personne morale est en diffusion partielle,
                               la valeur est remplacée par \"[ND]\"."
                           code_cedex:
                             title: Code cedex
                             type: string
                             nullable: true
-                            description: "Plus d'informations : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle
+                            description: "Plus d'informations dans la documentation
+                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
+                              \n Sur le sigle CEDEX lui-même : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle
                               \n Si la personne morale est en diffusion partielle,
                               la valeur est remplacée par \"[ND]\"."
                             example: '75590'
@@ -28940,7 +28954,7 @@ paths:
                           nulle. \n Pour les unités purgées, la date de création n'est
                           jamais à 'null'. Si elle est non renseignée, elle sera au
                           01/01/1900. \n \n Plus d'informations dans la documentation
-                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#datecreationunitelegale"
+                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#datecreationunitelegale"
                     required:
                     - siret
                     - siege_social
@@ -29477,7 +29491,7 @@ paths:
                           est à l'état 'actif'\n\n - fermé. Cet état découle de la
                           prise en compte d'une déclaration de fermeture. Un établissement
                           fermé peut être rouvert. \n \n Plus d'informations dans
-                          la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#etatadministratifetablissement"
+                          la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#etatadministratifetablissement"
                       date_fermeture:
                         title: Date de fermeture de l'établissement
                         type: integer
@@ -29564,7 +29578,7 @@ paths:
                               \n - 42 : 1 000 à 1 999 salariés \n - 51 : 2 000 à 4
                               999 salariés \n - 52 : 5 000 à 9 999 salariés \n - 53
                               : 10 000 salariés et plus \n \n Plus d'informations
-                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#trancheeffectifsetablissement.
+                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#trancheeffectifsetablissement.
                               \n \n L'effectif mensuel exact de l'établissement est
                               disponible au travers de l'[API Effectifs - URSSAF Caisse
                               nationale](TODO). Si votre jeton contient ce droit d'accès,
@@ -29650,7 +29664,7 @@ paths:
                           en aucun cas être accessibles au grand public. Ce cas n'étant
                           plus censé exister, préférer l'API en open data qui masque
                           automatiquement les données protégées. \n Plus d'informations
-                          sur les conditions de diffusion : https://sirene.fr/static-resources/htm/v_sommaire.htm#26"
+                          sur les conditions de diffusion : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=8279ad8c-c12d-4a2c-b9ad-8cc12dea2c39"
                       enseigne:
                         title: Enseigne de l'établissement
                         type: string
@@ -29660,7 +29674,7 @@ paths:
                           peut posséder une enseigne, plusieurs enseignes ou aucune.
                           \n \n Cette variable est la concaténation séparée par des
                           virgules des 3 champs \"renvoyés\" par l'Insee. Plus d'informations
-                          ici: https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#enseigne1etablissement-enseigne2etablissement-enseigne3etablissement
+                          ici: https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#enseigne1etablissement-enseigne2etablissement-enseigne3etablissement
                           \n Si la personne morale est en diffusion partielle, l'enseigne
                           n'est pas renvoyée, et la valeur est remplacée par \"[ND]\"."
                         example: Coiff Land, CoiffureLand
@@ -29877,7 +29891,7 @@ paths:
                               : 'true'. Dans ce cas, les informations protégées suite
                               au droit d'opposition sont masquées par la chaîne de
                               caractère '[ND]' ; \n Plus d'informations sur les conditions
-                              de diffusion : https://sirene.fr/static-resources/htm/v_sommaire.htm#26"
+                              de diffusion : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=8279ad8c-c12d-4a2c-b9ad-8cc12dea2c39"
                           forme_juridique:
                             type: object
                             additionalProperties: false
@@ -30005,7 +30019,7 @@ paths:
                                   : 2 000 à 4 999 salariés \n - 52 : 5 000 à 9 999
                                   salariés \n - 53 : 10 000 salariés et plus \n \n
                                   Plus d'informations dans la documentation Insee
-                                  de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#trancheeffectifsunitelegale.
+                                  de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#trancheeffectifsunitelegale.
                                   \n \n L'effectif exact de l'entreprise, mensuel
                                   et annuel, est disponible au travers de l'API Effectifs
                                   - URSSAF Caisse nationale. Si votre jeton contient
@@ -30079,7 +30093,7 @@ paths:
                               dépose une cessation d'activité. \n \n En dehors de
                               ces cas, l'état administratif de l'unité légale est
                               toujours « actif ». \n \n Plus d'informations dans la
-                              documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#etatadministratifunitelegale"
+                              documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#etatadministratifunitelegale"
                           economie_sociale_et_solidaire:
                             title: Unité légale de l'économie sociale et solidaire
                               (ESS)
@@ -30097,7 +30111,7 @@ paths:
                               Ces conditions cumulatives sont explicitées à l'[Article
                               1 de la loi n° 2014-856 du 31 juillet 2014](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000029314926){:target='_blank'}.
                               \n \n Plus d'informations dans la documentation INSEE
-                              de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#economiesocialesolidaireunitelegale"
+                              de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#economiesocialesolidaireunitelegale"
                             type: boolean
                             example: true
                             nullable: true
@@ -30119,7 +30133,7 @@ paths:
                               la date de création n'est jamais à 'null'. Si elle est
                               non renseignée, elle sera au 01/01/1900. \n \n Plus
                               d'informations dans la documentation Insee de l'API
-                              Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#datecreationunitelegale"
+                              Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#datecreationunitelegale"
                           activite_principale_naf_rev2:
                             title: Attributs de l'activité principale en nomenclature
                               NAFRev2
@@ -30179,7 +30193,7 @@ paths:
                           indice_repetition_voie:
                             title: Indice de répétition du numéro dans la voie
                             description: "Plus d'informations dans la documentation
-                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#indicerepetitionetablissement
+                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#indicerepetitionetablissement
                               \n Si la personne morale est en diffusion partielle,
                               la valeur est remplacée par \"[ND]\"."
                             type: string
@@ -30197,7 +30211,7 @@ paths:
                               en abrégé et en majuscules. L'information n'est pas
                               toujours renseignée. Pour certaines petites communes,
                               l'information n'existe pas. \n \n Plus d'informations
-                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#typevoieetablissement
+                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#typevoieetablissement
                               \n Si la personne morale est en diffusion partielle,
                               la valeur est remplacée par \"[ND]\"."
                             type: string
@@ -30292,14 +30306,16 @@ paths:
                               particuliers qui accompagnent une adresse de distribution
                               \  spéciale, la modalité la plus connue étant les adresses
                               en 'CEDEX'. \n \n Plus d'informations dans la documentation
-                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#distributionspecialeetablissement
+                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement
                               \n Si la personne morale est en diffusion partielle,
                               la valeur est remplacée par \"[ND]\"."
                           code_cedex:
                             title: Code cedex
                             type: string
                             nullable: true
-                            description: "Plus d'informations : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle
+                            description: "Plus d'informations dans la documentation
+                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
+                              \n Sur le sigle CEDEX lui-même : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle
                               \n Si la personne morale est en diffusion partielle,
                               la valeur est remplacée par \"[ND]\"."
                             example: '75590'
@@ -30468,7 +30484,7 @@ paths:
                           nulle. \n Pour les unités purgées, la date de création n'est
                           jamais à 'null'. Si elle est non renseignée, elle sera au
                           01/01/1900. \n \n Plus d'informations dans la documentation
-                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#datecreationunitelegale"
+                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#datecreationunitelegale"
                       activite_principale_naf_rev2:
                         title: Attributs de l'activité principale en nomenclature
                           NAFRev2
@@ -31034,7 +31050,7 @@ paths:
                           est à l'état 'actif'\n\n - fermé. Cet état découle de la
                           prise en compte d'une déclaration de fermeture. Un établissement
                           fermé peut être rouvert. \n \n Plus d'informations dans
-                          la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#etatadministratifetablissement"
+                          la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#etatadministratifetablissement"
                       date_fermeture:
                         title: Date de fermeture de l'établissement
                         type: integer
@@ -31121,7 +31137,7 @@ paths:
                               \n - 42 : 1 000 à 1 999 salariés \n - 51 : 2 000 à 4
                               999 salariés \n - 52 : 5 000 à 9 999 salariés \n - 53
                               : 10 000 salariés et plus \n \n Plus d'informations
-                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#trancheeffectifsetablissement.
+                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#trancheeffectifsetablissement.
                               \n \n L'effectif mensuel exact de l'établissement est
                               disponible au travers de l'[API Effectifs - URSSAF Caisse
                               nationale](TODO). Si votre jeton contient ce droit d'accès,
@@ -31207,7 +31223,7 @@ paths:
                           en aucun cas être accessibles au grand public. Ce cas n'étant
                           plus censé exister, préférer l'API en open data qui masque
                           automatiquement les données protégées. \n Plus d'informations
-                          sur les conditions de diffusion : https://sirene.fr/static-resources/htm/v_sommaire.htm#26"
+                          sur les conditions de diffusion : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=8279ad8c-c12d-4a2c-b9ad-8cc12dea2c39"
                       enseigne:
                         title: Enseigne de l'établissement
                         type: string
@@ -31217,7 +31233,7 @@ paths:
                           peut posséder une enseigne, plusieurs enseignes ou aucune.
                           \n \n Cette variable est la concaténation séparée par des
                           virgules des 3 champs \"renvoyés\" par l'Insee. Plus d'informations
-                          ici: https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#enseigne1etablissement-enseigne2etablissement-enseigne3etablissement"
+                          ici: https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#enseigne1etablissement-enseigne2etablissement-enseigne3etablissement"
                         example: Coiff Land, CoiffureLand
                       unite_legale:
                         type: object
@@ -31414,7 +31430,7 @@ paths:
                               Ce cas n'étant plus censé exister, préférer l'API en
                               open data qui masque automatiquement les données protégées.
                               \n Plus d'informations sur les conditions de diffusion
-                              : https://sirene.fr/static-resources/htm/v_sommaire.htm#26"
+                              : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=8279ad8c-c12d-4a2c-b9ad-8cc12dea2c39"
                           forme_juridique:
                             type: object
                             additionalProperties: false
@@ -31542,7 +31558,7 @@ paths:
                                   : 2 000 à 4 999 salariés \n - 52 : 5 000 à 9 999
                                   salariés \n - 53 : 10 000 salariés et plus \n \n
                                   Plus d'informations dans la documentation Insee
-                                  de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#trancheeffectifsunitelegale.
+                                  de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#trancheeffectifsunitelegale.
                                   \n \n L'effectif exact de l'entreprise, mensuel
                                   et annuel, est disponible au travers de l'API Effectifs
                                   - URSSAF Caisse nationale. Si votre jeton contient
@@ -31616,7 +31632,7 @@ paths:
                               dépose une cessation d'activité. \n \n En dehors de
                               ces cas, l'état administratif de l'unité légale est
                               toujours « actif ». \n \n Plus d'informations dans la
-                              documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#etatadministratifunitelegale"
+                              documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#etatadministratifunitelegale"
                           economie_sociale_et_solidaire:
                             title: Unité légale de l'économie sociale et solidaire
                               (ESS)
@@ -31634,7 +31650,7 @@ paths:
                               Ces conditions cumulatives sont explicitées à l'[Article
                               1 de la loi n° 2014-856 du 31 juillet 2014](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000029314926){:target='_blank'}.
                               \n \n Plus d'informations dans la documentation INSEE
-                              de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#economiesocialesolidaireunitelegale"
+                              de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#economiesocialesolidaireunitelegale"
                             type: boolean
                             example: true
                             nullable: true
@@ -31656,7 +31672,7 @@ paths:
                               la date de création n'est jamais à 'null'. Si elle est
                               non renseignée, elle sera au 01/01/1900. \n \n Plus
                               d'informations dans la documentation Insee de l'API
-                              Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#datecreationunitelegale"
+                              Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#datecreationunitelegale"
                         required:
                         - siren
                         - rna
@@ -31685,7 +31701,7 @@ paths:
                           indice_repetition_voie:
                             title: Indice de répétition du numéro dans la voie
                             description: 'Plus d''informations dans la documentation
-                              Insee de l''API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#indicerepetitionetablissement'
+                              Insee de l''API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#indicerepetitionetablissement'
                             type: string
                             nullable: true
                             enum:
@@ -31701,7 +31717,7 @@ paths:
                               en abrégé et en majuscules. L'information n'est pas
                               toujours renseignée. Pour certaines petites communes,
                               l'information n'existe pas. \n \n Plus d'informations
-                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#typevoieetablissement"
+                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#typevoieetablissement"
                             type: string
                             nullable: true
                             enum:
@@ -31788,12 +31804,14 @@ paths:
                               particuliers qui accompagnent une adresse de distribution
                               spéciale, la modalité la plus connue étant les adresses
                               en 'CEDEX'. \n \n Plus d'informations dans la documentation
-                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#distributionspecialeetablissement"
+                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement"
                           code_cedex:
                             title: Code cedex
                             type: string
                             nullable: true
-                            description: 'Plus d''informations : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle'
+                            description: "Plus d'informations dans la documentation
+                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
+                              \n \n Sur le sigle CEDEX lui-même : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle"
                             example: '75590'
                           libelle_cedex:
                             title: Libellé du code cedex
@@ -31948,7 +31966,7 @@ paths:
                           nulle. \n Pour les unités purgées, la date de création n'est
                           jamais à 'null'. Si elle est non renseignée, elle sera au
                           01/01/1900. \n \n Plus d'informations dans la documentation
-                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#datecreationunitelegale"
+                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#datecreationunitelegale"
                     required:
                     - siret
                     - siege_social
@@ -32486,7 +32504,7 @@ paths:
                           est à l'état 'actif'\n\n - fermé. Cet état découle de la
                           prise en compte d'une déclaration de fermeture. Un établissement
                           fermé peut être rouvert. \n \n Plus d'informations dans
-                          la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#etatadministratifetablissement"
+                          la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#etatadministratifetablissement"
                       date_fermeture:
                         title: Date de fermeture de l'établissement
                         type: integer
@@ -32573,7 +32591,7 @@ paths:
                               \n - 42 : 1 000 à 1 999 salariés \n - 51 : 2 000 à 4
                               999 salariés \n - 52 : 5 000 à 9 999 salariés \n - 53
                               : 10 000 salariés et plus \n \n Plus d'informations
-                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#trancheeffectifsetablissement.
+                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#trancheeffectifsetablissement.
                               \n \n L'effectif mensuel exact de l'établissement est
                               disponible au travers de l'[API Effectifs - URSSAF Caisse
                               nationale](TODO). Si votre jeton contient ce droit d'accès,
@@ -32659,7 +32677,7 @@ paths:
                           en aucun cas être accessibles au grand public. Ce cas n'étant
                           plus censé exister, préférer l'API en open data qui masque
                           automatiquement les données protégées. \n Plus d'informations
-                          sur les conditions de diffusion : https://sirene.fr/static-resources/htm/v_sommaire.htm#26"
+                          sur les conditions de diffusion : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=8279ad8c-c12d-4a2c-b9ad-8cc12dea2c39"
                       enseigne:
                         title: Enseigne de l'établissement
                         type: string
@@ -32669,7 +32687,7 @@ paths:
                           peut posséder une enseigne, plusieurs enseignes ou aucune.
                           \n \n Cette variable est la concaténation séparée par des
                           virgules des 3 champs \"renvoyés\" par l'Insee. Plus d'informations
-                          ici: https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#enseigne1etablissement-enseigne2etablissement-enseigne3etablissement"
+                          ici: https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#enseigne1etablissement-enseigne2etablissement-enseigne3etablissement"
                         example: Coiff Land, CoiffureLand
                       unite_legale:
                         type: object
@@ -32866,7 +32884,7 @@ paths:
                               Ce cas n'étant plus censé exister, préférer l'API en
                               open data qui masque automatiquement les données protégées.
                               \n Plus d'informations sur les conditions de diffusion
-                              : https://sirene.fr/static-resources/htm/v_sommaire.htm#26"
+                              : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=8279ad8c-c12d-4a2c-b9ad-8cc12dea2c39"
                           forme_juridique:
                             type: object
                             additionalProperties: false
@@ -32994,7 +33012,7 @@ paths:
                                   : 2 000 à 4 999 salariés \n - 52 : 5 000 à 9 999
                                   salariés \n - 53 : 10 000 salariés et plus \n \n
                                   Plus d'informations dans la documentation Insee
-                                  de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#trancheeffectifsunitelegale.
+                                  de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#trancheeffectifsunitelegale.
                                   \n \n L'effectif exact de l'entreprise, mensuel
                                   et annuel, est disponible au travers de l'API Effectifs
                                   - URSSAF Caisse nationale. Si votre jeton contient
@@ -33068,7 +33086,7 @@ paths:
                               dépose une cessation d'activité. \n \n En dehors de
                               ces cas, l'état administratif de l'unité légale est
                               toujours « actif ». \n \n Plus d'informations dans la
-                              documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#etatadministratifunitelegale"
+                              documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#etatadministratifunitelegale"
                           economie_sociale_et_solidaire:
                             title: Unité légale de l'économie sociale et solidaire
                               (ESS)
@@ -33086,7 +33104,7 @@ paths:
                               Ces conditions cumulatives sont explicitées à l'[Article
                               1 de la loi n° 2014-856 du 31 juillet 2014](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000029314926){:target='_blank'}.
                               \n \n Plus d'informations dans la documentation INSEE
-                              de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#economiesocialesolidaireunitelegale"
+                              de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#economiesocialesolidaireunitelegale"
                             type: boolean
                             example: true
                             nullable: true
@@ -33108,7 +33126,7 @@ paths:
                               la date de création n'est jamais à 'null'. Si elle est
                               non renseignée, elle sera au 01/01/1900. \n \n Plus
                               d'informations dans la documentation Insee de l'API
-                              Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#datecreationunitelegale"
+                              Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#datecreationunitelegale"
                           activite_principale_naf_rev2:
                             title: Attributs de l'activité principale en nomenclature
                               NAFRev2
@@ -33166,7 +33184,7 @@ paths:
                           indice_repetition_voie:
                             title: Indice de répétition du numéro dans la voie
                             description: 'Plus d''informations dans la documentation
-                              Insee de l''API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#indicerepetitionetablissement'
+                              Insee de l''API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#indicerepetitionetablissement'
                             type: string
                             nullable: true
                             enum:
@@ -33182,7 +33200,7 @@ paths:
                               en abrégé et en majuscules. L'information n'est pas
                               toujours renseignée. Pour certaines petites communes,
                               l'information n'existe pas. \n \n Plus d'informations
-                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#typevoieetablissement"
+                              dans la documentation Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#typevoieetablissement"
                             type: string
                             nullable: true
                             enum:
@@ -33269,12 +33287,14 @@ paths:
                               particuliers qui accompagnent une adresse de distribution
                               spéciale, la modalité la plus connue étant les adresses
                               en 'CEDEX'. \n \n Plus d'informations dans la documentation
-                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=10aae456-565f-4961-aae4-56565fa9617a#distributionspecialeetablissement"
+                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#distributionspecialeetablissement"
                           code_cedex:
                             title: Code cedex
                             type: string
                             nullable: true
-                            description: 'Plus d''informations : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle'
+                            description: "Plus d'informations dans la documentation
+                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=754efef5-1e50-41d3-8efe-f51e5071d320#codecedexetablissement
+                              \n \n Sur le sigle CEDEX lui-même : https://fr.wikipedia.org/wiki/Courrier_d%27entreprise_%C3%A0_distribution_exceptionnelle"
                             example: '75590'
                           libelle_cedex:
                             title: Libellé du code cedex
@@ -33429,7 +33449,7 @@ paths:
                           nulle. \n Pour les unités purgées, la date de création n'est
                           jamais à 'null'. Si elle est non renseignée, elle sera au
                           01/01/1900. \n \n Plus d'informations dans la documentation
-                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#datecreationunitelegale"
+                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#datecreationunitelegale"
                       activite_principale_naf_rev2:
                         title: Attributs de l'activité principale en nomenclature
                           NAFRev2
@@ -34679,7 +34699,7 @@ paths:
                           en aucun cas être accessibles au grand public. Ce cas n'étant
                           plus censé exister, préférer l'API en open data qui masque
                           automatiquement les données protégées. \n Plus d'informations
-                          sur les conditions de diffusion : https://sirene.fr/static-resources/htm/v_sommaire.htm#26"
+                          sur les conditions de diffusion : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=8279ad8c-c12d-4a2c-b9ad-8cc12dea2c39"
                       forme_juridique:
                         type: object
                         additionalProperties: false
@@ -34800,7 +34820,7 @@ paths:
                               salariés \n - 51 : 2 000 à 4 999 salariés \n - 52 :
                               5 000 à 9 999 salariés \n - 53 : 10 000 salariés et
                               plus \n \n Plus d'informations dans la documentation
-                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#trancheeffectifsunitelegale.
+                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#trancheeffectifsunitelegale.
                               \n \n L'effectif exact de l'entreprise, mensuel et annuel,
                               est disponible au travers de l'API Effectifs - URSSAF
                               Caisse nationale. Si votre jeton contient ce droit d'accès,
@@ -34873,7 +34893,7 @@ paths:
                           cessation d'activité. \n \n En dehors de ces cas, l'état
                           administratif de l'unité légale est toujours « actif ».
                           \n \n Plus d'informations dans la documentation Insee de
-                          l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#etatadministratifunitelegale"
+                          l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#etatadministratifunitelegale"
                       economie_sociale_et_solidaire:
                         title: Unité légale de l'économie sociale et solidaire (ESS)
                         description: "Indique si l'unité légale est une ESS : \n \n
@@ -34889,7 +34909,7 @@ paths:
                           Ces conditions cumulatives sont explicitées à l'[Article
                           1 de la loi n° 2014-856 du 31 juillet 2014](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000029314926){:target='_blank'}.
                           \n \n Plus d'informations dans la documentation INSEE de
-                          l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#economiesocialesolidaireunitelegale"
+                          l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#economiesocialesolidaireunitelegale"
                         type: boolean
                         example: true
                         nullable: true
@@ -34910,7 +34930,7 @@ paths:
                           nulle. \n Pour les unités purgées, la date de création n'est
                           jamais à 'null'. Si elle est non renseignée, elle sera au
                           01/01/1900. \n \n Plus d'informations dans la documentation
-                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#datecreationunitelegale"
+                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#datecreationunitelegale"
                       date_cessation:
                         title: Date de cessation de l'unité légale
                         type: integer
@@ -35625,7 +35645,7 @@ paths:
                           en aucun cas être accessibles au grand public. Ce cas n'étant
                           plus censé exister, préférer l'API en open data qui masque
                           automatiquement les données protégées. \n Plus d'informations
-                          sur les conditions de diffusion : https://sirene.fr/static-resources/htm/v_sommaire.htm#26"
+                          sur les conditions de diffusion : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=8279ad8c-c12d-4a2c-b9ad-8cc12dea2c39"
                       forme_juridique:
                         type: object
                         additionalProperties: false
@@ -35746,7 +35766,7 @@ paths:
                               salariés \n - 51 : 2 000 à 4 999 salariés \n - 52 :
                               5 000 à 9 999 salariés \n - 53 : 10 000 salariés et
                               plus \n \n Plus d'informations dans la documentation
-                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#trancheeffectifsunitelegale.
+                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#trancheeffectifsunitelegale.
                               \n \n L'effectif exact de l'entreprise, mensuel et annuel,
                               est disponible au travers de l'API Effectifs - URSSAF
                               Caisse nationale. Si votre jeton contient ce droit d'accès,
@@ -35819,7 +35839,7 @@ paths:
                           cessation d'activité. \n \n En dehors de ces cas, l'état
                           administratif de l'unité légale est toujours « actif ».
                           \n \n Plus d'informations dans la documentation Insee de
-                          l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#etatadministratifunitelegale"
+                          l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#etatadministratifunitelegale"
                       economie_sociale_et_solidaire:
                         title: Unité légale de l'économie sociale et solidaire (ESS)
                         description: "Indique si l'unité légale est une ESS : \n \n
@@ -35835,7 +35855,7 @@ paths:
                           Ces conditions cumulatives sont explicitées à l'[Article
                           1 de la loi n° 2014-856 du 31 juillet 2014](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000029314926){:target='_blank'}.
                           \n \n Plus d'informations dans la documentation INSEE de
-                          l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#economiesocialesolidaireunitelegale"
+                          l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#economiesocialesolidaireunitelegale"
                         type: boolean
                         example: true
                         nullable: true
@@ -35856,7 +35876,7 @@ paths:
                           nulle. \n Pour les unités purgées, la date de création n'est
                           jamais à 'null'. Si elle est non renseignée, elle sera au
                           01/01/1900. \n \n Plus d'informations dans la documentation
-                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#datecreationunitelegale"
+                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#datecreationunitelegale"
                       activite_principale_naf_rev2:
                         title: Attributs de l'activité principale en nomenclature
                           NAFRev2
@@ -36617,7 +36637,7 @@ paths:
                           sont publiques ; \n - partiellement-diffusible : 'true'.
                           Dans ce cas, les informations protégées suite au droit d'opposition
                           sont masquées par la chaîne de caractère '[ND]' ; \n Plus
-                          d'informations sur les conditions de diffusion : https://sirene.fr/static-resources/htm/v_sommaire.htm#26"
+                          d'informations sur les conditions de diffusion : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=8279ad8c-c12d-4a2c-b9ad-8cc12dea2c39"
                       forme_juridique:
                         type: object
                         additionalProperties: false
@@ -36738,7 +36758,7 @@ paths:
                               salariés \n - 51 : 2 000 à 4 999 salariés \n - 52 :
                               5 000 à 9 999 salariés \n - 53 : 10 000 salariés et
                               plus \n \n Plus d'informations dans la documentation
-                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#trancheeffectifsunitelegale.
+                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#trancheeffectifsunitelegale.
                               \n \n L'effectif exact de l'entreprise, mensuel et annuel,
                               est disponible au travers de l'API Effectifs - URSSAF
                               Caisse nationale. Si votre jeton contient ce droit d'accès,
@@ -36811,7 +36831,7 @@ paths:
                           cessation d'activité. \n \n En dehors de ces cas, l'état
                           administratif de l'unité légale est toujours « actif ».
                           \n \n Plus d'informations dans la documentation Insee de
-                          l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#etatadministratifunitelegale"
+                          l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#etatadministratifunitelegale"
                       economie_sociale_et_solidaire:
                         title: Unité légale de l'économie sociale et solidaire (ESS)
                         description: "Indique si l'unité légale est une ESS : \n \n
@@ -36827,7 +36847,7 @@ paths:
                           Ces conditions cumulatives sont explicitées à l'[Article
                           1 de la loi n° 2014-856 du 31 juillet 2014](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000029314926){:target='_blank'}.
                           \n \n Plus d'informations dans la documentation INSEE de
-                          l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#economiesocialesolidaireunitelegale"
+                          l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#economiesocialesolidaireunitelegale"
                         type: boolean
                         example: true
                         nullable: true
@@ -36848,7 +36868,7 @@ paths:
                           nulle. \n Pour les unités purgées, la date de création n'est
                           jamais à 'null'. Si elle est non renseignée, elle sera au
                           01/01/1900. \n \n Plus d'informations dans la documentation
-                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#datecreationunitelegale"
+                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#datecreationunitelegale"
                       date_cessation:
                         title: Date de cessation de l'unité légale
                         type: integer
@@ -37581,7 +37601,7 @@ paths:
                           sont publiques ; \n - partiellement-diffusible : 'true'.
                           Dans ce cas, les informations protégées suite au droit d'opposition
                           sont masquées par la chaîne de caractère '[ND]' ; \n Plus
-                          d'informations sur les conditions de diffusion : https://sirene.fr/static-resources/htm/v_sommaire.htm#26"
+                          d'informations sur les conditions de diffusion : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=8279ad8c-c12d-4a2c-b9ad-8cc12dea2c39"
                       forme_juridique:
                         type: object
                         additionalProperties: false
@@ -37702,7 +37722,7 @@ paths:
                               salariés \n - 51 : 2 000 à 4 999 salariés \n - 52 :
                               5 000 à 9 999 salariés \n - 53 : 10 000 salariés et
                               plus \n \n Plus d'informations dans la documentation
-                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#trancheeffectifsunitelegale.
+                              Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#trancheeffectifsunitelegale.
                               \n \n L'effectif exact de l'entreprise, mensuel et annuel,
                               est disponible au travers de l'API Effectifs - URSSAF
                               Caisse nationale. Si votre jeton contient ce droit d'accès,
@@ -37775,7 +37795,7 @@ paths:
                           cessation d'activité. \n \n En dehors de ces cas, l'état
                           administratif de l'unité légale est toujours « actif ».
                           \n \n Plus d'informations dans la documentation Insee de
-                          l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#etatadministratifunitelegale"
+                          l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#etatadministratifunitelegale"
                       economie_sociale_et_solidaire:
                         title: Unité légale de l'économie sociale et solidaire (ESS)
                         description: "Indique si l'unité légale est une ESS : \n \n
@@ -37791,7 +37811,7 @@ paths:
                           Ces conditions cumulatives sont explicitées à l'[Article
                           1 de la loi n° 2014-856 du 31 juillet 2014](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000029314926){:target='_blank'}.
                           \n \n Plus d'informations dans la documentation INSEE de
-                          l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#economiesocialesolidaireunitelegale"
+                          l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#economiesocialesolidaireunitelegale"
                         type: boolean
                         example: true
                         nullable: true
@@ -37812,7 +37832,7 @@ paths:
                           nulle. \n Pour les unités purgées, la date de création n'est
                           jamais à 'null'. Si elle est non renseignée, elle sera au
                           01/01/1900. \n \n Plus d'informations dans la documentation
-                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#datecreationunitelegale"
+                          Insee de l'API Sirene : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#datecreationunitelegale"
                       activite_principale_naf_rev2:
                         title: Attributs de l'activité principale en nomenclature
                           NAFRev2

--- a/commons/swagger/openapi-entreprise.yaml
+++ b/commons/swagger/openapi-entreprise.yaml
@@ -34942,13 +34942,13 @@ paths:
                     properties:
                       siege_social:
                         type: string
-                        example: https://entreprises.api.gouv.fr/api/v3/insee/etablissements/30613890001294
+                        example: https://entreprise.api.gouv.fr/api/v3/insee/etablissements/30613890001294
                         description: Lien vers la ressource 'Données de référence
                           d'un établissement' correspondant au siège social de cette
                           unité légale.
                       siege_social_adresse:
                         type: string
-                        example: https://entreprises.api.gouv.fr/api/v3/insee/etablissements/30613890001294/adresse
+                        example: https://entreprise.api.gouv.fr/api/v3/insee/etablissements/30613890001294/adresse
                         description: Lien vers la ressource 'Adresse d'un établissement'
                           correspondant au siège social de cette unité légale.
                     required:
@@ -35916,13 +35916,13 @@ paths:
                     properties:
                       siege_social:
                         type: string
-                        example: https://entreprises.api.gouv.fr/api/v3/insee/etablissements/30613890001294
+                        example: https://entreprise.api.gouv.fr/api/v3/insee/etablissements/30613890001294
                         description: Lien vers la ressource 'Données de référence
                           d'un établissement' correspondant au siège social de cette
                           unité légale.
                       siege_social_adresse:
                         type: string
-                        example: https://entreprises.api.gouv.fr/api/v3/insee/etablissements/30613890001294/adresse
+                        example: https://entreprise.api.gouv.fr/api/v3/insee/etablissements/30613890001294/adresse
                         description: Lien vers la ressource 'Adresse d'un établissement'
                           correspondant au siège social de cette unité légale.
                     required:
@@ -36880,13 +36880,13 @@ paths:
                     properties:
                       siege_social:
                         type: string
-                        example: https://entreprises.api.gouv.fr/api/v3/insee/etablissements/30613890001294
+                        example: https://entreprise.api.gouv.fr/api/v3/insee/etablissements/30613890001294
                         description: Lien vers la ressource 'Données de référence
                           d'un établissement' correspondant au siège social de cette
                           unité légale.
                       siege_social_adresse:
                         type: string
-                        example: https://entreprises.api.gouv.fr/api/v3/insee/etablissements/30613890001294/adresse
+                        example: https://entreprise.api.gouv.fr/api/v3/insee/etablissements/30613890001294/adresse
                         description: Lien vers la ressource 'Adresse d'un établissement'
                           correspondant au siège social de cette unité légale.
                     required:
@@ -37872,13 +37872,13 @@ paths:
                     properties:
                       siege_social:
                         type: string
-                        example: https://entreprises.api.gouv.fr/api/v3/insee/etablissements/30613890001294
+                        example: https://entreprise.api.gouv.fr/api/v3/insee/etablissements/30613890001294
                         description: Lien vers la ressource 'Données de référence
                           d'un établissement' correspondant au siège social de cette
                           unité légale.
                       siege_social_adresse:
                         type: string
-                        example: https://entreprises.api.gouv.fr/api/v3/insee/etablissements/30613890001294/adresse
+                        example: https://entreprise.api.gouv.fr/api/v3/insee/etablissements/30613890001294/adresse
                         description: Lien vers la ressource 'Adresse d'un établissement'
                           correspondant au siège social de cette unité légale.
                     required:

--- a/siade/public/v2/open-api.yml
+++ b/siade/public/v2/open-api.yml
@@ -81,7 +81,7 @@ paths:
                         example: "PME"
                       code_effectif_entreprise:
                         type: "string"
-                        description: "Le code effectif correspond à une fourchette de nombre de salariés, celle-ci est indiquée un peu plus loin au champ 'tranche_effectif_salarie_entreprise'. Ce code respecte la nomenclature de l'INSEE disponible à cette adresse : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#trancheeffectifsunitelegale"
+                        description: "Le code effectif correspond à une fourchette de nombre de salariés, celle-ci est indiquée un peu plus loin au champ 'tranche_effectif_salarie_entreprise'. Ce code respecte la nomenclature de l'INSEE disponible à cette adresse : https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#trancheeffectifsunitelegale"
                         example: "31"
                       date_creation:
                         type: "integer"

--- a/siade/spec/fixtures/json_api_schemas/insee/v3/tranche_effectif_salarie.json
+++ b/siade/spec/fixtures/json_api_schemas/insee/v3/tranche_effectif_salarie.json
@@ -1,7 +1,7 @@
 {
   "type": "object",
   "$id": "tranche_effectif_salarie",
-  "description": "https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=e5ad6542-3cac-4840-ad65-423cacf8408d#trancheeffectifsunitelegale",
+  "description": "https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc?page=2ed989b6-001c-4b22-9989-b6001c6b224e#trancheeffectifsunitelegale",
   "additionalProperties": false,
   "required": ["de", "a", "code", "date_reference", "intitule"],
   "properties": {

--- a/site/spec/fixtures/insee_unite_legale_example.json
+++ b/site/spec/fixtures/insee_unite_legale_example.json
@@ -49,8 +49,8 @@
     "date_cessation": 1634133818
   },
   "links": {
-    "siege_social": "https://entreprises.api.gouv.fr/api/v3/insee/etablissements/30613890001294",
-    "siege_social_adresse": "https://entreprises.api.gouv.fr/api/v3/insee/etablissements/30613890001294/adresse"
+    "siege_social": "https://entreprise.api.gouv.fr/api/v3/insee/etablissements/30613890001294",
+    "siege_social_adresse": "https://entreprise.api.gouv.fr/api/v3/insee/etablissements/30613890001294/adresse"
   },
   "meta": {
     "date_derniere_mise_a_jour": 1618396818,


### PR DESCRIPTION
Every external link the Sirene schemas offered was dead. The `portail-api.insee.fr` ones carry a Gravitee page uuid and Insee has republished the variable dictionary under new ones, so the old links render "No documentation for the moment" — only `page=` moves, the api uuid and the heading anchors are unchanged and were each checked against the markdown the portal serves. `sirene.fr` has no A record at all any more, so the "conditions de diffusion" links now point at the portal's "Diffusion partielle" page, which covers the same ground. The cedex description keeps Wikipedia, the only source that spells out the acronym, and gains the Insee variable entry alongside it.

Reading that dictionary turned up three address fields Insee no longer fills — `distribution_speciale`, `code_cedex`, `libelle_cedex` — which we passed through with examples no caller can ever observe. Confirmed on 18003502402369, the CNAM, whose own mail reads "75986 PARIS CEDEX 20" while Sirene answers 75020 PARIS with the three at null. The fields stay in the payload, their descriptions now say they are always null, and so do the two `acheminement_postal` lines that depended on them.

Separately, the `siege_social` and `siege_social_adresse` link examples advertised `entreprises.api.gouv.fr`, with a trailing "s" the platform has never served. Documentation only: both serializers build the link with `url_for`, so responses have always carried the real host.

API-7371